### PR TITLE
feat: log React rendering errors in DataDog

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,6 +49,7 @@
         "react": "^18.3.1",
         "react-copy-to-clipboard": "^5.1.0",
         "react-dom": "^18.3.1",
+        "react-error-boundary": "^5.0.0",
         "react-hook-form": "^7.53.1",
         "search-insights": "^2.17.3",
         "semver": "^7.6.3",
@@ -24002,6 +24003,17 @@
       },
       "peerDependencies": {
         "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-5.0.0.tgz",
+      "integrity": "sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-fast-compare": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "react": "^18.3.1",
     "react-copy-to-clipboard": "^5.1.0",
     "react-dom": "^18.3.1",
+    "react-error-boundary": "^5.0.0",
     "react-hook-form": "^7.53.1",
     "search-insights": "^2.17.3",
     "semver": "^7.6.3",

--- a/source/javascripts/utils/withRootProvider.tsx
+++ b/source/javascripts/utils/withRootProvider.tsx
@@ -1,7 +1,9 @@
-import { ReactNode } from 'react';
+import { ErrorInfo, ReactNode, useEffect } from 'react';
 import { theme } from '@bitrise/bitkit';
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary';
 import { ChakraProvider, mergeThemeOverride } from '@chakra-ui/react';
 
+import { datadogRum } from '@datadog/browser-rum';
 import createSharedContext from './createSharedContext';
 import withQueryClientProvider from './withQueryClientProvider';
 
@@ -14,8 +16,29 @@ const wfeTheme = mergeThemeOverride(theme, {
   },
 });
 
+const PassThroughFallback = ({ resetErrorBoundary }: FallbackProps) => {
+  useEffect(() => {
+    resetErrorBoundary();
+  }, [resetErrorBoundary]);
+
+  return null;
+};
+
+const logErrorToDataDog = (error: Error, info: ErrorInfo) => {
+  const renderingError = new Error(error.message);
+
+  renderingError.name = error.name;
+  renderingError.stack = info.componentStack || error.stack;
+
+  datadogRum.addError(renderingError);
+};
+
 const Root = ({ children }: { children: ReactNode }): JSX.Element => {
-  return <ChakraProvider theme={wfeTheme}>{children}</ChakraProvider>;
+  return (
+    <ErrorBoundary onError={logErrorToDataDog} FallbackComponent={PassThroughFallback}>
+      <ChakraProvider theme={wfeTheme}>{children}</ChakraProvider>
+    </ErrorBoundary>
+  );
 };
 
 const { component: RootComponent, use: withRootProvider } = createSharedContext(withQueryClientProvider(Root));


### PR DESCRIPTION
When an error occurs in React components, the whole WFE sometimes crashes, resulting in a blank screen for users. Additionally, no errors are logged in DataDog.

This PR addresses both issues: it prevents the blank screen while ensuring that errors are properly logged in DataDog, allowing the program to continue running without disruption.

https://docs.datadoghq.com/error_tracking/frontend/collecting_browser_errors/?tab=npm#react-error-boundaries-instrumentation