### PR TITLE
Update bitrise dep to v2.16.1

### DIFF
--- a/apiserver/tools/tools.go
+++ b/apiserver/tools/tools.go
@@ -4,21 +4,15 @@ import (
 	"fmt"
 
 	envmanModels "github.com/bitrise-io/envman/models"
-	"github.com/bitrise-io/go-utils/log"
+	logv2 "github.com/bitrise-io/go-utils/v2/log"
 	stepman "github.com/bitrise-io/stepman/cli"
 	stepmanModels "github.com/bitrise-io/stepman/models"
 )
 
-type stepmanLogger struct {
-}
-
-func (l stepmanLogger) Warnf(format string, v ...interface{}) {
-	log.Warnf(format, v...)
-}
-
 // StepmanStepInfo ...
 func StepmanStepInfo(library, id, version string) (stepmanModels.StepInfoModel, error) {
-	stepInfo, err := stepman.QueryStepInfo(library, id, version, stepmanLogger{})
+	logger := logv2.NewLogger()
+	stepInfo, err := stepman.QueryStepInfo(library, id, version, logger)
 	if err != nil {
 		return stepmanModels.StepInfoModel{}, fmt.Errorf("failed to get step info: %w", err)
 	}
@@ -57,7 +51,8 @@ func StepmanLocalLibraryInfos() ([]stepmanModels.SteplibInfoModel, error) {
 
 // StepmanSetupLibrary ...
 func StepmanSetupLibrary(libraryURI string) error {
-	if err := stepman.Setup(libraryURI, "", stepmanLogger{}); err != nil {
+	logger := logv2.NewLogger()
+	if err := stepman.Setup(libraryURI, "", logger); err != nil {
 		return fmt.Errorf("failed to setup library (%s): %w", libraryURI, err)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ toolchain go1.22.2
 
 require (
 	github.com/GeertJohan/go.rice v1.0.3
-	github.com/bitrise-io/bitrise v0.0.0-20240424072115-f5fadde8ae03
+	github.com/bitrise-io/bitrise v0.0.0-20240607091922-073c9a1820d7
 	github.com/bitrise-io/depman v0.0.0-20190402141727-e5c92c35cd92
 	github.com/bitrise-io/envman v0.0.0-20240516104659-4a3e6bd8252a
 	github.com/bitrise-io/go-utils v1.0.13
-	github.com/bitrise-io/stepman v0.0.0-20240402084208-9e349620ff4e
+	github.com/bitrise-io/stepman v0.0.0-20240530152555-8c02c2799166
 	github.com/gorilla/mux v1.8.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.9.0
@@ -19,7 +19,7 @@ require (
 
 require (
 	github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.28 // indirect
-	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.21 // indirect
+	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.22
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/GeertJohan/go.rice v1.0.3/go.mod h1:XVdrU4pW00M4ikZed5q56tPf1v2KwnIKe
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/akavel/rsrc v0.8.0/go.mod h1:uLoCtb9J+EyAqh+26kdrTgmzRBFPGOolLWKpdxkKq+c=
-github.com/bitrise-io/bitrise v0.0.0-20240424072115-f5fadde8ae03 h1:tgjA4zDUFf/YezVzceVWZY+NevLOotbAEnbyjS9xT0E=
-github.com/bitrise-io/bitrise v0.0.0-20240424072115-f5fadde8ae03/go.mod h1:4ffxYkJS9h7WBUd5dsFfPyAuBHZ6JZVt1HH1e/T8DLM=
+github.com/bitrise-io/bitrise v0.0.0-20240607091922-073c9a1820d7 h1:oca1xjy2MB1Qv0U9ultANr+1iwx+InAhKzvgIhhhl9A=
+github.com/bitrise-io/bitrise v0.0.0-20240607091922-073c9a1820d7/go.mod h1:/lNyOj2HayxvIoiGxb0s+P4GuXZlzs6cGe6MYp/5TT4=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192 h1:vSHYT6kCL/iOT9BVuUPm0tVcbW57r5zldLWg0aB7qbQ=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192/go.mod h1:CIHVcxZUvsG99XUJV6JlR7okNsMMGY81jMvPC20W+O0=
 github.com/bitrise-io/depman v0.0.0-20190402141727-e5c92c35cd92 h1:+alkNYr5sbvCpvu2YQC4SLddnIP2BeAIjr8/EsObonw=
@@ -19,12 +19,12 @@ github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.28 h1:HW9AueDVlrEN96riYgKAxwv
 github.com/bitrise-io/go-steputils/v2 v2.0.0-alpha.28/go.mod h1:aS6TO1DpbWJoBuAlvmpS/I/FU97C71wv1F/+p+kVrCk=
 github.com/bitrise-io/go-utils v1.0.13 h1:1QENhTS/JlKH9F7+/nB+TtbTcor6jGrE6cQ4CJWfp5U=
 github.com/bitrise-io/go-utils v1.0.13/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.21 h1:iwNnwOGg8VP8eqhse68Fxt5ZnfEYosgV2gRZB7LKfHg=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.21/go.mod h1:Laih4ji980SQkRgdnMCH0g4u2GZI/5nnbqmYT9UfKFQ=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.22 h1:/SD9xE4LlX/Ju9YZ+n/yW/uDs7hXMdFlXg4Nxlb7678=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.22/go.mod h1:Laih4ji980SQkRgdnMCH0g4u2GZI/5nnbqmYT9UfKFQ=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef h1:R5FOa8RHjqZwMN9g1FQ8W7nXxQAG7iwq1Cw+mUk5S9A=
 github.com/bitrise-io/goinp v0.0.0-20240103152431-054ed78518ef/go.mod h1:27ldH2bkCdYN5CEJ6x92EK+gkd5EcDBkA7dMrSKQFYU=
-github.com/bitrise-io/stepman v0.0.0-20240402084208-9e349620ff4e h1:GxelHVIsN5s9QANZVetuKJdUXuNCkpFEIQ+ZHmBCoFw=
-github.com/bitrise-io/stepman v0.0.0-20240402084208-9e349620ff4e/go.mod h1:netRLDQD95IzWZbzmn7CBolzNqH1tErRKS31BrZKt9s=
+github.com/bitrise-io/stepman v0.0.0-20240530152555-8c02c2799166 h1:bqcwVelwkx/UKSfoNfiAz5gygH1ZEmmz5CIgupXQFtE=
+github.com/bitrise-io/stepman v0.0.0-20240530152555-8c02c2799166/go.mod h1:netRLDQD95IzWZbzmn7CBolzNqH1tErRKS31BrZKt9s=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/cpuguy83/go-md2man/v2 v2.0.4 h1:wfIWP927BUkWJb2NmU/kNDYIBTh/ziUX91+lVfRxZq4=


### PR DESCRIPTION
This PR updates the Bitrise CLI dependency to the version [v2.16.1](https://github.com/bitrise-io/bitrise/releases/tag/2.16.1).

Other than a simply dep update `convertWorkflowElementTypes` had to be updated, because in the recent CLI version the Step List item isn't a homogenous list of Steps anymore, the item's are either Steps or the new With step groups.

The related CLI changes are here: https://github.com/bitrise-io/bitrise/pull/964

This is an example how the Bitrise CLI iterates on the steps of a workflow: https://github.com/bitrise-io/bitrise/blob/master/cli/run.go#L501-L533
