### PR TITLE
Update github.com/bitrise-io/bitrise to version 2.28.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.2
 
 require (
 	github.com/GeertJohan/go.rice v1.0.3
-	github.com/bitrise-io/bitrise v0.0.0-20250206133114-2c928f553cae
+	github.com/bitrise-io/bitrise v0.0.0-20250212092443-030954631c6d
 	github.com/bitrise-io/depman v0.0.0-20190402141727-e5c92c35cd92
 	github.com/bitrise-io/envman v0.0.0-20240730123632-8066eeb61599
 	github.com/bitrise-io/go-utils v1.0.13

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/bitrise-io/bitrise v0.0.0-20250206133114-2c928f553cae h1:3U7+oMqFsGYgUEBGUR2g7zuOiBNgO05ZOVqK3FGAlEg=
-github.com/bitrise-io/bitrise v0.0.0-20250206133114-2c928f553cae/go.mod h1:qivxh7r8oAluFnq1/fZC+Sa/4jyQM0CQDtAPmt9LRfI=
+github.com/bitrise-io/bitrise v0.0.0-20250212092443-030954631c6d h1:ughSlHymNkVyStxRDGRUk2vyiU9AUiKuoV59rz7WA4E=
+github.com/bitrise-io/bitrise v0.0.0-20250212092443-030954631c6d/go.mod h1:qivxh7r8oAluFnq1/fZC+Sa/4jyQM0CQDtAPmt9LRfI=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192 h1:vSHYT6kCL/iOT9BVuUPm0tVcbW57r5zldLWg0aB7qbQ=
 github.com/bitrise-io/colorstring v0.0.0-20180614154802-a8cd70115192/go.mod h1:CIHVcxZUvsG99XUJV6JlR7okNsMMGY81jMvPC20W+O0=
 github.com/bitrise-io/depman v0.0.0-20190402141727-e5c92c35cd92 h1:+alkNYr5sbvCpvu2YQC4SLddnIP2BeAIjr8/EsObonw=


### PR DESCRIPTION
This PR updates the `github.com/bitrise-io/bitrise` dependency to version [2.28.0](https://github.com/bitrise-io/bitrise/releases/tag/2.28.0).