### PR TITLE
Use upstream schema

### DIFF
--- a/source/javascripts/controllers/_YMLController.js.erb
+++ b/source/javascripts/controllers/_YMLController.js.erb
@@ -12,7 +12,7 @@ import { configureMonacoYaml } from 'monaco-yaml';
 			var model;
 
 			const defaultSchema = {
-				uri: 'https://raw.githubusercontent.com/bitrise-io/bitrise-json-schemas/main/bitrise.schema.json',
+				url: 'https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/bitrise.json'
 				fileMatch: ['monaco-yaml.yaml'],
 			};
 

--- a/source/javascripts/controllers/_YMLController.js.erb
+++ b/source/javascripts/controllers/_YMLController.js.erb
@@ -12,7 +12,7 @@ import { configureMonacoYaml } from 'monaco-yaml';
 			var model;
 
 			const defaultSchema = {
-				url: 'https://json.schemastore.org/bitrise.json',
+				uri: 'https://json.schemastore.org/bitrise.json',
 				fileMatch: ['monaco-yaml.yaml'],
 			};
 

--- a/source/javascripts/controllers/_YMLController.js.erb
+++ b/source/javascripts/controllers/_YMLController.js.erb
@@ -12,7 +12,7 @@ import { configureMonacoYaml } from 'monaco-yaml';
 			var model;
 
 			const defaultSchema = {
-				url: 'https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/bitrise.json'
+				url: 'https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/bitrise.json',
 				fileMatch: ['monaco-yaml.yaml'],
 			};
 

--- a/source/javascripts/controllers/_YMLController.js.erb
+++ b/source/javascripts/controllers/_YMLController.js.erb
@@ -12,7 +12,7 @@ import { configureMonacoYaml } from 'monaco-yaml';
 			var model;
 
 			const defaultSchema = {
-				url: 'https://raw.githubusercontent.com/SchemaStore/schemastore/master/src/schemas/json/bitrise.json',
+				url: 'https://json.schemastore.org/bitrise.json',
 				fileMatch: ['monaco-yaml.yaml'],
 			};
 


### PR DESCRIPTION
We often forget to upstream new additions/changes to the `bitrise.yml` schema because the workflow editor references the schema from our fork.

The upstream schema matches the fork as of yesterday: https://github.com/SchemaStore/schemastore/commit/7ad52d498e39b5237634bd6212fdf94f31457275