### PR TITLE
[WEB-3412] fix(workflow-selector): Long names

### DIFF
--- a/source/stylesheets/_default.scss
+++ b/source/stylesheets/_default.scss
@@ -542,6 +542,12 @@ $screen-minimum: 320px;
 	text-overflow: ellipsis;
 }
 
+@mixin wordbreak-oneliner {
+	overflow: hidden;
+	white-space: normal;
+	word-break: break-word;
+}
+
 @mixin column-count($value) {
 	-webkit-column-count: $value;
 	-moz-column-count: $value;

--- a/source/stylesheets/_tab-workflows.scss.erb
+++ b/source/stylesheets/_tab-workflows.scss.erb
@@ -60,11 +60,14 @@ section.manage-workflows {
 			$li_padding: 12px;
 			$li_fontsize: 16px;
 
-			@include position(absolute, 100%, 0);
+			@include position(absolute, 100%, null, null, 0);
 			z-index: $zindex-workflow_selector;
-			width: 100%;
 			margin-top: 10px;
 			margin-bottom: 0;
+			width: 548px;
+			@include media-below(580px) {
+				width: 100%;
+			}
 			border: $border;
 			@include border-radius($def-radius);
 			padding-left: 0;
@@ -95,7 +98,7 @@ section.manage-workflows {
 
 					span.workflow-id {
 						@include flex-grow(1);
-						@include ellipsis-oneliner;
+						@include wordbreak-oneliner;
 					}
 
 					button.select-workflow {
@@ -130,10 +133,12 @@ section.manage-workflows {
 					}
 
 					button.select-workflow {
+						display: inline-flex;
+						align-items: center;
 						width: 100%;
 						padding: $li_padding;
 						text-align: left;
-						@include ellipsis-oneliner;
+						@include wordbreak-oneliner;
 						background-color: white;
 						@include transition(color $def-transition_duration, background-color $def-transition_duration);
 
@@ -1618,7 +1623,6 @@ header.sticky section.manage-workflows {
 
 							h2 {
 								overflow: hidden;
-								max-width: none;
 							}
 
 							.stack {

--- a/source/stylesheets/_workflows-workflow_description.scss.erb
+++ b/source/stylesheets/_workflows-workflow_description.scss.erb
@@ -28,6 +28,7 @@
 	h3 {
 		@include display-flex;
 		@include margin-y(0);
+		@include wordbreak-oneliner;
 		border-bottom: 1px solid $def-mediumlightgrey;
 		padding: $padding;
 		font-size: 13px;


### PR DESCRIPTION
In case the workflow name is too long and two workflows only differ at their ends,
the user was not able to distinguish them.

To make it more flexible the following changes were made:
- Allow word-wrapping to handle harder edge cases
- On desktop viewport (+580px) make the selector wider, to give more room
- Under 580px width, let the selector fill up 100% of the width

This required some fine-tuning of the current style:
- center the dot, whenever the name of the workflow wraps into a new line (not selected case)
- make text behave more like when it is selected

The solution was to utilize `display: flex` on the non-selected items as well.