### PR TITLE
fix: graph pipeline performance issue

### DIFF
--- a/source/javascripts/hooks/useBitriseYmlStore.ts
+++ b/source/javascripts/hooks/useBitriseYmlStore.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { useStore } from 'zustand';
 
 import { BitriseYml } from '@/core/models/BitriseYml';
@@ -9,8 +10,12 @@ type ExtendedBitriseYmlStoreState = Omit<BitriseYmlStoreState, 'yml'> & {
 };
 
 function useBitriseYmlStore<U = ExtendedBitriseYmlStoreState>(selector?: (state: ExtendedBitriseYmlStoreState) => U) {
-  const withBitriseYml = (state: BitriseYmlStoreState) => ({ ...state, yml: state.ymlDocument.toJSON() as BitriseYml });
+  const ymlDocument = useStore(bitriseYmlStore, (state) => state.ymlDocument);
+  const ymlDocumentAsJson = useMemo(() => ymlDocument.toJSON() as BitriseYml, [ymlDocument]);
+  const withBitriseYml = useShallow((state: BitriseYmlStoreState) => ({ ...state, yml: ymlDocumentAsJson }));
+
   const finalSelector = selector ? (state: BitriseYmlStoreState) => selector(withBitriseYml(state)) : withBitriseYml;
+
   return useStore(bitriseYmlStore, useShallow(finalSelector as any)) as U;
 }
 

--- a/source/javascripts/hooks/useBitriseYmlStore.ts
+++ b/source/javascripts/hooks/useBitriseYmlStore.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { Document } from 'yaml';
 import { useStore } from 'zustand';
 
 import { BitriseYml } from '@/core/models/BitriseYml';
@@ -9,11 +10,22 @@ type ExtendedBitriseYmlStoreState = Omit<BitriseYmlStoreState, 'yml'> & {
   yml: BitriseYml;
 };
 
+let cachedYmlJson: BitriseYml | null = null;
+let cachedYmlDocument: Document | null = null;
+
 function useBitriseYmlStore<U = ExtendedBitriseYmlStoreState>(selector?: (state: ExtendedBitriseYmlStoreState) => U) {
   const ymlDocument = useStore(bitriseYmlStore, (state) => state.ymlDocument);
-  const ymlDocumentAsJson = useMemo(() => ymlDocument.toJSON() as BitriseYml, [ymlDocument]);
-  const withBitriseYml = useShallow((state: BitriseYmlStoreState) => ({ ...state, yml: ymlDocumentAsJson }));
 
+  const ymlJson = useMemo(() => {
+    if (ymlDocument !== cachedYmlDocument) {
+      cachedYmlJson = ymlDocument.toJSON() as BitriseYml;
+      cachedYmlDocument = ymlDocument;
+    }
+
+    return cachedYmlJson as BitriseYml;
+  }, [ymlDocument]);
+
+  const withBitriseYml = useShallow((state: BitriseYmlStoreState) => ({ ...state, yml: ymlJson }));
   const finalSelector = selector ? (state: BitriseYmlStoreState) => selector(withBitriseYml(state)) : withBitriseYml;
 
   return useStore(bitriseYmlStore, useShallow(finalSelector as any)) as U;

--- a/source/javascripts/hooks/useBitriseYmlStore.ts
+++ b/source/javascripts/hooks/useBitriseYmlStore.ts
@@ -10,6 +10,8 @@ type ExtendedBitriseYmlStoreState = Omit<BitriseYmlStoreState, 'yml'> & {
   yml: BitriseYml;
 };
 
+// NOTE: Cached values to avoid unnecessary recalculations when multiple components use this hook
+// and the ymlDocument does not change. Document.toJSON() can be expensive for large yml files.
 let cachedYmlJson: BitriseYml | null = null;
 let cachedYmlDocument: Document | null = null;
 


### PR DESCRIPTION
JIRA Ticket: [CI-4997](https://bitrise.atlassian.net/browse/CI-4997)

Explanation: The `state.ymlDocument.toJSON()` method was called every time the `useBitriseYmlStore` hook was invoked. In this update, the JSON formatting is performed only once, and only when the `ymlDocument` changes.

[CI-4997]: https://bitrise.atlassian.net/browse/CI-4997?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ