### PR TITLE
perf: move some heavy operations into the store

### DIFF
--- a/source/javascripts/core/utils/YmlUtils.ts
+++ b/source/javascripts/core/utils/YmlUtils.ts
@@ -338,7 +338,9 @@ function isEquals(a: Root, b: Root) {
     return aCache.get(b)!;
   }
 
-  aCache.set(b, toYml(a) === toYml(b));
+  // NOTE: Using toString() for equality check instead of toYml() as it's faster
+  // and sufficient for our use case since it preserves all node structure and formatting.
+  aCache.set(b, a.toString() === b.toString());
 
   return aCache.get(b)!;
 }

--- a/source/javascripts/hooks/useYmlHasChanges.ts
+++ b/source/javascripts/hooks/useYmlHasChanges.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-underscore-dangle */
-import YmlUtils from '@/core/utils/YmlUtils';
 
 import useBitriseYmlStore from './useBitriseYmlStore';
 
@@ -10,6 +9,6 @@ export default function useYmlHasChanges() {
     }
 
     // Check if the current YML document is different from the saved one
-    return !!s.__invalidYmlString || !YmlUtils.isEquals(s.ymlDocument, s.savedYmlDocument);
+    return !!s.__invalidYmlString || s.hasChanges;
   });
 }


### PR DESCRIPTION
Previously, the YAML document equality check was executed every time the document changed and whenever the `useYmlHasChanges` hook was used. Now, we store the `hasChanges` state and perform the calculation only once per change to improve efficiency.