### PR TITLE
fix: Step bundle fixes around inputs and env vars

### DIFF
--- a/source/javascripts/components/VariablePopover/EnvVarPopover.tsx
+++ b/source/javascripts/components/VariablePopover/EnvVarPopover.tsx
@@ -61,8 +61,15 @@ const EnvVarPopover = ({
 
   const handleOnCreate = useCallback(
     (envVar: EnvVar) => {
-      dispatchEnvVarCreated({ envVar, source: EnvVarSource.Workflows, sourceId: workflowId });
-      EnvVarService.append(envVar, { source: EnvVarSource.Workflows, sourceId: workflowId });
+      dispatchEnvVarCreated({
+        envVar,
+        source: workflowId ? EnvVarSource.Workflows : EnvVarSource.App,
+        sourceId: workflowId,
+      });
+      EnvVarService.append(envVar, {
+        source: workflowId ? EnvVarSource.Workflows : EnvVarSource.App,
+        sourceId: workflowId,
+      });
       onSelect(envVar);
     },
     [onSelect, workflowId],
@@ -111,7 +118,9 @@ const EnvVarPopover = ({
             alignItems="center"
             justifyContent="space-between"
           >
-            {isMode(Mode.CREATE) && <Text textStyle="heading/h4">Create variable</Text>}
+            {isMode(Mode.CREATE) && (
+              <Text textStyle="heading/h4">Create {workflowId ? 'workflow' : 'project'} variable</Text>
+            )}
             {isMode(Mode.SELECT) && (
               <>
                 <Text textStyle="heading/h4">Insert variable</Text>

--- a/source/javascripts/components/unified-editor/StepBundleConfig/StepBundleConfig.context.tsx
+++ b/source/javascripts/components/unified-editor/StepBundleConfig/StepBundleConfig.context.tsx
@@ -7,6 +7,8 @@ import StepService from '@/core/services/StepService';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
 import useDefaultStepLibrary from '@/hooks/useDefaultStepLibrary';
 
+import StepConfigDrawerProvider from '../StepConfigDrawer/StepConfigDrawer.context';
+
 type Props = PropsWithChildren<{
   stepBundleId?: string;
   parentWorkflowId?: string;
@@ -19,7 +21,11 @@ const Context = createContext<Omit<Props, 'children'>>({
 });
 
 const StepBundleConfigProvider = ({ children, ...props }: Props) => {
-  return <Context.Provider value={props}>{children}</Context.Provider>;
+  return (
+    <StepConfigDrawerProvider stepBundleId={props.stepBundleId} workflowId="" stepIndex={props.stepIndex}>
+      <Context.Provider value={props}>{children}</Context.Provider>
+    </StepConfigDrawerProvider>
+  );
 };
 
 type UseStepBundleConfigContextResult = Omit<Props, 'children'> & {
@@ -46,8 +52,7 @@ export function useStepBundleConfigContext<U = UseStepBundleConfigContextResult>
 
     if (!stepBundleId && parentWorkflowId && stepIndex >= 0) {
       const stepListItemModel = yml.workflows?.[parentWorkflowId]?.steps?.[stepIndex];
-      const stepListItems = Object.entries(stepListItemModel || {});
-      const [cvs, stepBundleInWorkflow] = stepListItems.length > 0 ? stepListItems[0] : ['', {}];
+      const [cvs, stepBundleInWorkflow] = Object.entries(stepListItemModel ?? {})[0] ?? ['', {}];
 
       const id = StepBundleService.cvsToId(cvs);
       const stepBundle = toMerged(yml.step_bundles?.[id] ?? {}, stepBundleInWorkflow ?? {});
@@ -56,8 +61,8 @@ export function useStepBundleConfigContext<U = UseStepBundleConfigContextResult>
         ? StepBundleService.ymlInstanceToStepBundle(
             id,
             stepBundle,
-            yml.step_bundles?.[id] || undefined,
-            stepBundleInWorkflow || undefined,
+            yml.step_bundles?.[id] ?? undefined,
+            stepBundleInWorkflow ?? undefined,
           )
         : undefined;
       result.stepBundleId = id;
@@ -65,7 +70,7 @@ export function useStepBundleConfigContext<U = UseStepBundleConfigContextResult>
 
     if (!stepBundleId && !parentWorkflowId && parentStepBundleId && stepIndex >= 0) {
       const stepListItemModel = yml.step_bundles?.[parentStepBundleId]?.steps?.[stepIndex];
-      const [cvs, stepBundleInStepBundle] = Object.entries(stepListItemModel || {})[0];
+      const [cvs, stepBundleInStepBundle] = Object.entries(stepListItemModel ?? {})[0] ?? ['', {}];
 
       const id = StepBundleService.cvsToId(cvs);
       const stepBundle = toMerged(yml.step_bundles?.[id] ?? {}, stepBundleInStepBundle ?? {});

--- a/source/javascripts/components/unified-editor/StepBundleConfig/StepBundleConfigDrawer.tsx
+++ b/source/javascripts/components/unified-editor/StepBundleConfig/StepBundleConfigDrawer.tsx
@@ -13,17 +13,26 @@ import StepBundleConfigHeader from './StepBundleConfigHeader';
 
 type Props = Omit<FloatingDrawerProps, 'children'> & {
   onRename?: (name: string) => void;
+  stepBundleId?: string;
+  parentWorkflowId?: string;
   parentStepBundleId?: string;
   stepIndex: number;
-  parentWorkflowId?: string;
 };
 
-const StepBundleConfigDrawer = ({ onRename, parentStepBundleId, stepIndex, parentWorkflowId, ...rest }: Props) => {
+const StepBundleConfigDrawer = ({
+  onRename,
+  stepBundleId,
+  stepIndex,
+  parentWorkflowId,
+  parentStepBundleId,
+  ...rest
+}: Props) => {
   return (
     <StepBundleConfigProvider
+      stepBundleId={stepBundleId}
+      parentWorkflowId={parentWorkflowId}
       parentStepBundleId={parentStepBundleId}
       stepIndex={stepIndex}
-      parentWorkflowId={parentWorkflowId}
     >
       <Tabs>
         <FloatingDrawer {...rest}>

--- a/source/javascripts/components/unified-editor/StepBundleConfig/StepBundleInputs/StepBundleInputsDialog.tsx
+++ b/source/javascripts/components/unified-editor/StepBundleConfig/StepBundleInputs/StepBundleInputsDialog.tsx
@@ -80,11 +80,6 @@ const StepBundleInputsDialog = (props: StepBundleInputsDialogProps) => {
     onSubmit({ [data.key]: data.value, opts: data.opts }, index, mode);
   };
 
-  const onCancelClick = () => {
-    reset();
-    onCancel();
-  };
-
   const valueOptions = watch('opts.value_options');
 
   const isSubmitDisabled = !(!!watch('key') && formState.isDirty) || !!formState.errors.key?.message;
@@ -92,6 +87,7 @@ const StepBundleInputsDialog = (props: StepBundleInputsDialogProps) => {
     <Dialog
       isOpen={isOpen}
       onClose={onCancel}
+      onCloseComplete={reset}
       title={mode === 'edit' ? 'Edit bundle input' : 'New bundle input'}
       scrollBehavior="inside"
       as="form"
@@ -185,7 +181,7 @@ const StepBundleInputsDialog = (props: StepBundleInputsDialogProps) => {
           <Button isDisabled={isSubmitDisabled} type="submit">
             {mode === 'edit' ? 'Update' : 'Create'}
           </Button>
-          <Button variant="secondary" onClick={onCancelClick}>
+          <Button variant="secondary" onClick={onCancel}>
             Cancel
           </Button>
         </ButtonGroup>

--- a/source/javascripts/core/services/StepBundleService.spec.ts
+++ b/source/javascripts/core/services/StepBundleService.spec.ts
@@ -1673,6 +1673,41 @@ describe('StepBundleService', () => {
       expect(getYmlString()).toEqual(expectedYml);
     });
 
+    it('should remove the inputs if last input is removed', () => {
+      updateBitriseYmlDocumentByString(
+        yaml`
+          workflows:
+            primary:
+              steps:
+              - bundle::sb1:
+                  inputs:
+                  - input1: value1
+          step_bundles:
+            sb1:
+              inputs:
+              - input1: value1`,
+      );
+
+      StepBundleService.updateStepBundleInputInstanceValue('input1', '', {
+        cvs: 'bundle::sb1',
+        source: 'workflows',
+        sourceId: 'primary',
+        stepIndex: 0,
+      });
+
+      const expectedYml = yaml`
+        workflows:
+          primary:
+            steps:
+            - bundle::sb1: {}
+        step_bundles:
+          sb1:
+            inputs:
+            - input1: value1`;
+
+      expect(getYmlString()).toEqual(expectedYml);
+    });
+
     it('should throw an error if the step bundle does not exist', () => {
       updateBitriseYmlDocumentByString(
         yaml`

--- a/source/javascripts/core/services/StepBundleService.ts
+++ b/source/javascripts/core/services/StepBundleService.ts
@@ -491,7 +491,8 @@ function updateStepBundleInputInstanceValue(
       YmlUtils.setIn(step, [cvs], {});
     }
 
-    const inputsInInstance = YmlUtils.getSeqIn(step, [cvs, 'inputs']);
+    const stepData = YmlUtils.getMapIn(step, [cvs], true);
+    const inputsInInstance = YmlUtils.getSeqIn(stepData, ['inputs']);
     const inputIndexInInstance = inputsInInstance?.items.findIndex((input) => isMap(input) && input.has(key)) ?? -1;
 
     const inputsInDefaults = YmlUtils.getSeqIn(stepBundle, ['inputs']);
@@ -506,15 +507,15 @@ function updateStepBundleInputInstanceValue(
     const shouldRemoveInstanceInput = !newValue && inputIndexInInstance >= 0;
 
     if (shouldCreateInstanceInput) {
-      YmlUtils.addIn(step, [cvs, 'inputs'], { [key]: newValue });
+      YmlUtils.addIn(stepData, ['inputs'], { [key]: newValue });
     }
 
     if (shouldUpdateInstanceInput) {
-      YmlUtils.updateValueByPath(step, [cvs, 'inputs', '*', key], newValue);
+      YmlUtils.updateValueByPath(stepData, ['inputs', '*', key], newValue);
     }
 
     if (shouldRemoveInstanceInput) {
-      YmlUtils.deleteByPath(step, [cvs, 'inputs', inputIndexInInstance]);
+      YmlUtils.deleteByPath(stepData, ['inputs', inputIndexInInstance]);
     }
 
     return doc;

--- a/source/javascripts/hooks/useStep.ts
+++ b/source/javascripts/hooks/useStep.ts
@@ -3,7 +3,7 @@ import { toMerged } from 'es-toolkit';
 import { useMemo } from 'react';
 
 import StepApi, { StepApiResult } from '@/core/api/StepApi';
-import { StepBundleModel, StepModel } from '@/core/models/BitriseYml';
+import { StepBundleOverrideModel, StepModel } from '@/core/models/BitriseYml';
 import { Step, StepBundleInstance, StepLike, WithGroup } from '@/core/models/Step';
 import StepService from '@/core/services/StepService';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
@@ -17,7 +17,7 @@ function useStepFromYml(props: UseStepProps): YmlStepResult {
   const defaultStepLibrary = useDefaultStepLibrary();
 
   return useBitriseYmlStore(({ yml }) => {
-    let stepObjectFromYml: StepModel | WithGroup | StepBundleModel | null | undefined;
+    let stepObjectFromYml: StepModel | WithGroup | StepBundleOverrideModel | null | undefined;
 
     if (props.workflowId) {
       const { workflowId, stepIndex } = props;
@@ -31,7 +31,7 @@ function useStepFromYml(props: UseStepProps): YmlStepResult {
       return { data: undefined };
     }
 
-    const [cvs, stepObj] = Object.entries(stepObjectFromYml)[0];
+    const [cvs, stepObj] = Object.entries(stepObjectFromYml)[0] ?? ['', {}];
     const step = stepObj ?? {};
 
     const { id } = StepService.parseStepCVS(cvs, defaultStepLibrary);
@@ -151,7 +151,7 @@ const useStep = (props: UseStepProps): UseStepResult => {
     }
 
     const inputs = defaultValues?.inputs?.map(({ opts, ...input }) => {
-      const [inputName, defaultValue] = Object.entries(input)[0];
+      const [inputName, defaultValue] = Object.entries(input)[0] ?? ['', ''];
       const inputFromYml = userValues?.inputs?.find(({ opts: _, ...inputObjectFromYml }) => {
         const inputNameFromYml = Object.keys(inputObjectFromYml)[0];
         return inputNameFromYml === inputName;

--- a/spec/integration/test_bitrise.yml
+++ b/spec/integration/test_bitrise.yml
@@ -207,9 +207,7 @@ workflows:
             - clone_depth: 5
             - update_submodules: "no"
             - merge_pr: "no"
-      - script@1:
-          inputs:
-            - content: echo "Hello Bitrise!"
+      - bundle::sb1: {}
   wf1:
     summary: My first workflow
     description: There will be more to come
@@ -521,3 +519,19 @@ step_bundles:
     steps:
       - theappspajamas-service-account-key-installer@0.0.3: {}
       - android-manifest-info@1.0.2: {}
+  sb1:
+    steps:
+      - bundle::sb2: {}
+    inputs:
+      - input1: sb1
+        opts:
+          title: sb1_input1
+  sb2:
+    steps:
+      - script@1:
+          inputs:
+            - content: echo "Hello Bitrise!"
+    inputs:
+      - input1: sb2
+        opts:
+          title: sb2_input1


### PR DESCRIPTION
Issues fixed:
- Creating an env var from a step bundle didn't work
- Resetting an input value in a step bundle instance crashed
- Step bundle input dialog didn't reset
- useStepDrawerContext was used without a provider under step bundles