### PR TITLE
fix: Rename Rearrange workflows

### DIFF
--- a/rails/strings.rb
+++ b/rails/strings.rb
@@ -100,7 +100,7 @@ def strings
                 },
                 rearrange: {
                     action: "Rearrange",
-                    drag_n_drop: "Drag & drop to rearrange Workflows",
+                    drag_n_drop: "Drag & drop to change Workflow execution order",
                     done: "Done",
                     cancel: "Cancel"
                 },

--- a/source/javascripts/components/WorkflowMainToolbar/WorkflowMainToolbar.tsx
+++ b/source/javascripts/components/WorkflowMainToolbar/WorkflowMainToolbar.tsx
@@ -34,11 +34,16 @@ const WorkflowMainToolbar = ({
 			)}
 			<IconButton iconName="PlusOpen" variant='secondary' onClick={onAddNewWorkflow} aria-label='Add new Workflow' />
 			<Menu placement="bottom-end">
-        <MenuButton as={IconButton} variant="secondary" iconName="MoreHorizontal" aria-label="Manage Workflows" />
+				<MenuButton as={IconButton} variant="secondary" iconName="MoreHorizontal" aria-label="Manage Workflows" />
 				<MenuList>
 					<MenuItem iconName="ArrowQuit" onClick={onInsertBeforeWorkflow}>Insert Workflow before</MenuItem>
 					<MenuItem iconName="ArrowQuit" onClick={onInsertAfterWorkflow}>Insert Workflow after</MenuItem>
-					<MenuItem iconName="Request" onClick={onRearrangeWorkflow}>Rearrange Workflows</MenuItem>
+					<MenuItem
+						iconName="Request"
+						onClick={onRearrangeWorkflow}
+					>
+						Change Workflow execution order
+					</MenuItem>
 					<MenuItem iconName="Trash" onClick={onDeleteSelectedWorkflow} isDanger>Delete selected Workflow</MenuItem>
 				</MenuList>
 			</Menu>

--- a/source/javascripts/components/WorkflowMainToolbar/WorkflowMainToolbar.tsx
+++ b/source/javascripts/components/WorkflowMainToolbar/WorkflowMainToolbar.tsx
@@ -40,6 +40,7 @@ const WorkflowMainToolbar = ({
 					<MenuItem iconName="ArrowQuit" onClick={onInsertAfterWorkflow}>Insert Workflow after</MenuItem>
 					<MenuItem
 						iconName="Request"
+						isDisabled={selectedWorkflow.workflowChain(workflows).length === 1}
 						onClick={onRearrangeWorkflow}
 					>
 						Change Workflow execution order

--- a/spec/integration/elements.js
+++ b/spec/integration/elements.js
@@ -158,7 +158,7 @@ export const elements = {
 	"Triggers tab": "button[data-e2e-tag='triggers-tab']",
 	"Workflows tab": "button[data-e2e-tag='workflows-tab']",
 
-	"Rearrange button": "button:contains('Rearrange Workflows')",
+	"Change Workflow execution order button": "button:contains('Change Workflow execution order')",
 	"Rearrange popup": "#rearrange-workflow-chain-popup-body",
 	"Workflow chain": ".workflow-chain",
 	"Workflow chain selected workflow": "#rearrange-workflow-chain-popup-body .workflow-chain .selected",

--- a/spec/integration/workflows.feature
+++ b/spec/integration/workflows.feature
@@ -193,7 +193,7 @@ Feature: Workflows
   Scenario: User opens the Rearrange
     Given "wf3" workflow is selected
     When I click on "Manage Workflows dropdown button"
-      And I click on "Rearrange button"
+      And I click on "Change Workflow execution order button"
     Then "Rearrange popup" should "be visible"
       And "Workflow chain before workflows" should contain 1 "li"
       And "Workflow chain after workflows" should contain 3 "li"

--- a/spec/integration/workflows/steps.js
+++ b/spec/integration/workflows/steps.js
@@ -36,7 +36,7 @@ Given("Workflow description is in edit mode", () => {
 
 Given("Rearrange popup is open", () => {
 	click("Manage Workflows dropdown button");
-	click("Rearrange button");
+	click("Change Workflow execution order button");
 });
 
 Then("Workflow appeared with name {string}", name => {


### PR DESCRIPTION
Rename "Rearrange workflows" button to "Change Workflow execution order" to avoid customer confusion.