### PR TITLE
[WEB-3520] plugin release #plugin

### DIFF
--- a/_scripts/compile_api.sh
+++ b/_scripts/compile_api.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -ex
+
+function assetst_precompile {
+    echo "  Boxing assets..."
+
+    go get github.com/GeertJohan/go.rice/rice
+    DIST=./apiserver/www/
+
+    mkdir -p $DIST
+    cp -rf ./build/* $DIST
+
+    cd ./apiserver
+    rice embed-go
+}
+
+function compile_bin {
+    export GOARCH=amd64
+
+    # Create Darwin bin
+    export GOOS=darwin
+
+    echo "  Create final Darwin binary at: $BIN_PATH_DARWIN"
+
+    version_package="github.com/bitrise-io/bitrise-workflow-editor/version"
+
+    go build \
+        -ldflags "-X $version_package.BuildNumber=$BITRISE_BUILD_NUMBER -X $version_package.Commit=$GIT_CLONE_COMMIT_HASH" \
+        -o "$BIN_PATH_DARWIN"
+
+    cp $BIN_PATH_DARWIN $BITRISE_DEPLOY_DIR/$BIN_NAME-$BIN_OS_DARWIN-$BIN_ARCH
+    echo "  Copy final Darwin binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$BIN_OS_DARWIN-$BIN_ARCH"
+
+
+    # Create Linux binary
+    export GOOS=linux
+
+    echo "  Create final Linux binary at: $BIN_PATH_LINUX"
+
+    go build \
+        -ldflags "-X $version_package.BuildNumber=$BITRISE_BUILD_NUMBER -X $version_package.Commit=$GIT_CLONE_COMMIT_HASH" \
+        -o "$BIN_PATH_LINUX"
+
+    cp $BIN_PATH_LINUX $BITRISE_DEPLOY_DIR/$BIN_NAME-$BIN_OS_LINUX-$BIN_ARCH
+    echo "  Copy final Linux binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$BIN_OS_LINUX-$BIN_ARCH"
+}
+
+echo
+echo "Create final binaries"
+echo "  Package version: $NPM_PACKAGE_VERSION"
+echo "  Build number: $BITRISE_BUILD_NUMBER"
+
+
+assetst_precompile
+
+compile_bin

--- a/_scripts/compile_api.sh
+++ b/_scripts/compile_api.sh
@@ -10,8 +10,9 @@ function assetst_precompile {
     mkdir -p $DIST
     cp -rf ./build/* $DIST
 
-    cd ./apiserver
-    rice embed-go
+    pushd ./apiserver
+        rice embed-go
+    popd
 }
 
 function compile_bin {
@@ -28,7 +29,7 @@ function compile_bin {
         -ldflags "-X $version_package.BuildNumber=$BITRISE_BUILD_NUMBER -X $version_package.Commit=$GIT_CLONE_COMMIT_HASH" \
         -o "$BIN_PATH_DARWIN"
 
-    cp $BIN_PATH_DARWIN $BITRISE_DEPLOY_DIR/$BIN_NAME-$BIN_OS_DARWIN-$BIN_ARCH
+    # cp $BIN_PATH_DARWIN $BITRISE_DEPLOY_DIR/$BIN_NAME-$BIN_OS_DARWIN-$BIN_ARCH
     echo "  Copy final Darwin binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$BIN_OS_DARWIN-$BIN_ARCH"
 
 
@@ -41,11 +42,10 @@ function compile_bin {
         -ldflags "-X $version_package.BuildNumber=$BITRISE_BUILD_NUMBER -X $version_package.Commit=$GIT_CLONE_COMMIT_HASH" \
         -o "$BIN_PATH_LINUX"
 
-    cp $BIN_PATH_LINUX $BITRISE_DEPLOY_DIR/$BIN_NAME-$BIN_OS_LINUX-$BIN_ARCH
+    # cp $BIN_PATH_LINUX $BITRISE_DEPLOY_DIR/$BIN_NAME-$BIN_OS_LINUX-$BIN_ARCH
     echo "  Copy final Linux binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$BIN_OS_LINUX-$BIN_ARCH"
 }
 
-echo
 echo "Create final binaries"
 echo "  Package version: $NPM_PACKAGE_VERSION"
 echo "  Build number: $BITRISE_BUILD_NUMBER"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -224,8 +224,9 @@ workflows:
       - setup-client
     steps:
       - script:
-        inputs:
-        - content: ./_scripts/compile_api.sh
+          title: Compile Api
+          inputs:
+          - content: ./_scripts/compile_api.sh
 
   create-binaries:
     title: Create binaries
@@ -234,6 +235,7 @@ workflows:
     envs:
       - NODE_ENV: "prod"
     steps:
-    - script:
-      inputs:
-      - content: ./_scripts/compile_api.sh
+      - script:
+          title: Compile Api
+          inputs:
+          - content: ./_scripts/compile_api.sh

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -94,8 +94,6 @@ workflows:
     - test-client
 
   go-install:
-    before_run:
-    - assets-precompile
     steps:
     - script:
         inputs:
@@ -140,24 +138,6 @@ workflows:
             go get github.com/inconshreveable/mousetrap
             godep save ./...
 
-  assets-precompile:
-    before_run:
-    - setup-client
-    steps:
-    - script:
-        inputs:
-        - content: |-
-            #!/bin/bash
-            set -ex
-            DIST=./apiserver/www/
-            go get github.com/GeertJohan/go.rice/rice
-
-            mkdir -p $DIST
-            cp -rf ./build/* $DIST
-
-            cd ./apiserver
-            rice embed-go
-
   _install_test_tools:
     steps:
     - script:
@@ -175,7 +155,7 @@ workflows:
     envs:
       - NODE_ENV: "prod"
     before_run:
-      - create-binaries
+      - setup-plugin-api
     steps:
     - script:
         title: Unit tests
@@ -234,51 +214,26 @@ workflows:
               golint -set_exit_status $line
             done <<< "$GOLIST_WITHOUT_VENDOR"
 
-  create-binaries:
-    title: Create binaries
+  setup-plugin-api:
+    title: Set up local plugin api
     description: |
-        Creates Linux and Darwin binaries
+        Set up and build plugin api from clean state
     envs:
       - NODE_ENV: "prod"
     before_run:
-    - assets-precompile
+      - setup-client
+    steps:
+      - script:
+        inputs:
+        - content: ./_scripts/compile_api.sh
+
+  create-binaries:
+    title: Create binaries
+    description: |
+        Creates Linux and Darwin binaries with embedded assets
+    envs:
+      - NODE_ENV: "prod"
     steps:
     - script:
-        title: Create binaries
-        inputs:
-        - content: |
-            #!/bin/bash
-            set -ex
-
-            echo
-            echo "Create final binaries"
-            echo "  Build number: $BITRISE_BUILD_NUMBER"
-
-            export GOARCH=amd64
-
-            # Create Darwin bin
-            export GOOS=darwin
-
-            echo "  Create final Darwin binary at: $BIN_PATH_DARWIN"
-
-            version_package="github.com/bitrise-io/bitrise-workflow-editor/version"
-
-            go build \
-              -ldflags "-X $version_package.BuildNumber=$BITRISE_BUILD_NUMBER -X $version_package.Commit=$GIT_CLONE_COMMIT_HASH" \
-              -o "$BIN_PATH_DARWIN"
-
-            cp $BIN_PATH_DARWIN $BITRISE_DEPLOY_DIR/$BIN_NAME-$BIN_OS_DARWIN-$BIN_ARCH
-            echo "  Copy final Darwin binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$BIN_OS_DARWIN-$BIN_ARCH"
-
-
-            # Create Linux binary
-            export GOOS=linux
-
-            echo "  Create final Linux binary at: $BIN_PATH_LINUX"
-
-            go build \
-              -ldflags "-X $version_package.BuildNumber=$BITRISE_BUILD_NUMBER -X $version_package.Commit=$GIT_CLONE_COMMIT_HASH" \
-              -o "$BIN_PATH_LINUX"
-
-            cp $BIN_PATH_LINUX $BITRISE_DEPLOY_DIR/$BIN_NAME-$BIN_OS_LINUX-$BIN_ARCH
-            echo "  Copy final Linux binary to: $BITRISE_DEPLOY_DIR/$BIN_NAME-$BIN_OS_LINUX-$BIN_ARCH"
+      inputs:
+      - content: ./_scripts/compile_api.sh

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"test-watch": "onchange -ik -d 500 'source/javascripts/**/*.js.erb' -- npm test",
 		"build": "webpack --bail -p",
 		"build:website": "MODE=WEBSITE ANALYTICS=true npm run build",
-		"build:plugin": "MODE=CLI ANALYTICS=true npm run build",
+		"build:plugin": "MODE=CLI ANALYTICS=true npm run build && bitrise run create-binaries",
 		"start:dev": "webpack-dev-server",
 		"start": "concurrently \"npm:start:dev\" \"DEV=true ./_scripts/run_api.sh 1234\"",
 		"e2e:dev": "cypress open",


### PR DESCRIPTION
* `create-binaries` no longer have assets build dependency, it is handled explicitly on CI
* `setup-plugin-api` wf with assets build dependency 

`#plugin` tag would release plugin as well