### PR TITLE
fix: infinite rendering loop on Secrets page

### DIFF
--- a/source/javascripts/pages/SecretsPage/SecretsPage.tsx
+++ b/source/javascripts/pages/SecretsPage/SecretsPage.tsx
@@ -18,11 +18,13 @@ const SecretsPage = ({ onSecretsChange }: SecretsPageProps) => {
   const [deleteId, setDeleteId] = useState<string | null>(null);
   const [appSecretList, setAppSecretList] = useState<Secret[]>([]);
   const [workspaceSecretList, setWorkspaceSecretList] = useState<Secret[]>([]);
-  const { data: secrets = [] } = useSecrets({ appSlug });
+  const { data: secrets } = useSecrets({ appSlug });
 
   useEffect(() => {
-    setWorkspaceSecretList(secrets.filter((secret) => secret.isShared));
-    setAppSecretList(secrets.filter((secret) => !secret.isShared));
+    if (secrets) {
+      setWorkspaceSecretList(secrets.filter((secret) => secret.isShared));
+      setAppSecretList(secrets.filter((secret) => !secret.isShared));
+    }
   }, [secrets]);
 
   useEffect(() => {


### PR DESCRIPTION
Fix this kind of errors: https://app.datadoghq.com/rum/sessions?query=%40type%3Aerror%20service%3Awfe&agg_m=count&agg_m_source=base&agg_t=count&event=AwAAAZUjIElLRuSpaAAAABhBWlVqSUstc0FBQXVpYVlXZjVuS3pnQUEAAAAkMDE5NTIzMjQtM2NhNy00ZTI2LTg1ZTMtMGRmOGZkZWFjM2YwAAAEdQ&fromUser=false&refresh_mode=paused&viz=stream&from_ts=1740050325106&to_ts=1740052125106&live=true

The infinite loop was caused by `data: secrets = []`. With each state change, `secrets` was assigned a new array, causing the `useEffect` to run during every render cycle.