### PR TITLE
filtered empty key/value env vars and secrets

### DIFF
--- a/source/javascripts/controllers/_EnvVarsController.js.erb
+++ b/source/javascripts/controllers/_EnvVarsController.js.erb
@@ -26,6 +26,32 @@ angular.module("BitriseWorkflowEditor").controller("EnvVarsController", function
 		}
 	}));
 
+	$scope.$on("$destroy", $rootScope.$on("MainController::savedFinishedWithSuccess", function() {
+		switch (mode) {
+			case "secrets":
+				configureWithSecrets();
+
+				break;
+			case "env-vars":
+				configureWithAppConfig();
+
+				break;
+		}
+	}));
+
+	$scope.$on("$destroy", $rootScope.$on("MainController::savedFinishedWithError", function() {
+		switch (mode) {
+			case "secrets":
+				configureWithSecrets();
+
+				break;
+			case "env-vars":
+				configureWithAppConfig();
+
+				break;
+		}
+	}));
+
 	viewModel.configureWithMode = function(_mode) {
 		mode = _mode;
 

--- a/source/javascripts/controllers/_MainController.js.erb
+++ b/source/javascripts/controllers/_MainController.js.erb
@@ -171,7 +171,7 @@ angular.module("BitriseWorkflowEditor").controller("MainController", function($s
 		if (!viewModel.currentMenu) {
 			return undefined;
 		}
-		
+
 		switch (viewModel.currentMenu.id) {
 			case "workflows":
 			case "env-vars":
@@ -234,8 +234,10 @@ angular.module("BitriseWorkflowEditor").controller("MainController", function($s
 			}
 		}), $timeout(function() {}, 1000)]).then(function() {
 			viewModel.saveProgress.reset();
+			$rootScope.$emit("MainController::savedFinishedWithSuccess");
 		}, function(error) {
 			viewModel.saveProgress.reset();
+			$rootScope.$emit("MainController::savedFinishedWithError");
 			Popup.showErrorPopup("<%= data[:strings][:main][:load_progress][:save_error] %>", error.message);
 
 			if (shouldReturnPromise) {

--- a/source/javascripts/services/_appService.js.erb
+++ b/source/javascripts/services/_appService.js.erb
@@ -147,6 +147,17 @@ angular.module("BitriseWorkflowEditor").service("appService", function($q, reque
 	appService.saveAppConfig = function(requestConfig) {
 		var variables = [];
 		if (appService.appConfig.app && appService.appConfig.app.envs) {
+			var variablesWithoutKeyAndValue = _.filter(_.map(appService.appConfig.app.envs, function(anEnvVarConfig, ind) {
+				return new Variable(anEnvVarConfig, Variable.defaultVariableConfig());
+			}), function(anEnvVar){
+				return (_.isEmpty(anEnvVar.key()) && _.isEmpty(anEnvVar.value()));
+			});
+
+			_.each(variablesWithoutKeyAndValue, function(aVariable) {
+				var index = _.findIndex(appService.appConfig.app.envs, aVariable.userVariableConfig);
+				appService.appConfig.app.envs.splice(index, 1);
+			});
+
 			variables = variables.concat(_.map(appService.appConfig.app.envs, function (anEnvVarConfig) {
 				return new Variable(anEnvVarConfig, Variable.defaultVariableConfig());
 			}));
@@ -176,7 +187,7 @@ angular.module("BitriseWorkflowEditor").service("appService", function($q, reque
 		if (!shouldForceReload && appService.secrets) {
 			return $q.when();
 		}
-		
+
 		return requestService.getSecrets(requestConfig).then(function(secretConfigs) {
 			normalizeSecretConfigs(secretConfigs);
 
@@ -197,6 +208,9 @@ angular.module("BitriseWorkflowEditor").service("appService", function($q, reque
 	};
 
 	appService.saveSecrets = function() {
+		appService.secrets = _.filter(appService.secrets, function(aSecretVar){
+			return (!_.isEmpty(aSecretVar.key()) || !_.isEmpty(aSecretVar.value()));
+		});
 		return validateVariables(appService.secrets).then(function() {
 			return requestService.postSecrets(appService.secrets);
 		}).then(function() {
@@ -241,7 +255,7 @@ angular.module("BitriseWorkflowEditor").service("appService", function($q, reque
 		if (!shouldForceReload && appService.availableProjectTypes) {
 			return $q.when();
 		}
-		
+
 		return requestService.getAppAvailableProjectTypes(requestConfig).then(function(availableProjectTypes) {
 			appService.availableProjectTypes = availableProjectTypes;
 		});

--- a/source/javascripts/services/_appService.js.erb
+++ b/source/javascripts/services/_appService.js.erb
@@ -147,7 +147,7 @@ angular.module("BitriseWorkflowEditor").service("appService", function($q, reque
 	appService.saveAppConfig = function(requestConfig) {
 		var variables = [];
 		if (appService.appConfig.app && appService.appConfig.app.envs) {
-			var variablesWithoutKeyAndValue = _.filter(_.map(appService.appConfig.app.envs, function(anEnvVarConfig, ind) {
+			var variablesWithoutKeyAndValue = _.filter(_.map(appService.appConfig.app.envs, function(anEnvVarConfig) {
 				return new Variable(anEnvVarConfig, Variable.defaultVariableConfig());
 			}), function(anEnvVar){
 				return (_.isEmpty(anEnvVar.key()) && _.isEmpty(anEnvVar.value()));


### PR DESCRIPTION
Changes:
- filtered empty key/value pairs from Environment variables list after save event triggered
- filtered empty key/value pairs from Secrets list after save event triggered