### PR TITLE
[CI-2392] Update Bitrise data model

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/GeertJohan/go.rice v1.0.3
-	github.com/bitrise-io/bitrise v0.0.0-20240123151919-094dbb3882a5
+	github.com/bitrise-io/bitrise v0.0.0-20240216102702-83e3e4058ae1
 	github.com/bitrise-io/depman v0.0.0-20190402141727-e5c92c35cd92
 	github.com/bitrise-io/envman v0.0.0-20230802102824-1300c57d49c4
 	github.com/bitrise-io/go-utils v1.0.11

--- a/go.sum
+++ b/go.sum
@@ -9,8 +9,8 @@ github.com/GeertJohan/go.rice v1.0.3/go.mod h1:XVdrU4pW00M4ikZed5q56tPf1v2KwnIKe
 github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+qxleU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
-github.com/bitrise-io/bitrise v0.0.0-20240123151919-094dbb3882a5 h1:U4YhWNxex9vx+NkCBXiG75dHGFWEN8sDrEcdj7u6iw0=
-github.com/bitrise-io/bitrise v0.0.0-20240123151919-094dbb3882a5/go.mod h1:d0VW0u7KByG/x8aob8T9kQqsptqsV/Y6P8iFuIyYC+I=
+github.com/bitrise-io/bitrise v0.0.0-20240216102702-83e3e4058ae1 h1:Nb7wMwM6FBBQp2cXH305+fnlf7jjoA5zwCRNPkqv7ak=
+github.com/bitrise-io/bitrise v0.0.0-20240216102702-83e3e4058ae1/go.mod h1:d0VW0u7KByG/x8aob8T9kQqsptqsV/Y6P8iFuIyYC+I=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192 h1:vSHYT6kCL/iOT9BVuUPm0tVcbW57r5zldLWg0aB7qbQ=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192/go.mod h1:CIHVcxZUvsG99XUJV6JlR7okNsMMGY81jMvPC20W+O0=
 github.com/bitrise-io/depman v0.0.0-20190402141727-e5c92c35cd92 h1:+alkNYr5sbvCpvu2YQC4SLddnIP2BeAIjr8/EsObonw=


### PR DESCRIPTION
This PR pulls in an update data model from the CLI. The previous one was incorrect because the stage workflow did not have a `run_if` property. This meant that saving a yaml with the local workflow editor always removed this field.