### PR TITLE
fix: deprecated icon size hotfix

### DIFF
--- a/source/javascripts/components/StepItem/StepItemBadge.tsx
+++ b/source/javascripts/components/StepItem/StepItemBadge.tsx
@@ -27,7 +27,12 @@ const StepItemBadge = ({ step }: StepItemBadgeProps): JSX.Element => (
 				alignChildrenVertical="middle"
 				data-e2e-tag="deprecated-badge"
 			>
-				<img className="deprecated" src={deprecatedIcon} />
+				<img
+					className="deprecated"
+					src={deprecatedIcon}
+					width="18"
+					height="18"
+					alt="Deprecated" />
 			</Flex>
 		)}
 	</Fragment>


### PR DESCRIPTION
The deprecated icon doesn't have any size limits, so it's displayed as a 400x400px image.

### Before

![image](https://user-images.githubusercontent.com/1694986/156745455-135e5904-6f06-4d00-aa11-bbf0f482946a.png)

### After

![image](https://user-images.githubusercontent.com/1694986/156745407-30c33ea7-3816-466c-b391-6a19e081b7d3.png)

### Changes

The image is now constrained to 18px. This seems to be the size of other icons (in BitKit)
