### PR TITLE
change terser config to preserve licence

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -60,9 +60,14 @@ module.exports = {
     minimize: isProd,
     minimizer: [
       new TerserPLugin({
+        extractComments: true,
+        parallel: true,
         terserOptions: {
           mangle: false,
-          safari10: true
+          safari10: true,
+          output: {
+            comments: /@license/i,
+          },
         }
       })
     ],


### PR DESCRIPTION
uglify got deprecated -> migrated to terser but it drops comments be default.
This config is to preserve licence comments.