### PR TITLE
Update github.com/bitrise-io/bitrise to version 2.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.22.5
 
 require (
 	github.com/GeertJohan/go.rice v1.0.3
-	github.com/bitrise-io/bitrise v0.0.0-20240925090158-6f15bd121285
+	github.com/bitrise-io/bitrise v0.0.0-20240930125536-9ea0867c5a34
 	github.com/bitrise-io/depman v0.0.0-20190402141727-e5c92c35cd92
 	github.com/bitrise-io/envman v0.0.0-20240730123632-8066eeb61599
 	github.com/bitrise-io/go-utils v1.0.13

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/bitrise-io/bitrise v0.0.0-20240925090158-6f15bd121285 h1:sBWuyJ/KzyneRpD/heC2PFb6cOca1FKMevb0vMG3VkU=
-github.com/bitrise-io/bitrise v0.0.0-20240925090158-6f15bd121285/go.mod h1:qU3jArPNldj34z15L+zLxdnX+bdzgk7AeH8FC36RDmA=
+github.com/bitrise-io/bitrise v0.0.0-20240930125536-9ea0867c5a34 h1:wtD46HKKA7iBOqYqjhJQFFTxjpcc1GHOzZAY1axzneo=
+github.com/bitrise-io/bitrise v0.0.0-20240930125536-9ea0867c5a34/go.mod h1:qU3jArPNldj34z15L+zLxdnX+bdzgk7AeH8FC36RDmA=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192 h1:vSHYT6kCL/iOT9BVuUPm0tVcbW57r5zldLWg0aB7qbQ=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192/go.mod h1:CIHVcxZUvsG99XUJV6JlR7okNsMMGY81jMvPC20W+O0=
 github.com/bitrise-io/depman v0.0.0-20190402141727-e5c92c35cd92 h1:+alkNYr5sbvCpvu2YQC4SLddnIP2BeAIjr8/EsObonw=


### PR DESCRIPTION
This PR updates github.com/bitrise-io/bitrise to version [2.22.0](https://github.com/bitrise-io/bitrise/releases/tag/2.22.0), where a new `enabled` field was introduced for the target-based triggers.

I tested this change, by locally running the WFE and saving valid and invalid triggers.

A valid trigger saved without any validation error:

```
pipelines:
  pl1:
    triggers:
      enabled: true
      push:
      - branch: master
```

while for invalid triggers WFE throws an error:

```
pipelines:
  pl1:
    triggers:
      enabled: "should not be a string"
      push:
      - branch: master
```

error: `Validation failed: Config validation error: failed to get Bitrise config (bitrise.yml) from base 64 data: Failed to parse bitrise config, error: 'triggers': 'enabled' value should be a boolean`