### PR TITLE
feat: don't guess stack OS type, use the new API field

### DIFF
--- a/source/javascripts/core/api/StacksAndMachinesApi.mswMocks.ts
+++ b/source/javascripts/core/api/StacksAndMachinesApi.mswMocks.ts
@@ -18,6 +18,7 @@ export const getStacksAndMachines = (options?: Options) => {
         description?: string;
         available_machines?: string[];
         rollback_version?: any;
+        os?: string;
       }
     > = {
       'osx-xcode-16': {
@@ -28,6 +29,7 @@ export const getStacksAndMachines = (options?: Options) => {
           options?.privateCloud === 'no-machines'
             ? []
             : ['m1.medium', 'm1.large', 'm2.medium', 'm2.large', 'm2.x-large', 'machine-y1', 'machine-y2'],
+        os: 'macos',
       },
       'osx-xcode-15': {
         title: 'Xcode 15.0.x',
@@ -51,6 +53,7 @@ export const getStacksAndMachines = (options?: Options) => {
             paying: '2-82-0',
           },
         },
+        os: 'macos',
       },
       'linux-ubuntu-22.04': {
         title: 'Ubuntu 22.04 with Android SDK',
@@ -69,6 +72,7 @@ export const getStacksAndMachines = (options?: Options) => {
                 'machine-x',
                 'machine-z1',
               ],
+        os: 'linux',
       },
       'mixed-stack': {
         title: 'Mixed Stack',
@@ -77,6 +81,7 @@ export const getStacksAndMachines = (options?: Options) => {
           options?.privateCloud === 'no-machines'
             ? []
             : ['m2.medium', 'm2.large', 'm2.x-large', 'amd.medium', 'amd.large', 'amd.x-large'],
+        os: 'unknown',
       },
     };
 

--- a/source/javascripts/core/api/StacksAndMachinesApi.ts
+++ b/source/javascripts/core/api/StacksAndMachinesApi.ts
@@ -19,6 +19,7 @@ type StacksAndMachinesResponse = {
       rollback_version?: {
         [machineTypeId: string]: { free?: string; paying?: string };
       };
+      os?: string;
     };
   };
   available_machines: {
@@ -69,9 +70,20 @@ async function getStacksAndMachines({ appSlug, signal }: { appSlug: string; sign
   const promotedMachineTypes: MachineType[] = [];
   const defaultMachineTypeIdOfOSs: { [key: string]: string } = {};
 
+  const mapOSValues = (os?: string) => {
+    switch (os) {
+      case 'macos':
+        return 'macos';
+      case 'linux':
+        return 'linux';
+      default:
+        return 'unknown';
+    }
+  };
+
   mapValues(
     response.available_stacks,
-    ({ title, description = '', available_machines = [], rollback_version, ...rest }, id) => {
+    ({ title, description = '', available_machines = [], rollback_version, os, ...rest }, id) => {
       availableStacks.push({
         id: String(id),
         name: title,
@@ -80,6 +92,7 @@ async function getStacksAndMachines({ appSlug, signal }: { appSlug: string; sign
           rest['description-link-gen2-applesilicon'] || rest['description-link-gen2'] || rest['description-link'],
         machineTypes: available_machines,
         rollbackVersion: rollback_version,
+        os: mapOSValues(os),
       });
     },
   );

--- a/source/javascripts/core/models/StackAndMachine.ts
+++ b/source/javascripts/core/models/StackAndMachine.ts
@@ -5,6 +5,7 @@ export type Stack = {
   descriptionUrl?: string;
   machineTypes: string[];
   rollbackVersion?: Record<string, { free?: string; paying?: string }>;
+  os: 'macos' | 'linux' | 'unknown';
 };
 
 export type StackOption = {

--- a/source/javascripts/core/services/StackAndMachineService.spec.ts
+++ b/source/javascripts/core/services/StackAndMachineService.spec.ts
@@ -8,6 +8,7 @@ const stacks: Stack[] = [
     description:
       'Xcode 16.0 based on macOS 14.5 Sonoma.\n\nThe Android SDK and other common mobile tools are also installed.',
     machineTypes: ['mac-m1', 'mac-m2', 'mac-m3', 'mac-m4', 'joker'],
+    os: 'macos',
   },
   {
     id: 'osx-xcode-15',
@@ -15,18 +16,21 @@ const stacks: Stack[] = [
     description:
       'Xcode 15.0.1 based on macOS 13.5 Ventura.\n\nThe Android SDK and other common mobile tools are also installed.',
     machineTypes: ['mac-m1', 'mac-m2', 'joker'],
+    os: 'macos',
   },
   {
     id: 'linux-ubuntu-22',
     name: 'Ubuntu 22.04',
     description: 'Docker container environment based on Ubuntu 22.04. Preinstalled Android SDK and other common tools.',
     machineTypes: ['standard', 'elite', 'joker'],
+    os: 'linux',
   },
   {
     id: 'agent-pool-stack',
     name: 'Self-hosted agent',
     description: '',
     machineTypes: [],
+    os: 'unknown',
   },
 ];
 

--- a/source/javascripts/core/services/StackAndMachineService.ts
+++ b/source/javascripts/core/services/StackAndMachineService.ts
@@ -44,7 +44,18 @@ function isSelfHostedStack(stack: Stack) {
 }
 
 function getOsOfStack(stack: Stack): string {
-  return stack.id.split('-')[0];
+  switch (stack.os) {
+    case 'macos':
+      // This is a workaround to keep it compatible with other data structures returned by the API.
+      // The `stacks_and_machines` endpoint returns machine types grouped by OS, but it uses `osx` as the key for macOS at the moment.
+      // It should be cleaned up once the API response uses `macos` everywhere.
+      return 'osx';
+    case 'linux':
+      return 'linux';
+    default:
+      // Fallback to the first part of the stack ID
+      return stack.id.split('-')[0];
+  }
 }
 
 function getMachinesOfStack(machines: MachineType[], stack?: Stack): MachineType[] {
@@ -88,6 +99,7 @@ function createStack(override?: PartialDeep<StackWithValue>): StackWithValue {
     name: '',
     description: '',
     machineTypes: [],
+    os: 'unknown',
   };
 
   return toMerged(base, override || {}) as StackWithValue;


### PR DESCRIPTION
### Context

Upcoming Linux stacks will have a more meaningful stack ID convention and won't start with `linux-`. This would break the string parsing thing in this repo, therefore a new `os` field was added to the stack API response.

### Changes

Make the `Stack` model aware of the OS with a typed field (not just a string). I think it's important to make this model as clear as possible, and "warp" everything else, such as the mapping of `osx` to `macos` (`osx` is something I want to purge from all codebases anyway, this is a nice opportunity to make the workflow editor future-proof).