### PR TITLE
[PLANG-556] Fix step list filtering

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 2.5.7
+ruby 2.6.9
 nodejs 10.20.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bitrise-workflow-editor",
-	"version": "1.3.99",
+	"version": "1.3.100",
 	"description": "Bitrise workflow editor",
 	"main": "index.js",
 	"scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "bitrise-workflow-editor",
-	"version": "1.3.100",
+	"version": "1.3.99",
 	"description": "Bitrise workflow editor",
 	"main": "index.js",
 	"scripts": {

--- a/source/javascripts/components/_AddStep.js.erb
+++ b/source/javascripts/components/_AddStep.js.erb
@@ -173,9 +173,9 @@ import { safeDigest } from "../services/react-compat";
 								)
 							);
 
-							if (viewModel.shouldFilterByProjectType) {
-								loadPromises.push(stepSourceService.loadLatestOfficialSteps(appService.appDetails.projectTypeID));
-							}
+							// NOTE: quick fix for step filtering - it seems there is an issue with the Algolia query or service filetring steps by project type (returns 0 steps)
+							// this was originally stepSourceService.loadLatestOfficialSteps(appService.appDetails.projectTypeID) when filtering is enabled
+							loadPromises.push(stepSourceService.loadLatestOfficialSteps());							
 						}
 
 						steps = [];
@@ -184,6 +184,8 @@ import { safeDigest } from "../services/react-compat";
 						$q.all(loadPromises).then(parseStepsInfo, function(error) {
 							logger.error(error);
 							viewModel.loadProgress.error(error);
+						}).then(function() {
+							viewModel.allStepsHaveBeenLoaded = true;							
 						});
 					} else {
 						viewModel.shouldFilterByProjectType = shouldFilterByProjectTypeDefaultValue;


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/PLANG-556

NOTE: the root cause seem to be an Algolia filtering issue: I debugged the code, if a project type filter goes out to Algolia, it doesn't return any steps.

This fix does not fix the root cause but skips the Algolia filtering. Even though this results in larger traffic, this has been already what the users were doing to tackle the issue: clicking the All button to get all steps first and the filter locally. UX wise I don't see a noticable difference in load times and such.

Fixing the Algolia filtering requires more investigation/time and I suggest fixing this ASAP as it's a serious user facing issue.