### PR TITLE
Add failing step related envs to GetDefaultOutputsHandler

### DIFF
--- a/apiserver/service/default_options.go
+++ b/apiserver/service/default_options.go
@@ -14,11 +14,14 @@ func GetDefaultOutputsHandler(w http.ResponseWriter, r *http.Request) {
 		FromBitriseCLI: []EnvItmModel{
 			{"BITRISE_SOURCE_DIR": ""},
 			{"BITRISE_DEPLOY_DIR": ""},
+			{"BITRISE_TEST_RESULT_DIR": ""},
 			{"BITRISE_BUILD_STATUS": ""},
 			{"BITRISE_TRIGGERED_WORKFLOW_ID": ""},
 			{"BITRISE_TRIGGERED_WORKFLOW_TITLE": ""},
 			{"CI": ""},
 			{"PR": ""},
+			{"BITRISE_FAILED_STEP_TITLE": ""},
+			{"BITRISE_FAILED_STEP_ERROR_MESSAGE": ""},
 		},
 	})
 }


### PR DESCRIPTION
This PR adds the [newly introduced failed step related envs](https://github.com/bitrise-io/bitrise/pull/1063) (`BITRISE_FAILED_STEP_TITLE` and `BITRISE_FAILED_STEP_ERROR_MESSAGE`) to the Bitrise CLI available env vars list (`GetDefaultOutputsHandler`).
Also added the missing `BITRISE_TEST_RESULT_DIR` env var.
Related Monolith PR: https://github.com/bitrise-io/bitrise-website/pull/15814