### PR TITLE
Made FE fixes to Product Tour

### DIFF
--- a/source/javascripts/components/ProductTour/HighlighterProductTooltip.tsx
+++ b/source/javascripts/components/ProductTour/HighlighterProductTooltip.tsx
@@ -75,7 +75,7 @@ export const HighlighterProductTooltip = ({
             <PopoverContent maxWidth="420" minHeight="212" padding="24" zIndex="300" gap="8">
                 <PopoverArrow bg="white"/>
                 <Box display="flex" flexGrow="1" >
-                    <Box display="flex" flexDirection="column" flex="1 0 0" gap="8px">
+                    <Box display="flex" flexDirection="column" flex="1 0 0" gap="8px" color="neutral.10">
                         <Text size="4" fontWeight="bold">
                             {tip.title}
                         </Text>
@@ -105,7 +105,7 @@ export const HighlighterProductTooltip = ({
                     </Box>
 
                 {finished ? (
-                    <Box>
+                    <Box display="flex" gap="8">
                         <Button variant="tertiary" size="small" color="purple.50" onClick={onStartAgain}>
                         Start again
                         </Button>


### PR DESCRIPTION
@avivenzio-bitrise I ran into issues with my previous branch and had to re-create my change on a new one. I also saw your comment regarding wanting to see screenshots. You were correct in that I had the wrong flex direction value. That has been updated, and everything else remains the same. 
<img width="1192" alt="Screen Shot 2023-05-03 at 10 19 59 PM" src="https://user-images.githubusercontent.com/109980940/236100089-76939229-846e-496a-93ea-d6f4e288ca91.png">
<img width="1192" alt="Screen Shot 2023-05-03 at 10 19 59 PM" src="https://user-images.githubusercontent.com/109980940/236100096-b9fdda49-6101-4ff8-a1b9-aca6f2bcfbc2.png">
