### PR TITLE
fix: EnvVars page Tabs loose state on discard

### DIFF
--- a/source/javascripts/pages/EnvVarsPage/EnvVarsPage.tsx
+++ b/source/javascripts/pages/EnvVarsPage/EnvVarsPage.tsx
@@ -1,3 +1,5 @@
+import { create } from 'zustand';
+import { combine } from 'zustand/middleware';
 import { TabList, Tabs, Text, Tab, TabPanels, TabPanel } from '@bitrise/bitkit';
 
 import { BitriseYml } from '@/core/models/BitriseYml';
@@ -11,9 +13,11 @@ type Props = {
   onChange: (yml: BitriseYml) => void;
 };
 
+const useTabs = create(combine({ index: 0 }, (set) => ({ onChange: (index: number) => set({ index }) })));
+
 const EnvVarsPageContent = () => {
   return (
-    <Tabs isLazy>
+    <Tabs {...useTabs()} isLazy>
       <Text as="h2" textStyle="heading/h2" p="32">
         Environment Variables
       </Text>


### PR DESCRIPTION
**Problem:** After pressing 'Discard' having added (but not saved) a new EnvVar in the Workflows tab, I'm moved me to the bottom of the list in the Project tab - this is a bit confusing and annoying