### PR TITLE
[PLANG-558] Add new step - search returns no results 

### DIFF
--- a/rails/strings.rb
+++ b/rails/strings.rb
@@ -116,6 +116,8 @@ def strings
                     add: {
                         search_placeholder: "Search steps",
                         all_project_types: "All",
+                        search_in_all_steps: "Search in All category",
+                        create_new_step: "Would you like to create a new step?",
                         show_all_steps: "Show all steps",
                         categories: {
                             new_releases: "New releases",

--- a/source/javascripts/components/_AddStep.js.erb
+++ b/source/javascripts/components/_AddStep.js.erb
@@ -175,7 +175,7 @@ import { safeDigest } from "../services/react-compat";
 
 							// NOTE: quick fix for step filtering - it seems there is an issue with the Algolia query or service filetring steps by project type (returns 0 steps)
 							// this was originally stepSourceService.loadLatestOfficialSteps(appService.appDetails.projectTypeID) when filtering is enabled
-							loadPromises.push(stepSourceService.loadLatestOfficialSteps());							
+							loadPromises.push(stepSourceService.loadLatestOfficialSteps());
 						}
 
 						steps = [];
@@ -185,7 +185,7 @@ import { safeDigest } from "../services/react-compat";
 							logger.error(error);
 							viewModel.loadProgress.error(error);
 						}).then(function() {
-							viewModel.allStepsHaveBeenLoaded = true;							
+							viewModel.allStepsHaveBeenLoaded = true;
 						});
 					} else {
 						viewModel.shouldFilterByProjectType = shouldFilterByProjectTypeDefaultValue;
@@ -322,6 +322,10 @@ import { safeDigest } from "../services/react-compat";
 				}
 
 				addStepService.stepSelected(step);
+			};
+
+			viewModel.navigateToAllCategories = function() {
+				viewModel.shouldFilterByProjectType = false;
 			};
 
 			viewModel.paginateSelected = function(category, direction) {

--- a/source/javascripts/components/_AddStep.js.erb
+++ b/source/javascripts/components/_AddStep.js.erb
@@ -328,6 +328,31 @@ import { safeDigest } from "../services/react-compat";
 				viewModel.shouldFilterByProjectType = false;
 			};
 
+			viewModel.getStackNameByProjectType = function(projectType) {
+				switch (projectType) {
+        				case "ios":
+        					return "iOS";
+        				case "osx":
+        					return "OSX";
+        				case "macos":
+        					return "MacOS";
+        				case "android":
+        					return "Android";
+        				case "xamarin":
+        					return "Xamarin";
+        				case "cordova":
+        					return "Cordova";
+        				case "ionic":
+        					return "Ionic";
+        				case "react-native":
+        					return "React Native";
+        				case "flutter":
+        					return "Flutter";
+        				case "other":
+        					return "Other";
+        			}
+			};
+
 			viewModel.paginateSelected = function(category, direction) {
 				if (direction == "left") {
 					if (category.paginateStepsConfig.currentOffsetInPage > 0) {

--- a/source/javascripts/components/_AddStep.js.erb
+++ b/source/javascripts/components/_AddStep.js.erb
@@ -350,6 +350,8 @@ import { safeDigest } from "../services/react-compat";
         					return "Flutter";
         				case "other":
         					return "Other";
+                default:
+                  return projectType;
         			}
 			};
 

--- a/source/stylesheets/_add_step_sidebar.scss.erb
+++ b/source/stylesheets/_add_step_sidebar.scss.erb
@@ -422,6 +422,22 @@
 					margin-bottom: 15px;
 				}
 			}
+
+			.not-found-all {
+				display: flex;
+
+				.create-new-step{
+					margin-left: 5px;
+					margin-top: 1px;
+					font-size: 15px;
+					font-weight: 500;
+					color: $def-green;
+
+					&:hover, &:focus {
+						text-decoration: underline;
+					}
+				}
+			}
 		}
 	}
 }

--- a/source/templates/add_step_sidebar.slim
+++ b/source/templates/add_step_sidebar.slim
@@ -39,7 +39,11 @@
 					== svg("workflow/icon-add_step-show_all")
 					span == data[:strings][:workflows][:steps][:add][:show_all_steps]
 			ol.steps[ng-if="!addStepCtrl.isCategoryMode"]
-				div[ng-if="addStepCtrl.filteredSteps().length == 0"]
-					p We didn't find any results for your search in ReactNative steps, would you like to search all steps?
+				div[ng-if="addStepCtrl.shouldFilterByProjectType && addStepCtrl.filteredSteps(category.steps).length == 0"]
+					p We didn't find any results for your search in {{ appService.appDetails.projectTypeID }} steps category, would you like to search all steps?
+					button.show-all-steps[ng-click="addStepCtrl.navigateToAllCategories()"] == data[:strings][:workflows][:steps][:add][:search_in_all_steps]
+				div.not-found-all[ng-if="!addStepCtrl.shouldFilterByProjectType && addStepCtrl.filteredSteps().length == 0"]
+					p We didn't find any results for your search in our step library.
+					a.create-new-step[ng-href="https://devcenter.bitrise.io/en/steps-and-workflows/developing-your-own-bitrise-step/developing-a-new-step.html" target="_blank"] == data[:strings][:workflows][:steps][:add][:create_new_step]
 				li.add-step-sidebar-step[ng-repeat="step in addStepCtrl.filteredSteps()" step="step" select-callback="addStepCtrl.stepSelected(step)" step-id="{{ step.id }}"]
 					r-add-step-item[step="step" on-selected="addStepCtrl.stepSelected"]

--- a/source/templates/add_step_sidebar.slim
+++ b/source/templates/add_step_sidebar.slim
@@ -39,5 +39,7 @@
 					== svg("workflow/icon-add_step-show_all")
 					span == data[:strings][:workflows][:steps][:add][:show_all_steps]
 			ol.steps[ng-if="!addStepCtrl.isCategoryMode"]
+				div[ng-if="addStepCtrl.filteredSteps().length == 0"]
+					p We didn't find any results for your search in ReactNative steps, would you like to search all steps?
 				li.add-step-sidebar-step[ng-repeat="step in addStepCtrl.filteredSteps()" step="step" select-callback="addStepCtrl.stepSelected(step)" step-id="{{ step.id }}"]
 					r-add-step-item[step="step" on-selected="addStepCtrl.stepSelected"]

--- a/source/templates/add_step_sidebar.slim
+++ b/source/templates/add_step_sidebar.slim
@@ -40,7 +40,7 @@
 					span == data[:strings][:workflows][:steps][:add][:show_all_steps]
 			ol.steps[ng-if="!addStepCtrl.isCategoryMode"]
 				div[ng-if="addStepCtrl.shouldFilterByProjectType && addStepCtrl.filteredSteps(category.steps).length == 0"]
-					p We didn't find any results for your search in {{ appService.appDetails.projectTypeID }} steps category, would you like to search all steps?
+					p We didn't find any results for your search in {{ addStepCtrl.getStackNameByProjectType(appService.appDetails.projectTypeID) }} steps category, would you like to search all steps?
 					button.show-all-steps[ng-click="addStepCtrl.navigateToAllCategories()"] == data[:strings][:workflows][:steps][:add][:search_in_all_steps]
 				div.not-found-all[ng-if="!addStepCtrl.shouldFilterByProjectType && addStepCtrl.filteredSteps().length == 0"]
 					p We didn't find any results for your search in our step library.


### PR DESCRIPTION
When searching for a step the default is Project Type filter which does not always return results

When this happens customers tend to think there are no steps available

This begs the question when we find no results should be show something to the user?

"We didn't find any results for your search in ReactNative steps, would you like to search all steps? <click link to search all steps>"

or 

"We didn't find any results for your search in ReactNative steps, here are some additional results we found that are not React"

Steps to reproduce:
Using a ReactNative app
In the WFE click + to add a new step
Search for "device testing for android"

Actual result:
No results are shown 

Expected result:
Results are shown

![image](https://user-images.githubusercontent.com/19280914/148079755-ed892eb5-1dad-46b4-9c68-ffcde909e770.png)

![image](https://user-images.githubusercontent.com/19280914/148079786-cb35bf00-d784-47cd-aac4-e9a81e23cf82.png)
