### PR TITLE
UI always reloads the project file storages when there is an un-processed file

### DIFF
--- a/source/javascripts/controllers/_AndroidKeystoreController.js.erb
+++ b/source/javascripts/controllers/_AndroidKeystoreController.js.erb
@@ -42,6 +42,10 @@ angular.module("BitriseWorkflowEditor").controller("AndroidKeystoreController", 
 	function loadKeystoreFile() {
 		viewModel.loadProgress.start("<%= data[:strings][:code_signing][:android_keystore][:load_progress][:in_progress] %>");
 
+		refreshKeystoreFile()
+	};
+
+	function refreshKeystoreFile() {
 		requestService.getKeystoreFile().then(function(data) {
 			if (data !== null) {
 				viewModel.keystoreFile = new KeystoreFile();
@@ -60,7 +64,7 @@ angular.module("BitriseWorkflowEditor").controller("AndroidKeystoreController", 
 
 				if (!viewModel.keystoreFile.isProcessed) {
 					$timeout(function() {
-						loadKeystoreFile();
+						refreshKeystoreFile();
 					}, reloadIntervalInSeconds * 1000);
 				}
 
@@ -73,7 +77,6 @@ angular.module("BitriseWorkflowEditor").controller("AndroidKeystoreController", 
 			else {
 				viewModel.keystoreFile = null;
 			}
-
 
 			viewModel.loadProgress.success();
 		}, function(error) {

--- a/source/javascripts/controllers/_CertificateController.js.erb
+++ b/source/javascripts/controllers/_CertificateController.js.erb
@@ -44,6 +44,10 @@ angular.module("BitriseWorkflowEditor").controller("CertificateController", func
 			certificateService.certificates = undefined;
 		}
 
+		refreshCertificates();
+	};
+
+	function refreshCertificates() {
 		requestService.getCertificates().then(function(certificateDatas) {
 			certificateService.certificates = _.map(certificateDatas, function(aCertificateData) {
 				var certificate = new Certificate();
@@ -78,7 +82,7 @@ angular.module("BitriseWorkflowEditor").controller("CertificateController", func
 				isProcessed: false
 			})) {
 				$timeout(function() {
-					loadCertificates();
+					refreshCertificates();
 				}, certificatesReloadIntervalInSeconds * 1000);
 			}
 		}, function(error) {

--- a/source/javascripts/controllers/_GenericFileController.js.erb
+++ b/source/javascripts/controllers/_GenericFileController.js.erb
@@ -36,6 +36,10 @@ angular.module("BitriseWorkflowEditor").controller("GenericFileController", func
 			viewModel.genericFiles = undefined;
 		}
 
+		refreshGenericFiles();
+	};
+
+	function refreshGenericFiles() {
 		requestService.getGenericFiles().then(function(genericFileDatas) {
 			viewModel.genericFiles = _.map(genericFileDatas, function(aGenericFileData) {
 				var genericFile = new GenericFile(aGenericFileData.envVarPartialID);
@@ -67,7 +71,7 @@ angular.module("BitriseWorkflowEditor").controller("GenericFileController", func
 				isProcessed: false
 			})) {
 				$timeout(function() {
-					loadGenericFiles();
+					refreshGenericFiles();
 				}, genericFilesReloadIntervalInSeconds * 1000);
 			}
 		}, function(error) {

--- a/source/javascripts/services/_requestService.js.erb
+++ b/source/javascripts/services/_requestService.js.erb
@@ -188,13 +188,14 @@ angular.module("BitriseWorkflowEditor").service("requestService", function($q, $
 
 		return $q(function(resolve, reject) {
 			$http.post(requestURL, requestData, requestConfig).then(function(response) {
+			console.log(response)
 				resolve(response.data);
 			}, function(response) {
 				var error = new Error("<%= data[:strings][:request_service][:save_app_config][:default_error] %>");
 				if (response && response.data && response.data.error) {
 					error.message = response.data.error;
 				}
-
+				console.log(response)
 				reject(errorFromResponse(response, error.message, "<%= data[:strings][:request_service][:save_app_config][:error_prefix] %>"));
 			});
 		});

--- a/source/templates/code_signing.slim
+++ b/source/templates/code_signing.slim
@@ -353,6 +353,10 @@
 										.icon-wrapper = svg("lock-closed")
 										span protected
 									.name[ng-bind="genericFile.displayName()"]
+									.unprocessed-text[ng-if="!genericFile.isProcessed"]
+										p unprocessed
+									.unprocessed-text[ng-if="genericFile.isProcessed"]
+										p processed
 								.detail.code.env-var-key[ng-bind="genericFile.downloadURLEnvVarKey() | prettifiedKey"]
 							.expose-and-actions
 								.expose-with-popover


### PR DESCRIPTION
# Description
Actually, the workflow editor's GENERIC FILE STORAGE section always refreshes when there is a not processed upload. When you start the file upload process from the API side, there is the first step when you POST a request to start the upload process and request an upload (S3 tmp) URL. While you do not upload the needed file, the WFE will refresh the section in each second. 

# Expected Behaviour
We have to distinguish the successfully/finished upload documents and the upload is not finished project file documents. 
I think we have to set the file icon to grey and write out something about the upload process. We can show a progress bar or a step indicator (uploading process 2/3) . We have to refresh only the given record not the whole table.

Related issue: #373 