### PR TITLE
[WEB-4246] ignore empty stepids

### DIFF
--- a/source/javascripts/services/_stepLibSearchService.ts
+++ b/source/javascripts/services/_stepLibSearchService.ts
@@ -1,3 +1,4 @@
+import { isEmpty } from "underscore";
 import { Step, SearchOptions } from "@bitrise/steplib-search";
 import { Logger } from "./logger";
 
@@ -58,7 +59,7 @@ angular.module("BitriseWorkflowEditor").service(
 
 				let filters;
 
-				if (options.stepIDs) {
+				if (!isEmpty(options.stepIDs)) {
 					filters = `(${options.stepIDs.map(id => `id:${id}`).join(" OR ")})`;
 				}
 


### PR DESCRIPTION
it caused failures for some orgs with very special workflow setup. I hotfixed it but we need to refactor step loading in the mid term.