### PR TITLE
Fix issue where you can't delete a generic file

### DIFF
--- a/source/templates/code_signing.slim
+++ b/source/templates/code_signing.slim
@@ -289,10 +289,10 @@
 									button.dropdown-toggle[ng-click="genericFileCtrl.genericFileSettings[genericFile.databaseID].isMenuVisible = !genericFileCtrl.genericFileSettings[genericFile.databaseID].isMenuVisible"] = svg("three-horizontal-dots")
 									.dropdown[ng-if="genericFileCtrl.genericFileSettings[genericFile.databaseID].isMenuVisible"]
 										a.dropdown-option.download[href="{{ genericFile.download() }}"] == data[:strings][:code_signing][:generic_file][:article][:actions][:download]
-										button.dropdown-option.delete[ng-click="genericFileCtrl.deleteCertificate(genericFile)"] == data[:strings][:code_signing][:generic_file][:article][:actions][:delete]
+										button.dropdown-option.delete[ng-click="genericFileCtrl.deleteGenericFile(genericFile)"] == data[:strings][:code_signing][:generic_file][:article][:actions][:delete]
 								.actions.small
 									a.option.download[href="{{ genericFile.download() }}"] == data[:strings][:code_signing][:generic_file][:article][:actions][:download]
-									button.option.delete[ng-click="genericFileCtrl.deleteCertificate(genericFile)"] == data[:strings][:code_signing][:generic_file][:article][:actions][:delete]
+									button.option.delete[ng-click="genericFileCtrl.deleteGenericFile(genericFile)"] == data[:strings][:code_signing][:generic_file][:article][:actions][:delete]
 				p.notification.error[ng-if="genericFileCtrl.genericFiles.length >= genericFileCtrl.maximumGenericFilesCount"] == data[:strings][:code_signing][:generic_file][:upload_count_limit_reached]
 				p.progress-indicator[progress-model="genericFileCtrl.uploadGenericFileProgress"]
 				.file-upload[ng-if="!genericFileCtrl.uploadGenericFileProgress.isInProgress && genericFileCtrl.genericFiles.length < genericFileCtrl.maximumGenericFilesCount"]


### PR DESCRIPTION
Steps to replicate:
* Open the workflow editor
* Go to the code signing tab
* Scroll to the Generic File Storage section at the bottom
* Click ellipsis beside an existing file
* Click Delete

Expected result:
A popup confirming you want to delete the file

Actual result:
Nothing happens

This PR fixes a bug where the template is calling `deleteCertificate` on the `GenericFileController`, but that function doesn't exist. The function name appears to be `deleteGenericFile`.

Tested on prod by intercepting the response from bitrise and changing the function name, it allowed me to delete the file.