### PR TITLE
feat: fit the height of monaco editor to the content

### DIFF
--- a/source/javascripts/controllers/_YMLController.js.erb
+++ b/source/javascripts/controllers/_YMLController.js.erb
@@ -75,19 +75,31 @@ import { configureMonacoYaml } from 'monaco-yaml';
 
 			function configureEditor() {
 				model = monaco.editor.createModel(appService.appConfigYML, 'yaml', monaco.Uri.parse('monaco-yaml.yaml'));
+				
+				const container = document.getElementById("code-container")
 
-				editor = monaco.editor.create(document.getElementById("code-container"), {
-					model: model,
+				editor = monaco.editor.create(container, {
+					model,
+					readOnly: false,
+					theme: "vs-dark",
 					language: "yaml",
 					lineNumbers: "on",
+					automaticLayout: true,
+					overviewRulerLanes: 0,
 					roundedSelection: false,
+					minimap: { enabled: false },
 					scrollBeyondLastLine: false,
-					readOnly: false,
-					theme: "vs-dark"
+					scrollbar: { alwaysConsumeMouseWheel: false },
 				});
+
 				editor.layout();
 				editor.focus();
 				editor.onDidChangeModelContent(updateAppConfigYML);
+				
+				editor.onDidContentSizeChange((e) => {
+					container.style.height = `${e.contentHeight}px`;
+					editor.layout({ width: container.clientWidth, height: e.contentHeight });
+				});
 			}
 
 			function updateAppConfigYML() {


### PR DESCRIPTION
In the `bitrise.yml` page, this PR adjusts the Monaco editor height to fit its content, eliminating the double scrollbar, and removing the minimap and the overview ruler lanes. As a result, only the page content will be scrollable.