### PR TITLE
fix: ensure inputs do not lose focus on first change

### DIFF
--- a/source/javascripts/_componentRegister.js
+++ b/source/javascripts/_componentRegister.js
@@ -156,6 +156,7 @@ angular
     register(StepConfig, [
       "step",
       "tabId",
+      "focusInput",
       "environmentVariables",
       "secrets",
       "hasVersionUpdate",
@@ -167,6 +168,7 @@ angular
       "onRemove",
       "onChangeTabId",
       "onCreateSecret",
+      "onChangeFocusInput",
       "onOpenSecretsDialog",
       "onOpenEnvironmentVariablesDialog",
     ]),

--- a/source/javascripts/components/FocusInputProvider.tsx
+++ b/source/javascripts/components/FocusInputProvider.tsx
@@ -1,0 +1,28 @@
+import { PropsWithChildren, createContext, useContext, useMemo } from 'react';
+
+type Props = PropsWithChildren<{
+  focusInput?: string;
+  onChangeFocusInput: (name?: string) => void;
+}>;
+
+const Context = createContext<Omit<Props, 'children'>>({
+  onChangeFocusInput: () => undefined,
+});
+
+// TODO: Please remove all code that is related to the 'lose input focus on safe digest'
+//       issue after we have completely removed AngularJS from the workflows page.
+const FocusInputProvider = ({ children, focusInput, onChangeFocusInput }: Props) => {
+  const value = useMemo(() => ({ focusInput, onChangeFocusInput }), [focusInput, onChangeFocusInput]);
+  return <Context.Provider value={value}>{children}</Context.Provider>;
+};
+
+export const useFocusInput = () => {
+  const { focusInput, onChangeFocusInput } = useContext(Context);
+
+  return {
+    isInFocus: (name: string) => focusInput === name,
+    handleFocus: (name: string) => () => onChangeFocusInput(name),
+  };
+};
+
+export default FocusInputProvider;

--- a/source/javascripts/components/StepConfiguration/components/StepInput/StepInput.tsx
+++ b/source/javascripts/components/StepConfiguration/components/StepInput/StepInput.tsx
@@ -6,6 +6,7 @@ import { useFormContext } from 'react-hook-form';
 
 import { useSecretsDialog } from '../../../SecretsDialog';
 import { useEnvironmentVariablesDialog } from '../../../EnvironmentVariablesDialog/EnvironmentVariablesDialogProvider';
+import { useFocusInput } from '../../../FocusInputProvider';
 import StepInputHelper from './StepInputHelper';
 import StepInputLabel from './StepInputLabel';
 
@@ -50,6 +51,7 @@ const StepInput = forwardRef<Props, 'textarea' | 'select'>((props: Props, ref) =
 
   const [cursorPosition, setCursorPosition] = useState<CursorPosition>();
 
+  const { isInFocus, handleFocus } = useFocusInput();
   const { open: openSecretsDialog } = useSecretsDialog();
   const { open: openEnvironmentVariablesDialog } = useEnvironmentVariablesDialog();
 
@@ -114,7 +116,14 @@ const StepInput = forwardRef<Props, 'textarea' | 'select'>((props: Props, ref) =
 
       <Box pos="relative">
         {isSelectInput(rest) && (
-          <Select ref={ref} {...omit(rest, 'options')} size="medium" backgroundSize="unset">
+          <Select
+            ref={ref}
+            {...omit(rest, 'options')}
+            size="medium"
+            backgroundSize="unset"
+            onFocus={handleFocus(name)}
+            autoFocus={isInFocus(name)}
+          >
             {rest.options.map((optionValue) => (
               <option key={optionValue} value={optionValue}>
                 {optionValue}
@@ -154,6 +163,8 @@ const StepInput = forwardRef<Props, 'textarea' | 'select'>((props: Props, ref) =
                 onBlur={handleOnBlur}
                 transition="height none"
                 gridArea="1 / 1 / 2 / 2"
+                onFocus={handleFocus(name)}
+                autoFocus={isInFocus(name)}
                 isDisabled={isSensitive || isDisabled}
                 placeholder={isSensitive ? 'Add secret' : 'Enter value'}
               />

--- a/source/javascripts/components/StepProperties/StepProperties.tsx
+++ b/source/javascripts/components/StepProperties/StepProperties.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Box, Collapse, Divider, Icon, Input, Link, MarkdownContent, Select, Text } from '@bitrise/bitkit';
 import { useForm } from 'react-hook-form';
 
 import { OnStepChange, Step, StepVersionWithRemark } from '../../models';
+import { useFocusInput } from '../FocusInputProvider';
 import { extractStepFields } from './utils';
 
 type Props = {
@@ -14,16 +15,24 @@ type Props = {
 const StepProperties = ({ step, versionsWithRemarks, onChange }: Props) => {
   const { name, version, sourceURL, summary, description, isLibraryStep } = extractStepFields(step);
   const [showMore, setShowMore] = useState(false);
+  const { isInFocus, handleFocus } = useFocusInput();
 
-  const { register, setValue, handleSubmit } = useForm<{
-    properties: { name: string; version: string };
-  }>();
-  useEffect(() => {
-    setValue('properties.name', name);
-    setValue('properties.version', version);
-  }, [name, version, setValue]);
+  const { register, handleSubmit } = useForm<{
+    properties: {
+      name: string;
+      version: string;
+    };
+  }>({
+    defaultValues: {
+      properties: {
+        name,
+        version,
+      },
+    },
+  });
 
   const handleChange = handleSubmit(onChange);
+
   return (
     <Box as="form" display="flex" flexDirection="column" p="24" gap="24" onChange={handleChange}>
       {sourceURL && (
@@ -44,10 +53,25 @@ const StepProperties = ({ step, versionsWithRemarks, onChange }: Props) => {
         </Link>
       )}
 
-      <Input {...register('properties.name')} type="text" label="Name" placeholder="Step name" isRequired />
+      <Input
+        {...register('properties.name')}
+        type="text"
+        label="Name"
+        placeholder="Step name"
+        onFocus={handleFocus('properties.name')}
+        autoFocus={isInFocus('properties.name')}
+        isRequired
+      />
       <Divider />
       {isLibraryStep && (
-        <Select {...register('properties.version')} label="Version updates" isRequired backgroundSize="none">
+        <Select
+          {...register('properties.version')}
+          isRequired
+          backgroundSize="none"
+          label="Version updates"
+          onFocus={handleFocus('properties.version')}
+          autoFocus={isInFocus('properties.version')}
+        >
           {versionsWithRemarks.map(({ version: value, remark }) => {
             return (
               <option key={value} value={value || ''}>

--- a/source/javascripts/controllers/_WorkflowsController.js.erb
+++ b/source/javascripts/controllers/_WorkflowsController.js.erb
@@ -1113,8 +1113,16 @@ import { extractInputNames, extractReleaseNotesUrl } from "../components/StepPro
       viewModel.setTabId = (tabId) => {
         viewModel.tabId = tabId;
       };
+
+      // Preserve the focus state of the selected input during a safe digest cycle.
+      viewModel.focusInput = undefined;
+      viewModel.setFocusInput = (name) => {
+        viewModel.focusInput = name;
+      };
+
       $scope.$watch(() => viewModel.selectedStep, () => {
         viewModel.tabId = undefined;
+        viewModel.focusInput = undefined;
       });
     });
 })();

--- a/source/templates/workflows.slim
+++ b/source/templates/workflows.slim
@@ -61,6 +61,7 @@
               r-step-config[
                 tab-id="workflowsCtrl.tabId"
                 step="workflowsCtrl.selectedStep"
+                focus-input="workflowsCtrl.focusInput"
                 secrets="insertSecretCtrl.insertableVariablesForReact"
                 environment-variables="insertVariableCtrl.insertableVariablesForReact"
                 has-version-update="workflowsCtrl.checkStepVersionUpdate(workflowsCtrl.selectedStep)"
@@ -71,6 +72,7 @@
                 on-clone="workflowsCtrl.cloneSelectedStep"
                 on-remove="workflowsCtrl.deleteSelectedStep"
                 on-change="workflowsCtrl.handleSelectedStepChanges"
+                on-change-focus-input="workflowsCtrl.setFocusInput"
                 on-create-secret="workflowsCtrl.saveSecretFromReact"
                 on-open-environment-variables-dialog="insertVariableCtrl.initForReact(null, workflowsCtrl.workflows, workflowsCtrl.selectedWorkflow, workflowsCtrl.selectedStep)"
                 on-open-secrets-dialog="insertSecretCtrl.initForReact(requestService.mode == 'website' ? ['from_code_signing_files', 'from_secrets'] : ['from_secrets'], workflowsCtrl.workflows, workflowsCtrl.selectedWorkflow, workflowsCtrl.selectedStep)"


### PR DESCRIPTION
This is a temporary fix until we remove AngularJS from workflows page.

JIRA ticket: https://bitrise.atlassian.net/browse/CI-2864