### PR TITLE
feat: Support deleting canvas nodes (depends_on items)

### DIFF
--- a/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.stories.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.stories.tsx
@@ -6,25 +6,29 @@ import WorkflowCard from './WorkflowCard';
 
 export default {
   component: WorkflowCard,
-  args: {
-    id: 'wf1',
-    isCollapsable: true,
-  },
   argTypes: {
     // Workflow actions
     onCreateWorkflow: { type: 'function' },
+    onChainWorkflow: { type: 'function' },
+    onChainChainedWorkflow: { type: 'function' },
     onEditWorkflow: { type: 'function' },
+    onEditChainedWorkflow: { type: 'function' },
     onRemoveWorkflow: { type: 'function' },
-    onAddChainedWorkflow: { type: 'function' },
     onRemoveChainedWorkflow: { type: 'function' },
-    onChainedWorkflowsUpdate: { type: 'function' },
-
+    onChainedWorkflowsUpdate: {
+      type: 'function',
+    },
+    // Step actions
     onAddStep: { type: 'function' },
     onMoveStep: { type: 'function' },
     onSelectStep: { type: 'function' },
     onUpgradeStep: { type: 'function' },
     onCloneStep: { type: 'function' },
     onDeleteStep: { type: 'function' },
+  },
+  args: {
+    id: 'wf1',
+    isCollapsable: true,
   },
   decorators: (Story) => withBitriseYml(MockYml, Story),
   render: withQueryClientProvider((props) => <WorkflowCard {...props} />),

--- a/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
@@ -9,34 +9,32 @@ import StepList from './components/StepList';
 import ChainedWorkflowList from './components/ChainedWorkflowList';
 import SortableWorkflowsContext from './components/SortableWorkflowsContext';
 
-type Action = 'edit' | 'chain' | 'remove';
-
 type Props = WorkflowActions &
   StepActions & {
     id: string;
     isCollapsable?: boolean;
     containerProps?: CardProps;
-    hideActions?: Action[];
   };
 
-const WorkflowCard = ({ id, isCollapsable, containerProps, hideActions, ...actions }: Props) => {
+const WorkflowCard = ({ id, isCollapsable, containerProps, ...actions }: Props) => {
   const workflow = useWorkflow(id);
   const containerRef = useRef(null);
   const { data: stacksAndMachines } = useStacksAndMachines();
   const {
     onCreateWorkflow,
     onEditWorkflow,
+    onChainWorkflow,
     onRemoveWorkflow,
-    onAddChainedWorkflow,
+    onChainChainedWorkflow,
+    onEditChainedWorkflow,
     onRemoveChainedWorkflow,
     onChainedWorkflowsUpdate,
     ...stepActions
   } = actions;
   const workflowActions = {
     onCreateWorkflow,
-    onEditWorkflow,
-    onRemoveWorkflow,
-    onAddChainedWorkflow,
+    onEditChainedWorkflow,
+    onChainChainedWorkflow,
     onRemoveChainedWorkflow,
     onChainedWorkflowsUpdate,
   };
@@ -80,7 +78,7 @@ const WorkflowCard = ({ id, isCollapsable, containerProps, hideActions, ...actio
           </Text>
         </Box>
 
-        {onAddChainedWorkflow && !hideActions?.includes('chain') && (
+        {onChainWorkflow && (
           <ControlButton
             size="xs"
             display="none"
@@ -89,10 +87,10 @@ const WorkflowCard = ({ id, isCollapsable, containerProps, hideActions, ...actio
             aria-label="Chain Workflows"
             tooltipProps={{ 'aria-label': 'Chain Workflows' }}
             _groupHover={{ display: 'inline-flex' }}
-            onClick={() => onAddChainedWorkflow(id)}
+            onClick={() => onChainWorkflow(id)}
           />
         )}
-        {onEditWorkflow && !hideActions?.includes('edit') && (
+        {onEditWorkflow && (
           <ControlButton
             size="xs"
             display="none"
@@ -104,7 +102,7 @@ const WorkflowCard = ({ id, isCollapsable, containerProps, hideActions, ...actio
             onClick={() => onEditWorkflow(id)}
           />
         )}
-        {onRemoveWorkflow && !hideActions?.includes('remove') && (
+        {onRemoveWorkflow && (
           <ControlButton
             size="xs"
             display="none"

--- a/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.types.ts
+++ b/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.types.ts
@@ -7,7 +7,7 @@ export type WorkflowActions = {
   onEditWorkflow?: (workflowId: string) => void;
   onRemoveWorkflow?: (workflowId: string) => void;
   onAddChainedWorkflow?: (workflowId: string) => void;
-  onRemoveChainedWorkflow?: BitriseYmlStoreState['deleteChainedWorkflow'];
+  onRemoveChainedWorkflow?: BitriseYmlStoreState['removeChainedWorkflow'];
   onChainedWorkflowsUpdate?: BitriseYmlStoreState['setChainedWorkflows'];
 };
 

--- a/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.types.ts
+++ b/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.types.ts
@@ -5,8 +5,10 @@ import { LibraryType } from '@/core/models/Step';
 export type WorkflowActions = {
   onCreateWorkflow?: () => void;
   onEditWorkflow?: (workflowId: string) => void;
+  onEditChainedWorkflow?: (workflowId: string) => void;
+  onChainWorkflow?: (workflowId: string) => void;
+  onChainChainedWorkflow?: (workflowId: string) => void;
   onRemoveWorkflow?: (workflowId: string) => void;
-  onAddChainedWorkflow?: (workflowId: string) => void;
   onRemoveChainedWorkflow?: BitriseYmlStoreState['removeChainedWorkflow'];
   onChainedWorkflowsUpdate?: BitriseYmlStoreState['setChainedWorkflows'];
 };

--- a/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
@@ -37,13 +37,16 @@ const ChainedWorkflowCard = ({
   const {
     onCreateWorkflow,
     onEditWorkflow,
-    onAddChainedWorkflow,
+    onChainWorkflow,
+    onRemoveWorkflow,
+    onEditChainedWorkflow,
+    onChainChainedWorkflow,
     onRemoveChainedWorkflow,
     onChainedWorkflowsUpdate,
     ...stepActions
   } = actions;
 
-  const isEditable = Boolean(onEditWorkflow || onAddChainedWorkflow || onRemoveChainedWorkflow);
+  const isEditable = Boolean(onEditChainedWorkflow || onChainChainedWorkflow || onRemoveChainedWorkflow);
   const isSortable = Boolean(onChainedWorkflowsUpdate);
 
   const result = useWorkflow(id);
@@ -144,7 +147,7 @@ const ChainedWorkflowCard = ({
 
         {isEditable && (
           <ButtonGroup spacing="0" display="none" _groupHover={{ display: 'flex' }}>
-            {onAddChainedWorkflow && (
+            {onChainChainedWorkflow && (
               <ControlButton
                 size="xs"
                 iconName="Link"
@@ -152,17 +155,17 @@ const ChainedWorkflowCard = ({
                 tooltipProps={{ 'aria-label': 'Chain Workflows' }}
                 onClick={() => {
                   onOpen();
-                  onAddChainedWorkflow(id);
+                  onChainChainedWorkflow(id);
                 }}
               />
             )}
-            {onEditWorkflow && (
+            {onEditChainedWorkflow && (
               <ControlButton
                 size="xs"
                 iconName="Settings"
                 aria-label="Edit Workflow"
                 tooltipProps={{ 'aria-label': 'Edit Workflow' }}
-                onClick={() => onEditWorkflow(id)}
+                onClick={() => onEditChainedWorkflow(id)}
               />
             )}
             {onRemoveChainedWorkflow && (

--- a/source/javascripts/core/models/BitriseYmlService.spec.ts
+++ b/source/javascripts/core/models/BitriseYmlService.spec.ts
@@ -1185,7 +1185,7 @@ describe('BitriseYmlService', () => {
     });
   });
 
-  describe('deleteChainedWorkflow', () => {
+  describe('removeChainedWorkflow', () => {
     const placements: ChainedWorkflowPlacement[] = ['after_run', 'before_run'];
 
     placements.forEach((placement) => {
@@ -1201,7 +1201,7 @@ describe('BitriseYmlService', () => {
             },
           };
 
-          const actualYml = BitriseYmlService.deleteChainedWorkflow(0, 'wf1', placement, sourceYml);
+          const actualYml = BitriseYmlService.removeChainedWorkflow(0, 'wf1', placement, sourceYml);
 
           expect(actualYml.workflows?.wf1?.[placement]).toEqual(['wf3', 'wf2']);
           // Check the other placement
@@ -1223,7 +1223,7 @@ describe('BitriseYmlService', () => {
             },
           };
 
-          const actualYml = BitriseYmlService.deleteChainedWorkflow(0, 'wf1', placement, sourceYml);
+          const actualYml = BitriseYmlService.removeChainedWorkflow(0, 'wf1', placement, sourceYml);
 
           expect(actualYml.workflows?.wf1?.[placement]).toBeUndefined();
         });
@@ -1234,7 +1234,7 @@ describe('BitriseYmlService', () => {
             workflows: { wf1: { [placement]: ['wf2'] }, wf2: {} },
           };
 
-          const actualYml = BitriseYmlService.deleteChainedWorkflow(0, 'wf3', placement, sourceAndExpectedYml);
+          const actualYml = BitriseYmlService.removeChainedWorkflow(0, 'wf3', placement, sourceAndExpectedYml);
 
           expect(actualYml).toMatchBitriseYml(sourceAndExpectedYml);
         });
@@ -1248,7 +1248,7 @@ describe('BitriseYmlService', () => {
       };
 
       const placement = 'invalid_placement' as ChainedWorkflowPlacement;
-      const actualYml = BitriseYmlService.deleteChainedWorkflow(0, 'wf2', placement, sourceAndExpectedYml);
+      const actualYml = BitriseYmlService.removeChainedWorkflow(0, 'wf2', placement, sourceAndExpectedYml);
 
       expect(actualYml).toMatchBitriseYml(sourceAndExpectedYml);
     });

--- a/source/javascripts/core/models/BitriseYmlService.ts
+++ b/source/javascripts/core/models/BitriseYmlService.ts
@@ -295,7 +295,7 @@ function deleteWorkflows(workflowIds: string[], yml: BitriseYml): BitriseYml {
   return copy;
 }
 
-function deleteChainedWorkflow(
+function removeChainedWorkflow(
   chainedWorkflowIndex: number,
   parentWorkflowId: string,
   placement: Placement,
@@ -1042,7 +1042,7 @@ export default {
   deleteWorkflows,
   addChainedWorkflow,
   setChainedWorkflows,
-  deleteChainedWorkflow,
+  removeChainedWorkflow,
   createPipeline,
   renamePipeline,
   updatePipeline,

--- a/source/javascripts/core/stores/BitriseYmlStore.ts
+++ b/source/javascripts/core/stores/BitriseYmlStore.ts
@@ -14,6 +14,27 @@ type BitriseYmlStoreState = {
 
   getUniqueStepIds: () => string[];
 
+  // Pipeline related actions
+  createPipeline: (pipelineId: string, basePipelineId?: string) => void;
+  renamePipeline: (pipelineId: string, newPipelineId: string) => void;
+  updatePipeline: (pipelineId: string, pipeline: PipelineYmlObject) => void;
+  deletePipeline: (pipelineId: string) => void;
+  deletePipelines: (pipelineIds: string[]) => void;
+  addWorkflowToPipeline: (pipelineId: string, workflowId: string, parentWorkflowId?: string) => void;
+  removeWorkflowFromPipeline: (pipelineId: string, workflowId: string) => void;
+  removePipelineWorkflowDependency: (pipelineId: string, workflowId: string, dependencyId: string) => void;
+  updatePipelineWorkflowConditionAbortPipelineOnFailureEnabled: (
+    pipelineId: string,
+    workflowId: string,
+    abortPipelineOnFailureEnabled: boolean,
+  ) => void;
+  updatePipelineWorkflowConditionShouldAlwaysRun: (
+    pipelineId: string,
+    workflowId: string,
+    shouldAlwaysRun: string,
+  ) => void;
+  updatePipelineWorkflowConditionRunIfExpression: (pipelineId: string, workflowId: string, expression: string) => void;
+
   // Workflow related actions
   createWorkflow: (workflowId: string, baseWorkflowId?: string) => void;
   renameWorkflow: (workflowId: string, newWorkflowId: string) => void;
@@ -26,34 +47,16 @@ type BitriseYmlStoreState = {
     parentWorkflowId: string,
     placement: ChainedWorkflowPlacement,
   ) => void;
-
-  // Pipeline related actions
-  createPipeline: (pipelineId: string, basePipelineId?: string) => void;
-  renamePipeline: (pipelineId: string, newPipelineId: string) => void;
-  updatePipeline: (pipelineId: string, pipeline: PipelineYmlObject) => void;
-  deletePipeline: (pipelineId: string) => void;
-  deletePipelines: (pipelineIds: string[]) => void;
-  addWorkflowToPipeline: (pipelineId: string, workflowId: string, parentWorkflowId?: string) => void;
-  removeWorkflowFromPipeline: (pipelineId: string, workflowId: string) => void;
-  updatePipelineWorkflowConditionAbortPipelineOnFailureEnabled: (
-    pipelineId: string,
-    workflowId: string,
-    abortPipelineOnFailureEnabled: boolean,
-  ) => void;
-  updatePipelineWorkflowConditionShouldAlwaysRun: (
-    pipelineId: string,
-    workflowId: string,
-    shouldAlwaysRun: string,
-  ) => void;
-  updatePipelineWorkflowConditionRunIfExpression: (pipelineId: string, workflowId: string, expression: string) => void;
-  updateStackAndMachine: (workflowId: string, stack: string, machineTypeId: string) => void;
-  appendWorkflowEnvVar: (workflowId: string, envVar: EnvVar) => void;
-  updateWorkflowEnvVars: (workflowId: string, envVars: EnvVar[]) => void;
-  deleteChainedWorkflow: (
+  removeChainedWorkflow: (
     chainedWorkflowIndex: number,
     parentWorkflowId: string,
     placement: ChainedWorkflowPlacement,
   ) => void;
+  updateStackAndMachine: (workflowId: string, stack: string, machineTypeId: string) => void;
+  appendWorkflowEnvVar: (workflowId: string, envVar: EnvVar) => void;
+  updateWorkflowEnvVars: (workflowId: string, envVars: EnvVar[]) => void;
+
+  // Step related actions
   addStep: (workflowId: string, cvs: string, to: number) => void;
   moveStep: (workflowId: string, stepIndex: number, to: number) => void;
   cloneStep: (workflowId: string, stepIndex: number) => void;
@@ -85,55 +88,8 @@ function create(yml: BitriseYml, defaultMeta?: Meta): BitriseYmlStore {
     getUniqueStepIds() {
       return BitriseYmlService.getUniqueStepIds(get().yml);
     },
-    createWorkflow(workflowId, baseWorkflowId) {
-      return set((state) => {
-        return {
-          yml: BitriseYmlService.createWorkflow(workflowId, state.yml, baseWorkflowId),
-        };
-      });
-    },
-    renameWorkflow(workflowId, newWorkflowId) {
-      return set((state) => {
-        return {
-          yml: BitriseYmlService.renameWorkflow(workflowId, newWorkflowId, state.yml),
-        };
-      });
-    },
-    updateWorkflow(workflowId, workflow) {
-      return set((state) => {
-        return {
-          yml: BitriseYmlService.updateWorkflow(workflowId, workflow, state.yml),
-        };
-      });
-    },
-    deleteWorkflow(workflowId) {
-      return set((state) => {
-        return {
-          yml: BitriseYmlService.deleteWorkflow(workflowId, state.yml),
-        };
-      });
-    },
-    deleteWorkflows(workflowIds) {
-      return set((state) => {
-        return {
-          yml: BitriseYmlService.deleteWorkflows(workflowIds, state.yml),
-        };
-      });
-    },
-    setChainedWorkflows(workflowId, placement, chainedWorkflowIds) {
-      return set((state) => {
-        return {
-          yml: BitriseYmlService.setChainedWorkflows(workflowId, placement, chainedWorkflowIds, state.yml),
-        };
-      });
-    },
-    addChainedWorkflow(chainableWorkflowId, parentWorkflowId, placement) {
-      return set((state) => {
-        return {
-          yml: BitriseYmlService.addChainedWorkflow(chainableWorkflowId, parentWorkflowId, placement, state.yml),
-        };
-      });
-    },
+
+    // Pipeline related actions
     createPipeline(pipelineId, basePipelineId) {
       return set((state) => {
         return {
@@ -183,6 +139,13 @@ function create(yml: BitriseYml, defaultMeta?: Meta): BitriseYmlStore {
         };
       });
     },
+    removePipelineWorkflowDependency: (pipelineId, workflowId, dependencyId) => {
+      return set((state) => {
+        return {
+          yml: BitriseYmlService.removePipelineWorkflowDependency(pipelineId, workflowId, dependencyId, state.yml),
+        };
+      });
+    },
     updatePipelineWorkflowConditionAbortPipelineOnFailureEnabled(
       pipelineId,
       workflowId,
@@ -224,6 +187,63 @@ function create(yml: BitriseYml, defaultMeta?: Meta): BitriseYmlStore {
       });
     },
 
+    // Workflow related actions
+    createWorkflow(workflowId, baseWorkflowId) {
+      return set((state) => {
+        return {
+          yml: BitriseYmlService.createWorkflow(workflowId, state.yml, baseWorkflowId),
+        };
+      });
+    },
+    renameWorkflow(workflowId, newWorkflowId) {
+      return set((state) => {
+        return {
+          yml: BitriseYmlService.renameWorkflow(workflowId, newWorkflowId, state.yml),
+        };
+      });
+    },
+    updateWorkflow(workflowId, workflow) {
+      return set((state) => {
+        return {
+          yml: BitriseYmlService.updateWorkflow(workflowId, workflow, state.yml),
+        };
+      });
+    },
+    deleteWorkflow(workflowId) {
+      return set((state) => {
+        return {
+          yml: BitriseYmlService.deleteWorkflow(workflowId, state.yml),
+        };
+      });
+    },
+    deleteWorkflows(workflowIds) {
+      return set((state) => {
+        return {
+          yml: BitriseYmlService.deleteWorkflows(workflowIds, state.yml),
+        };
+      });
+    },
+    setChainedWorkflows(workflowId, placement, chainedWorkflowIds) {
+      return set((state) => {
+        return {
+          yml: BitriseYmlService.setChainedWorkflows(workflowId, placement, chainedWorkflowIds, state.yml),
+        };
+      });
+    },
+    addChainedWorkflow(chainableWorkflowId, parentWorkflowId, placement) {
+      return set((state) => {
+        return {
+          yml: BitriseYmlService.addChainedWorkflow(chainableWorkflowId, parentWorkflowId, placement, state.yml),
+        };
+      });
+    },
+    removeChainedWorkflow(chainedWorkflowIndex, parentWorkflowId, placement) {
+      return set((state) => {
+        return {
+          yml: BitriseYmlService.removeChainedWorkflow(chainedWorkflowIndex, parentWorkflowId, placement, state.yml),
+        };
+      });
+    },
     updateStackAndMachine(workflowId, stack, machineTypeId) {
       return set((state) => {
         return {
@@ -245,13 +265,8 @@ function create(yml: BitriseYml, defaultMeta?: Meta): BitriseYmlStore {
         };
       });
     },
-    deleteChainedWorkflow(chainedWorkflowIndex, parentWorkflowId, placement) {
-      return set((state) => {
-        return {
-          yml: BitriseYmlService.deleteChainedWorkflow(chainedWorkflowIndex, parentWorkflowId, placement, state.yml),
-        };
-      });
-    },
+
+    // Step related actions
     addStep(workflowId, cvs, to) {
       return set((state) => {
         return {

--- a/source/javascripts/pages/PipelinesPage/components/Drawers/Drawers.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/Drawers/Drawers.tsx
@@ -19,6 +19,8 @@ const Drawers = ({ children }: PropsWithChildren) => {
   const { pipelineId, workflowId, isDialogMounted, isDialogOpen, closeDialog, unmountDialog, setWorkflowId } =
     usePipelinesPageStore();
 
+  const showPipelineConditions = workflows.some((wf) => wf.id === workflowId);
+
   const { createPipeline, addWorkflowToPipeline } = useBitriseYmlStore((s) => ({
     createPipeline: s.createPipeline,
     addWorkflowToPipeline: s.addWorkflowToPipeline,
@@ -85,7 +87,7 @@ const Drawers = ({ children }: PropsWithChildren) => {
       {isDialogMounted(PipelineConfigDialogType.WORKFLOW_CONFIG) && (
         <WorkflowConfigDrawer
           workflowId={workflowId}
-          showPipelineConditions
+          showPipelineConditions={showPipelineConditions}
           onRename={handleRenameWorkflow}
           isOpen={isDialogOpen(PipelineConfigDialogType.WORKFLOW_CONFIG)}
           onClose={closeDialog}

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/GraphEdge.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/GraphEdge.tsx
@@ -6,11 +6,20 @@ const edgeStyle = (style?: CSSProperties) => {
 };
 
 const GraphEdge = (props: EdgeProps) => {
-  const { style } = props;
+  const { style, selected } = props;
 
   const [path] = getSmoothStepPath({ ...props, offset: 0, borderRadius: 12 });
 
-  return <BaseEdge {...props} path={path} style={edgeStyle({ ...style, stroke: 'var(--colors-border-minimal)' })} />;
+  return (
+    <BaseEdge
+      {...props}
+      path={path}
+      style={edgeStyle({
+        ...style,
+        stroke: selected ? 'var(--colors-border-selected)' : 'var(--colors-border-minimal)',
+      })}
+    />
+  );
 };
 
 export const ConnectionGraphEdge = (props: ConnectionLineComponentProps) => {

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/WorkflowNode/Handles.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/WorkflowNode/Handles.tsx
@@ -51,6 +51,7 @@ const createPlaceholderEdge = (source?: string | null): Edge => ({
   type: GRAPH_EDGE_TYPE,
   source: source || '',
   target: PLACEHOLDER_NODE_TYPE,
+  animated: true,
 });
 
 const HandleIcon = ({ isDragging, ...props }: IconProps & { isDragging: boolean }) => {
@@ -88,7 +89,10 @@ const HandleButton = ({ style, position, isDragging, ...props }: HandleProps & {
   };
 
   const onPointerLeave = () => {
-    deleteElements({ nodes: [{ id: PLACEHOLDER_NODE_TYPE }], edges: [{ id: `${id}->${PLACEHOLDER_NODE_TYPE}` }] });
+    deleteElements({
+      nodes: [{ id: PLACEHOLDER_NODE_TYPE }],
+      edges: [{ id: `${id}->${PLACEHOLDER_NODE_TYPE}` }],
+    });
     updateNodeData(id || '', (data) => ({ ...data, fixed: false }));
   };
 

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/WorkflowNode/WorkflowNode.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/WorkflowNode/WorkflowNode.tsx
@@ -12,7 +12,7 @@ import { LeftHandle, RightHandle } from './Handles';
 type Props = NodeProps<Node<WorkflowNodeDataType>>;
 type WorkflowNodeDataType = PipelineWorkflow & { pipelineId: string };
 
-const WorkflowNode = ({ data: { pipelineId }, id, zIndex }: Props) => {
+const WorkflowNode = ({ data: { pipelineId }, id, zIndex, selected }: Props) => {
   const ref = useRef<HTMLDivElement>(null);
   const { openDialog } = usePipelinesPageStore();
   const { updateNode, deleteElements } = useReactFlow();
@@ -23,6 +23,11 @@ const WorkflowNode = ({ data: { pipelineId }, id, zIndex }: Props) => {
     (workflowId: string) => openDialog(PipelineConfigDialogType.WORKFLOW_CONFIG, pipelineId, workflowId)(),
     [openDialog, pipelineId],
   );
+
+  const hoverStyle = {
+    outline: '2px solid',
+    outlineColor: 'var(--colors-border-selected)',
+  };
 
   useResizeObserver({
     ref,
@@ -38,6 +43,7 @@ const WorkflowNode = ({ data: { pipelineId }, id, zIndex }: Props) => {
         onEditWorkflow={openEditWorkflowDialog}
         onRemoveWorkflow={(wfId) => deleteElements({ nodes: [{ id: wfId }] })}
         onRemoveChainedWorkflow={removeChainedWorkflow}
+        containerProps={{ style: selected ? hoverStyle : {} }}
       />
       <RightHandle />
     </Box>

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/WorkflowNode/WorkflowNode.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/WorkflowNode/WorkflowNode.tsx
@@ -14,25 +14,15 @@ type WorkflowNodeDataType = PipelineWorkflow & { pipelineId: string };
 
 const WorkflowNode = ({ data: { pipelineId }, id, zIndex }: Props) => {
   const ref = useRef<HTMLDivElement>(null);
-  const openDialog = usePipelinesPageStore((s) => s.openDialog);
-  const removeWorkflowFromPipeline = useBitriseYmlStore((s) => s.removeWorkflowFromPipeline);
-  const { updateNode, setNodes, deleteElements } = useReactFlow<Node<WorkflowNodeDataType>>();
-
-  const handleRemoveWorkflow = useCallback(() => {
-    removeWorkflowFromPipeline(pipelineId, id);
-    deleteElements({ nodes: [{ id }] });
-    setNodes((nodes) => {
-      return nodes.map((node) => {
-        return {
-          ...node,
-          data: {
-            ...node.data,
-            dependsOn: node.data.dependsOn.filter((dep) => dep !== id),
-          },
-        };
-      });
-    });
-  }, [id, pipelineId, deleteElements, removeWorkflowFromPipeline, setNodes]);
+  const { openDialog } = usePipelinesPageStore();
+  const { updateNode, deleteElements } = useReactFlow();
+  const { removeChainedWorkflow } = useBitriseYmlStore((s) => ({
+    removeChainedWorkflow: s.removeChainedWorkflow,
+  }));
+  const openEditWorkflowDialog = useCallback(
+    (workflowId: string) => openDialog(PipelineConfigDialogType.WORKFLOW_CONFIG, pipelineId, workflowId)(),
+    [openDialog, pipelineId],
+  );
 
   useResizeObserver({
     ref,
@@ -45,8 +35,9 @@ const WorkflowNode = ({ data: { pipelineId }, id, zIndex }: Props) => {
       <WorkflowCard
         id={id}
         isCollapsable
-        onEditWorkflow={openDialog(PipelineConfigDialogType.WORKFLOW_CONFIG, pipelineId, id)}
-        onRemoveWorkflow={handleRemoveWorkflow}
+        onEditWorkflow={openEditWorkflowDialog}
+        onRemoveWorkflow={(wfId) => deleteElements({ nodes: [{ id: wfId }] })}
+        onRemoveChainedWorkflow={removeChainedWorkflow}
       />
       <RightHandle />
     </Box>

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/WorkflowNode/WorkflowNode.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/WorkflowNode/WorkflowNode.tsx
@@ -4,21 +4,22 @@ import { useResizeObserver } from 'usehooks-ts';
 import { Node, NodeProps, useReactFlow } from '@xyflow/react';
 import { PipelineWorkflow } from '@/core/models/Workflow';
 import { WorkflowCard } from '@/components/unified-editor';
-import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
 import { WORKFLOW_NODE_WIDTH } from '../../GraphPipelineCanvas.const';
 import { PipelineConfigDialogType, usePipelinesPageStore } from '../../../../../PipelinesPage.store';
 import { LeftHandle, RightHandle } from './Handles';
 
 type Props = NodeProps<Node<WorkflowNodeDataType>>;
-type WorkflowNodeDataType = PipelineWorkflow & { pipelineId: string };
+export type WorkflowNodeDataType = PipelineWorkflow & { pipelineId: string };
 
 const WorkflowNode = ({ data: { pipelineId }, id, zIndex, selected }: Props) => {
   const ref = useRef<HTMLDivElement>(null);
   const { openDialog } = usePipelinesPageStore();
-  const { updateNode, deleteElements } = useReactFlow();
+  const { updateNode, deleteElements } = useReactFlow<Node<WorkflowNodeDataType>>();
+  /* NOTE: will be included later
   const { removeChainedWorkflow } = useBitriseYmlStore((s) => ({
     removeChainedWorkflow: s.removeChainedWorkflow,
   }));
+  */
   const openEditWorkflowDialog = useCallback(
     (workflowId: string) => openDialog(PipelineConfigDialogType.WORKFLOW_CONFIG, pipelineId, workflowId)(),
     [openDialog, pipelineId],
@@ -42,7 +43,7 @@ const WorkflowNode = ({ data: { pipelineId }, id, zIndex, selected }: Props) => 
         isCollapsable
         onEditWorkflow={openEditWorkflowDialog}
         onRemoveWorkflow={(wfId) => deleteElements({ nodes: [{ id: wfId }] })}
-        onRemoveChainedWorkflow={removeChainedWorkflow}
+        // onRemoveChainedWorkflow={removeChainedWorkflow}
         containerProps={{ style: selected ? hoverStyle : {} }}
       />
       <RightHandle />

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/WorkflowNode/WorkflowNode.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/WorkflowNode/WorkflowNode.tsx
@@ -41,7 +41,20 @@ const WorkflowNode = ({ data: { pipelineId }, id, zIndex, selected }: Props) => 
       <WorkflowCard
         id={id}
         isCollapsable
+        /* TODO needs plumbing
+        onAddStep={}
+        onSelectStep={}
+        onMoveStep={}
+        onUpgradeStep={}
+        onCloneStep={}
+        onDeleteStep={}
+        onCreateWorkflow={]
+        onChainWorkflow={}
+        onChainChainedWorkflow={}
+        onChainedWorkflowsUpdate={}
+         */
         onEditWorkflow={openEditWorkflowDialog}
+        // onEditChainedWorkflow={openEditWorkflowDialog}
         onRemoveWorkflow={(wfId) => deleteElements({ nodes: [{ id: wfId }] })}
         // onRemoveChainedWorkflow={removeChainedWorkflow}
         containerProps={{ style: selected ? hoverStyle : {} }}

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/utils/autoLayoutingGraphNodes.ts
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/utils/autoLayoutingGraphNodes.ts
@@ -24,7 +24,10 @@ export default function autoLayoutingGraphNodes(nodes: Node[]) {
   });
 
   (nodes as Array<Node<PipelineWorkflow>>).forEach((node) => {
-    graph.setNode(node.data.id, { width: WORKFLOW_NODE_WIDTH, height: node.height ?? WORKFLOW_NODE_HEIGHT });
+    graph.setNode(node.data.id, {
+      width: WORKFLOW_NODE_WIDTH,
+      height: node.height ?? WORKFLOW_NODE_HEIGHT,
+    });
     node.data.dependsOn.forEach((source) => graph.setEdge(source, node.id));
   });
 

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/utils/createGraphEdge.ts
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/utils/createGraphEdge.ts
@@ -5,7 +5,7 @@ export default function createGraphEdge(sourceWorkflowId: string, targetWorkflow
     id: `${sourceWorkflowId}->${targetWorkflowId}`,
     deletable: true,
     focusable: false,
-    selectable: false,
+    selectable: true,
     reconnectable: false,
     type: GRAPH_EDGE_TYPE,
     source: sourceWorkflowId,

--- a/source/javascripts/pages/WorkflowsPage/components.new/WorkflowCanvasPanel/WorkflowCanvasPanel.tsx
+++ b/source/javascripts/pages/WorkflowsPage/components.new/WorkflowCanvasPanel/WorkflowCanvasPanel.tsx
@@ -73,10 +73,12 @@ const WorkflowCanvasPanel = ({ workflowId }: Props) => {
         <WorkflowCard
           id={workflowId}
           containerProps={{ maxW: 400, marginX: 'auto' }}
-          hideActions={['edit', 'remove']}
           // Workflow actions
-          onEditWorkflow={openWorkflowConfigDrawer}
-          onAddChainedWorkflow={openChainWorkflowDialog}
+          onEditWorkflow={undefined}
+          onEditChainedWorkflow={openWorkflowConfigDrawer}
+          onChainWorkflow={openChainWorkflowDialog}
+          onChainChainedWorkflow={openChainWorkflowDialog}
+          onRemoveWorkflow={undefined}
           onRemoveChainedWorkflow={removeChainedWorkflow}
           onChainedWorkflowsUpdate={setChainedWorkflows}
           // Step actions

--- a/source/javascripts/pages/WorkflowsPage/components.new/WorkflowCanvasPanel/WorkflowCanvasPanel.tsx
+++ b/source/javascripts/pages/WorkflowsPage/components.new/WorkflowCanvasPanel/WorkflowCanvasPanel.tsx
@@ -13,11 +13,11 @@ type Props = {
 };
 
 const WorkflowCanvasPanel = ({ workflowId }: Props) => {
-  const { moveStep, upgradeStep, cloneStep, deleteStep, setChainedWorkflows, deleteChainedWorkflow } =
+  const { moveStep, upgradeStep, cloneStep, deleteStep, setChainedWorkflows, removeChainedWorkflow } =
     useBitriseYmlStore((s) => ({
       moveStep: s.moveStep,
       setChainedWorkflows: s.setChainedWorkflows,
-      deleteChainedWorkflow: s.deleteChainedWorkflow,
+      removeChainedWorkflow: s.removeChainedWorkflow,
       upgradeStep: s.changeStepVersion,
       cloneStep: s.cloneStep,
       deleteStep: s.deleteStep,
@@ -77,7 +77,7 @@ const WorkflowCanvasPanel = ({ workflowId }: Props) => {
           // Workflow actions
           onEditWorkflow={openWorkflowConfigDrawer}
           onAddChainedWorkflow={openChainWorkflowDialog}
-          onRemoveChainedWorkflow={deleteChainedWorkflow}
+          onRemoveChainedWorkflow={removeChainedWorkflow}
           onChainedWorkflowsUpdate={setChainedWorkflows}
           // Step actions
           onAddStep={openStepSelectorDrawer}


### PR DESCRIPTION
- Fix workflow config panel, now opens chained workflows as well
- Implement remove chain workflow
- Implement remove pipeline workflow dependency
- Move node and edge deletion to the ReactFlow onNodesDelete and onEdgesDelete callbacks (to support Backspace deletion)