### PR TITLE
fix: errcheck version

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -93,7 +93,7 @@ workflows:
                 set -ex
 
                 go install golang.org/x/lint/golint@latest
-                go install github.com/kisielk/errcheck@latest
+                go install github.com/kisielk/errcheck@v1.7.0
                 go install github.com/GeertJohan/go.rice/rice@latest
                 asdf reshim golang
   build-api-server:


### PR DESCRIPTION
The errcheck v1.8.0 causes unexpected errors on CI.