### PR TITLE
[PLG-380] bugfix for sticky header

### DIFF
--- a/source/javascripts/components/GuidedOnboarding/GuidedOnboardingAccordion.tsx
+++ b/source/javascripts/components/GuidedOnboarding/GuidedOnboardingAccordion.tsx
@@ -36,6 +36,9 @@ export const OnboardingAccordion = ({
         color="orange.10"
         index={expandedAccordionIndexArray}
         onChange={onAccordionChange}
+        // Negative margin below because AccordionItem does not
+        // respect marginBottom={0} prop. Will raise with bitkit team.
+        marginBottom={-16}
       >
         <AccordionItem
           id="item-details"


### PR DESCRIPTION
https://bitrise.atlassian.net/browse/PLG-380

Resolves an issue where content was passing underneath guide when in sticky header mode.

### Before
![Screen Shot 2022-10-18 at 11 11 01 AM](https://user-images.githubusercontent.com/112978063/196478470-45470160-4eae-4998-af99-e08e62d6cb3c.png)

### After
![Screen Shot 2022-10-18 at 11 31 34 AM](https://user-images.githubusercontent.com/112978063/196478288-4a55f76f-4551-4205-b128-fec683189878.png)
