### PR TITLE
[PLANG-289] Fix workflow rename

### DIFF
--- a/source/javascripts/controllers/_WorkflowsController.js.erb
+++ b/source/javascripts/controllers/_WorkflowsController.js.erb
@@ -557,6 +557,15 @@ import datadogRumCustomTiming from "../utils/datadogCustomRumTiming.ts";
 					}
 				});
 
+				_.each(appService.appConfig.stages, function(aStage) {
+					_.each( aStage.workflows, function(aWorkflow) {
+						if (aWorkflow[oldWorkflowID]) {
+							aWorkflow[newWorkflowID] = aWorkflow[oldWorkflowID]
+							delete aWorkflow[oldWorkflowID]
+						}
+					});
+				});
+
 				workflow.id = newWorkflowID;
 				viewModel.selectWorkflow(workflow);
 


### PR DESCRIPTION
Workflow rename throws an error if the workflow is used in a Stage.