### PR TITLE
[PLANG-185] enable mangle for Terser

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -93,8 +93,6 @@ module.exports = {
 				extractComments: true,
 				parallel: true,
 				terserOptions: {
-					mangle: false,
-					safari10: true,
 					output: {
 						comments: /@license/i
 					}


### PR DESCRIPTION
I removed `mangle: false` from Terser options, so the mangle will be true as default.
I also removed the `safari10` options, it's not necessary.