### PR TITLE
fix(secrets): fix editing on protected secret override

### DIFF
--- a/source/javascripts/controllers/_SecretsController.js.erb
+++ b/source/javascripts/controllers/_SecretsController.js.erb
@@ -99,7 +99,7 @@
 				appService.secrets.forEach(secret => {
 					if (secret.scope() === 'workspace') return;
 
-					const s = secretsFromReact.find((s) => s.key === secret.key());
+					const s = secretsFromReact.find((s) => s.key === secret.key() && !s.isShared);
 
 					if (s) {
 						secret.value(s.value);


### PR DESCRIPTION
The edit `forEach` that updates all Angular secrets based on their React counterparts didn't exclude the shared ones, so it messed up the original object with invalid prop overrides.