### PR TITLE
feat: set failed state if response isn't in 2xx range - CI-608

### DIFF
--- a/source/javascripts/hooks/api/useFetchCallback.ts
+++ b/source/javascripts/hooks/api/useFetchCallback.ts
@@ -63,7 +63,7 @@ function useFetchCallback<T, E>(
 					if (body.length > 0) {
 						const resBody = parser(body);
 
-						if (body.includes("error_msg")) {
+						if (body.includes("error_msg") || !result.ok) {
 							setFailed(resBody as E);
 						} else {
 							setResult(resBody as T);


### PR DESCRIPTION
Cloudflare will set a 4xx response if something is off and our error handling only checks for 5xx and if error_msg is present. I've added an additional constraint that we should check if the response is in 2xx range.