### PR TITLE
Visualize dynamic pipeline workflows on the PipelinesPage canvas

### DIFF
--- a/source/javascripts/core/services/PipelineService.spec.ts
+++ b/source/javascripts/core/services/PipelineService.spec.ts
@@ -295,6 +295,125 @@ describe('PipelineService', () => {
     });
   });
 
+  describe('isGeneratorWorkflow', () => {
+    it('returns false if the workflow does not exist', () => {
+      const yml: BitriseYml = { format_version: '' };
+      expect(PipelineService.isGeneratorWorkflow('wf1', yml)).toBe(false);
+    });
+
+    it('returns false if the workflow has no steps', () => {
+      const yml: BitriseYml = { format_version: '', workflows: { wf1: {} } };
+      expect(PipelineService.isGeneratorWorkflow('wf1', yml)).toBe(false);
+    });
+
+    it('returns false if no step matches', () => {
+      const yml: BitriseYml = {
+        format_version: '',
+        workflows: { wf1: { steps: [{ 'script@1': {} }] } },
+      };
+      expect(PipelineService.isGeneratorWorkflow('wf1', yml)).toBe(false);
+    });
+
+    it('returns true for steplib extend-pipeline with a version', () => {
+      const yml: BitriseYml = {
+        format_version: '',
+        workflows: { wf1: { steps: [{ 'extend-pipeline@1': {} }] } },
+      };
+      expect(PipelineService.isGeneratorWorkflow('wf1', yml)).toBe(true);
+    });
+
+    it('returns true for steplib extend-pipeline without a version', () => {
+      const yml: BitriseYml = {
+        format_version: '',
+        workflows: { wf1: { steps: [{ 'extend-pipeline': {} }] } },
+      };
+      expect(PipelineService.isGeneratorWorkflow('wf1', yml)).toBe(true);
+    });
+
+    it('returns true for the fully qualified Bitrise steplib URL form', () => {
+      const yml: BitriseYml = {
+        format_version: '',
+        workflows: {
+          wf1: {
+            steps: [{ 'https://github.com/bitrise-io/bitrise-steplib.git::extend-pipeline@1': {} }],
+          },
+        },
+      };
+      expect(PipelineService.isGeneratorWorkflow('wf1', yml)).toBe(true);
+    });
+
+    it('returns true for git:: HTTPS source pointing to extend-pipeline.git', () => {
+      const yml: BitriseYml = {
+        format_version: '',
+        workflows: {
+          wf1: {
+            steps: [{ 'git::https://github.com/bitrise-io/extend-pipeline.git@main': {} }],
+          },
+        },
+      };
+      expect(PipelineService.isGeneratorWorkflow('wf1', yml)).toBe(true);
+    });
+
+    it('returns true for git:: SSH source pointing to extend-pipeline.git', () => {
+      const yml: BitriseYml = {
+        format_version: '',
+        workflows: {
+          wf1: {
+            steps: [{ 'git::git@github.com:bitrise-io/extend-pipeline.git@main': {} }],
+          },
+        },
+      };
+      expect(PipelineService.isGeneratorWorkflow('wf1', yml)).toBe(true);
+    });
+
+    it('returns true for git:: source with bitrise steps-<id> repo naming', () => {
+      const yml: BitriseYml = {
+        format_version: '',
+        workflows: {
+          wf1: {
+            steps: [{ 'git::https://github.com/bitrise-silver/steps-extend-pipeline.git@main': {} }],
+          },
+        },
+      };
+      expect(PipelineService.isGeneratorWorkflow('wf1', yml)).toBe(true);
+    });
+
+    it('returns true for path:: source ending in extend-pipeline', () => {
+      const yml: BitriseYml = {
+        format_version: '',
+        workflows: { wf1: { steps: [{ 'path::./extend-pipeline': {} }] } },
+      };
+      expect(PipelineService.isGeneratorWorkflow('wf1', yml)).toBe(true);
+    });
+
+    it('does not match when the last path segment differs', () => {
+      const yml: BitriseYml = {
+        format_version: '',
+        workflows: { wf1: { steps: [{ 'path::./tools/extend-pipeline-helper': {} }] } },
+      };
+      expect(PipelineService.isGeneratorWorkflow('wf1', yml)).toBe(false);
+    });
+
+    it('walks the before_run chain when looking for the step', () => {
+      const yml: BitriseYml = {
+        format_version: '',
+        workflows: {
+          wf1: { before_run: ['util'], steps: [{ 'script@1': {} }] },
+          util: { steps: [{ 'extend-pipeline@1': {} }] },
+        },
+      };
+      expect(PipelineService.isGeneratorWorkflow('wf1', yml)).toBe(true);
+    });
+
+    it('does not expand bundle:: references', () => {
+      const yml: BitriseYml = {
+        format_version: '',
+        workflows: { wf1: { steps: [{ 'bundle::extend-pipeline': {} }] } },
+      };
+      expect(PipelineService.isGeneratorWorkflow('wf1', yml)).toBe(false);
+    });
+  });
+
   describe('numberOfStages', () => {
     it('returns the correct number of stages', () => {
       const pipeline: PipelineModel = {

--- a/source/javascripts/core/services/PipelineService.ts
+++ b/source/javascripts/core/services/PipelineService.ts
@@ -3,7 +3,7 @@ import { Get, Paths } from 'type-fest';
 import { Document, isMap } from 'yaml';
 
 import { BitriseYml, GraphPipelineWorkflowModel, PipelineModel, PipelineWorkflows, Stages } from '../models/BitriseYml';
-import { BITRISE_STEP_LIBRARY_URL } from '../models/Step';
+import { BITRISE_STEP_LIBRARY_URL, LibraryType } from '../models/Step';
 import { updateBitriseYmlDocument } from '../stores/BitriseYmlStore';
 import YmlUtils from '../utils/YmlUtils';
 import StepService from './StepService';
@@ -121,6 +121,37 @@ function hasStepInside(pipelineId: string, stepId: string, yml: BitriseYml) {
         const { id } = StepService.parseStepCVS(cvs, yml.default_step_lib_source || BITRISE_STEP_LIBRARY_URL);
         return id === stepId;
       });
+    });
+  });
+}
+
+const EXTEND_PIPELINE_STEP_ID = 'extend-pipeline';
+
+// parseStepCVS returns id = full URL/path for git::/path:: sources, so we compare on the last
+// path segment to match extend-pipeline regardless of whether it came from steplib, git, or path.
+function lastStepIdSegment(parsedId: string): string {
+  return (
+    parsedId
+      .replace(/\.git$/, '')
+      .split('/')
+      .pop() || parsedId
+  );
+}
+
+function isGeneratorWorkflow(workflowId: string, yml: BitriseYml): boolean {
+  const defaultLib = yml.default_step_lib_source || BITRISE_STEP_LIBRARY_URL;
+
+  return WorkflowService.getWorkflowChain(yml.workflows ?? {}, workflowId).some((wfId) => {
+    return yml.workflows?.[wfId]?.steps?.some((stepObject) => {
+      const cvs = Object.keys(stepObject)[0];
+      const { library, id } = StepService.parseStepCVS(cvs, defaultLib);
+      // bundle/with references are not steps themselves, and bundles are not expanded.
+      if (library === LibraryType.BUNDLE || library === LibraryType.WITH) {
+        return false;
+      }
+      const last = lastStepIdSegment(id);
+      // Bitrise repo convention: step repos are named `steps-<step-id>`, so accept both forms.
+      return last === EXTEND_PIPELINE_STEP_ID || last === `steps-${EXTEND_PIPELINE_STEP_ID}`;
     });
   });
 }
@@ -380,6 +411,7 @@ export default {
   sanitizeName,
   validateParallel,
   hasStepInside,
+  isGeneratorWorkflow,
   numberOfStages,
   convertToGraphPipeline,
   EMPTY_PIPELINE,

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/GraphPipelineCanvas.const.ts
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/GraphPipelineCanvas.const.ts
@@ -9,6 +9,8 @@ export const GRAPH_EDGE_TYPE = 'graph-edge';
 export const WORKFLOW_NODE_TYPE = 'workflow';
 export const PLACEHOLDER_NODE_TYPE = 'placeholder';
 export const PLACEHOLDER_NODE_ID = crypto.randomUUID();
+export const GENERATED_WORKFLOWS_PLACEHOLDER_NODE_TYPE = 'generated-workflows-placeholder';
+export const GENERATED_WORKFLOWS_PLACEHOLDER_NODE_ID_PREFIX = '__generated_workflows__::';
 
 export const DEFAULT_GRAPH_EDGE_ZINDEX = 0;
 export const HIGHLIGHTED_GRAPH_EDGE_ZINDEX = 1;

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/GraphPipelineCanvas.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/GraphPipelineCanvas.tsx
@@ -21,10 +21,16 @@ import usePipelineSelector from '@/pages/PipelinesPage/hooks/usePipelineSelector
 import { PipelinesPageDialogType, usePipelinesPageStore } from '@/pages/PipelinesPage/PipelinesPage.store';
 
 import GraphPipelineCanvasEmptyState from '../../EmptyStates/GraphPipelineCanvasEmptyState';
+import GeneratedWorkflowsPlaceholderNode from './components/GeneratedWorkflowsPlaceholderNode';
 import GraphEdge, { ConnectionGraphEdge } from './components/GraphEdge';
 import PlaceholderNode from './components/PlaceholderWorkflowNode';
 import WorkflowNode from './components/WorkflowNode';
-import { GRAPH_EDGE_TYPE, PLACEHOLDER_NODE_TYPE, WORKFLOW_NODE_TYPE } from './GraphPipelineCanvas.const';
+import {
+  GENERATED_WORKFLOWS_PLACEHOLDER_NODE_TYPE,
+  GRAPH_EDGE_TYPE,
+  PLACEHOLDER_NODE_TYPE,
+  WORKFLOW_NODE_TYPE,
+} from './GraphPipelineCanvas.const';
 import { GraphPipelineEdgeType, GraphPipelineNodeType, isWorkflowNode } from './GraphPipelineCanvas.types';
 import usePipelineWorkflows from './hooks/usePipelineWorkflows';
 import autoLayoutingGraphNodes from './utils/autoLayoutingGraphNodes';
@@ -34,6 +40,7 @@ import validateConnection from './utils/validateConnection';
 const nodeTypes: NodeTypes = {
   [WORKFLOW_NODE_TYPE]: WorkflowNode,
   [PLACEHOLDER_NODE_TYPE]: PlaceholderNode,
+  [GENERATED_WORKFLOWS_PLACEHOLDER_NODE_TYPE]: GeneratedWorkflowsPlaceholderNode,
 };
 
 const edgeTypes: EdgeTypes = {

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/GraphPipelineCanvas.types.ts
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/GraphPipelineCanvas.types.ts
@@ -1,6 +1,14 @@
 import { Edge, Node } from '@xyflow/react';
 
-import { PLACEHOLDER_NODE_TYPE, WORKFLOW_NODE_TYPE } from './GraphPipelineCanvas.const';
+import { PipelineWorkflow } from '@/core/models/Workflow';
+
+import {
+  GENERATED_WORKFLOWS_PLACEHOLDER_NODE_TYPE,
+  PLACEHOLDER_NODE_TYPE,
+  WORKFLOW_NODE_TYPE,
+} from './GraphPipelineCanvas.const';
+
+export type PipelineCanvasWorkflow = PipelineWorkflow & { isGenerator: boolean };
 
 export type WorkflowNodeType = Node<{
   uses?: string;
@@ -9,8 +17,9 @@ export type WorkflowNodeType = Node<{
   parallel?: string | number;
 }>;
 export type PlaceholderNodeType = Node<{ dependsOn: string[] }>;
+export type GeneratedWorkflowsPlaceholderNodeType = Node<{ generatorId: string }>;
 export type GraphPipelineEdgeType = Edge<{ highlighted?: boolean }>;
-export type GraphPipelineNodeType = PlaceholderNodeType | WorkflowNodeType;
+export type GraphPipelineNodeType = PlaceholderNodeType | WorkflowNodeType | GeneratedWorkflowsPlaceholderNodeType;
 
 export function isWorkflowNode(node: GraphPipelineNodeType): node is WorkflowNodeType {
   return node.type === WORKFLOW_NODE_TYPE;
@@ -18,4 +27,10 @@ export function isWorkflowNode(node: GraphPipelineNodeType): node is WorkflowNod
 
 export function isPlaceholderNode(node: GraphPipelineNodeType): node is PlaceholderNodeType {
   return node.type === PLACEHOLDER_NODE_TYPE;
+}
+
+export function isGeneratedWorkflowsPlaceholderNode(
+  node: GraphPipelineNodeType,
+): node is GeneratedWorkflowsPlaceholderNodeType {
+  return node.type === GENERATED_WORKFLOWS_PLACEHOLDER_NODE_TYPE;
 }

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/GeneratedWorkflowsPlaceholderNode.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/GeneratedWorkflowsPlaceholderNode.tsx
@@ -1,0 +1,44 @@
+import { Box, Text, Tooltip } from '@bitrise/bitkit';
+import { NodeProps } from '@xyflow/react';
+
+import { WORKFLOW_NODE_HEIGHT, WORKFLOW_NODE_WIDTH } from '../GraphPipelineCanvas.const';
+import { LeftHandle } from './Handles';
+
+const TOOLTIP_LABEL = 'The upstream step will append workflows here when the pipeline runs.';
+
+const GeneratedWorkflowsPlaceholderNode = ({ zIndex }: NodeProps) => {
+  return (
+    <Box display="flex" alignItems="stretch" h={WORKFLOW_NODE_HEIGHT} w={WORKFLOW_NODE_WIDTH} zIndex={zIndex}>
+      <LeftHandle />
+      <Tooltip label={TOOLTIP_LABEL}>
+        <Box
+          flex="1"
+          minW={0}
+          minH={WORKFLOW_NODE_HEIGHT}
+          display="flex"
+          alignItems="center"
+          pl="42"
+          pr="8"
+          py="6"
+          borderRadius="8"
+          border="1px dashed"
+          borderColor="border/regular"
+          backgroundColor="background/primary"
+          data-testid="generated-workflows-placeholder-node"
+        >
+          <Box display="flex" flexDir="column" alignItems="flex-start" justifyContent="center" flex="1" minW={0}>
+            <Text textStyle="body/md/semibold" color="text/secondary" hasEllipsis>
+              Dynamic workflows
+            </Text>
+            <Text textStyle="body/sm/regular" color="text/tertiary" hasEllipsis>
+              Appended at runtime
+            </Text>
+          </Box>
+        </Box>
+      </Tooltip>
+      <Box w={16} />
+    </Box>
+  );
+};
+
+export default GeneratedWorkflowsPlaceholderNode;

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/hooks/usePipelineWorkflows.ts
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/hooks/usePipelineWorkflows.ts
@@ -1,9 +1,10 @@
-import { PipelineWorkflow } from '@/core/models/Workflow';
+import PipelineService from '@/core/services/PipelineService';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
 
 import usePipelineSelector from '../../../../hooks/usePipelineSelector';
+import { PipelineCanvasWorkflow } from '../GraphPipelineCanvas.types';
 
-const usePipelineWorkflows = (): PipelineWorkflow[] => {
+const usePipelineWorkflows = (): PipelineCanvasWorkflow[] => {
   const { selectedPipeline } = usePipelineSelector();
 
   return useBitriseYmlStore(({ yml }) => {
@@ -15,7 +16,8 @@ const usePipelineWorkflows = (): PipelineWorkflow[] => {
         uses: pipelineWorkflow?.uses,
         parallel: pipelineWorkflow?.parallel,
         dependsOn: pipelineWorkflow?.depends_on ?? [],
-      } satisfies PipelineWorkflow;
+        isGenerator: PipelineService.isGeneratorWorkflow(pipelineWorkflow?.uses || id, yml),
+      } satisfies PipelineCanvasWorkflow;
     });
   });
 };

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/utils/autoLayoutingGraphNodes.ts
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/utils/autoLayoutingGraphNodes.ts
@@ -1,7 +1,5 @@
 import dagre from '@dagrejs/dagre';
 
-import { PipelineWorkflow } from '@/core/models/Workflow';
-
 import {
   CANVAS_PADDING,
   TOOLBAR_CONTAINER_HEIGHT,
@@ -10,9 +8,15 @@ import {
   WORKFLOW_NODE_HEIGHT,
   WORKFLOW_NODE_WIDTH,
 } from '../GraphPipelineCanvas.const';
-import { GraphPipelineNodeType, isPlaceholderNode, isWorkflowNode } from '../GraphPipelineCanvas.types';
+import {
+  GraphPipelineNodeType,
+  isGeneratedWorkflowsPlaceholderNode,
+  isPlaceholderNode,
+  isWorkflowNode,
+  PipelineCanvasWorkflow,
+} from '../GraphPipelineCanvas.types';
 
-function autoLayoutingGraphNodes(workflows: PipelineWorkflow[], nodes: GraphPipelineNodeType[]) {
+function autoLayoutingGraphNodes(workflows: PipelineCanvasWorkflow[], nodes: GraphPipelineNodeType[]) {
   const graph = new dagre.graphlib.Graph().setDefaultEdgeLabel(() => ({}));
 
   graph.setGraph({
@@ -29,6 +33,9 @@ function autoLayoutingGraphNodes(workflows: PipelineWorkflow[], nodes: GraphPipe
     if (isPlaceholderNode(node)) {
       graph.setNode(node.id, { width: WORKFLOW_NODE_WIDTH, height: WORKFLOW_NODE_HEIGHT });
       node.data.dependsOn.forEach((source) => graph.setEdge(source, node.id));
+    } else if (isGeneratedWorkflowsPlaceholderNode(node)) {
+      graph.setNode(node.id, { width: WORKFLOW_NODE_WIDTH, height: WORKFLOW_NODE_HEIGHT });
+      graph.setEdge(node.data.generatorId, node.id);
     } else {
       const workflow = workflows.find((w) => w.id === node.id);
 

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/utils/createGeneratedWorkflowsPlaceholderNode.ts
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/utils/createGeneratedWorkflowsPlaceholderNode.ts
@@ -1,0 +1,31 @@
+import {
+  DEFAULT_WORKFLOW_NODE_ZINDEX,
+  GENERATED_WORKFLOWS_PLACEHOLDER_NODE_ID_PREFIX,
+  GENERATED_WORKFLOWS_PLACEHOLDER_NODE_TYPE,
+  WORKFLOW_NODE_HEIGHT,
+  WORKFLOW_NODE_WIDTH,
+} from '../GraphPipelineCanvas.const';
+import { GeneratedWorkflowsPlaceholderNodeType } from '../GraphPipelineCanvas.types';
+
+export function generatedWorkflowsPlaceholderNodeId(generatorWorkflowId: string): string {
+  return `${GENERATED_WORKFLOWS_PLACEHOLDER_NODE_ID_PREFIX}${generatorWorkflowId}`;
+}
+
+function createGeneratedWorkflowsPlaceholderNode(generatorWorkflowId: string) {
+  return {
+    id: generatedWorkflowsPlaceholderNodeId(generatorWorkflowId),
+    type: GENERATED_WORKFLOWS_PLACEHOLDER_NODE_TYPE,
+    data: { generatorId: generatorWorkflowId },
+    deletable: false,
+    draggable: false,
+    focusable: false,
+    selectable: false,
+    connectable: false,
+    width: WORKFLOW_NODE_WIDTH,
+    height: WORKFLOW_NODE_HEIGHT,
+    position: { x: -9999, y: -9999 },
+    zIndex: DEFAULT_WORKFLOW_NODE_ZINDEX,
+  } satisfies GeneratedWorkflowsPlaceholderNodeType;
+}
+
+export default createGeneratedWorkflowsPlaceholderNode;

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/utils/createWorkflowNode.ts
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/utils/createWorkflowNode.ts
@@ -1,14 +1,12 @@
-import { PipelineWorkflow } from '@/core/models/Workflow';
-
 import {
   DEFAULT_WORKFLOW_NODE_ZINDEX,
   WORKFLOW_NODE_HEIGHT,
   WORKFLOW_NODE_TYPE,
   WORKFLOW_NODE_WIDTH,
 } from '../GraphPipelineCanvas.const';
-import { GraphPipelineNodeType } from '../GraphPipelineCanvas.types';
+import { GraphPipelineNodeType, PipelineCanvasWorkflow } from '../GraphPipelineCanvas.types';
 
-function createWorkflowNode(workflow: PipelineWorkflow) {
+function createWorkflowNode(workflow: PipelineCanvasWorkflow) {
   return {
     id: workflow.id,
     data: {

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/utils/transformWorkflowsToGraphEntities.spec.ts
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/utils/transformWorkflowsToGraphEntities.spec.ts
@@ -1,0 +1,69 @@
+import { GENERATED_WORKFLOWS_PLACEHOLDER_NODE_TYPE, WORKFLOW_NODE_TYPE } from '../GraphPipelineCanvas.const';
+import { PipelineCanvasWorkflow } from '../GraphPipelineCanvas.types';
+import { generatedWorkflowsPlaceholderNodeId } from './createGeneratedWorkflowsPlaceholderNode';
+import transformWorkflowsToGraphEntities from './transformWorkflowsToGraphEntities';
+
+const workflow = (overrides: Partial<PipelineCanvasWorkflow>): PipelineCanvasWorkflow => ({
+  id: 'wf',
+  dependsOn: [],
+  isGenerator: false,
+  ...overrides,
+});
+
+describe('transformWorkflowsToGraphEntities', () => {
+  it('emits a single workflow node and no placeholders for a non-generator workflow', () => {
+    const { nodes, edges } = transformWorkflowsToGraphEntities([workflow({ id: 'wf1' })]);
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0].type).toBe(WORKFLOW_NODE_TYPE);
+    expect(edges).toHaveLength(0);
+  });
+
+  it('emits a placeholder node and edge for a generator workflow with no dependants', () => {
+    const { nodes, edges } = transformWorkflowsToGraphEntities([workflow({ id: 'gen', isGenerator: true })]);
+
+    expect(nodes).toHaveLength(2);
+    expect(nodes[0].type).toBe(WORKFLOW_NODE_TYPE);
+    expect(nodes[1].type).toBe(GENERATED_WORKFLOWS_PLACEHOLDER_NODE_TYPE);
+
+    expect(edges).toHaveLength(1);
+    expect(edges[0].source).toBe('gen');
+    expect(edges[0].target).toBe(generatedWorkflowsPlaceholderNodeId('gen'));
+    expect(edges[0].animated).toBe(true);
+    expect(edges[0].deletable).toBe(false);
+    expect(edges[0].selectable).toBe(false);
+    expect(edges[0].reconnectable).toBe(false);
+  });
+
+  it('emits the placeholder even when other static workflows already depend on the generator', () => {
+    const { nodes, edges } = transformWorkflowsToGraphEntities([
+      workflow({ id: 'gen', isGenerator: true }),
+      workflow({ id: 'tests', dependsOn: ['gen'] }),
+    ]);
+
+    const placeholderNodes = nodes.filter((n) => n.type === GENERATED_WORKFLOWS_PLACEHOLDER_NODE_TYPE);
+    const placeholderEdges = edges.filter((e) => e.target === generatedWorkflowsPlaceholderNodeId('gen'));
+
+    expect(placeholderNodes).toHaveLength(1);
+    expect(placeholderEdges).toHaveLength(1);
+    expect(edges.some((e) => e.source === 'gen' && e.target === 'tests')).toBe(true);
+  });
+
+  it('produces a deterministic placeholder id derived from the generator workflow id', () => {
+    const { nodes: nodesA } = transformWorkflowsToGraphEntities([workflow({ id: 'gen', isGenerator: true })]);
+    const { nodes: nodesB } = transformWorkflowsToGraphEntities([workflow({ id: 'gen', isGenerator: true })]);
+
+    expect(nodesA[1].id).toBe(generatedWorkflowsPlaceholderNodeId('gen'));
+    expect(nodesA[1].id).toBe(nodesB[1].id);
+  });
+
+  it('marks the placeholder node as not connectable / selectable / deletable', () => {
+    const { nodes } = transformWorkflowsToGraphEntities([workflow({ id: 'gen', isGenerator: true })]);
+    const placeholder = nodes.find((n) => n.type === GENERATED_WORKFLOWS_PLACEHOLDER_NODE_TYPE);
+
+    expect(placeholder).toBeDefined();
+    expect(placeholder?.connectable).toBe(false);
+    expect(placeholder?.selectable).toBe(false);
+    expect(placeholder?.deletable).toBe(false);
+  });
+});

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/utils/transformWorkflowsToGraphEntities.ts
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/utils/transformWorkflowsToGraphEntities.ts
@@ -1,10 +1,11 @@
-import { PipelineWorkflow } from '@/core/models/Workflow';
-
-import { GraphPipelineEdgeType, GraphPipelineNodeType } from '../GraphPipelineCanvas.types';
+import { GraphPipelineEdgeType, GraphPipelineNodeType, PipelineCanvasWorkflow } from '../GraphPipelineCanvas.types';
+import createGeneratedWorkflowsPlaceholderNode, {
+  generatedWorkflowsPlaceholderNodeId,
+} from './createGeneratedWorkflowsPlaceholderNode';
 import createGraphPipelineEdge from './createGraphPipelineEdge';
 import createWorkflowNode from './createWorkflowNode';
 
-function transformWorkflowsToGraphEntities(workflows: PipelineWorkflow[]) {
+function transformWorkflowsToGraphEntities(workflows: PipelineCanvasWorkflow[]) {
   const nodes: GraphPipelineNodeType[] = [];
   const edges: GraphPipelineEdgeType[] = [];
 
@@ -14,6 +15,17 @@ function transformWorkflowsToGraphEntities(workflows: PipelineWorkflow[]) {
     workflow.dependsOn?.forEach((source) => {
       edges.push(createGraphPipelineEdge(source, workflow.id));
     });
+
+    if (workflow.isGenerator) {
+      nodes.push(createGeneratedWorkflowsPlaceholderNode(workflow.id));
+      edges.push({
+        ...createGraphPipelineEdge(workflow.id, generatedWorkflowsPlaceholderNodeId(workflow.id)),
+        animated: true,
+        deletable: false,
+        selectable: false,
+        reconnectable: false,
+      });
+    }
   });
 
   return { nodes, edges };

--- a/spec/integration/test_bitrise.yml
+++ b/spec/integration/test_bitrise.yml
@@ -65,6 +65,7 @@ pipelines:
       push:
         - branch: main
     workflows:
+      generator: {}
       tmp: { depends_on: [ wf1 ], parallel: 4 }
       wf1: {}
       wf2:
@@ -125,6 +126,9 @@ stages:
     workflows:
       - wf3: {}
 workflows:
+  generator:
+    steps:
+      - git::https://github.com/bitrise-silver/steps-extend-pipeline.git@main: {}
   custom-steplib-steps:
     triggers:
       push:


### PR DESCRIPTION
## Summary

Editor-side companion to [bitrise-website#19414](https://github.com/bitrise-io/bitrise-website/pull/19414) — surfaces the upcoming `extend-pipeline` step (hackathon project [#hackathon-2026-dynamic-pipelines](https://bitfall.slack.com/archives/C0B1QB86M54)) on the WFE PipelinesPage graph canvas, so YAML authors can see at edit time that a workflow generates more workflows at runtime.

- New `PipelineService.isGeneratorWorkflow` walks the workflow's before/after_run chain and detects the `extend-pipeline` step from any source — steplib (`extend-pipeline@1`), git (`git::…/steps-extend-pipeline.git@…`), or path (`path::./extend-pipeline`). Bundle/with references are intentionally not expanded.
- A dashed **Dynamic workflows / Appended at runtime** placeholder node is rendered downstream of every generator workflow on the graph canvas.
- The placeholder is a **dead-end node**: no source handle, `connectable: false`, `selectable: false`, `deletable: false`, and not in `usePipelineWorkflows`'s output — so it cannot become a `depends_on` target through any UI path.

`spec/integration/test_bitrise.yml` adds a `generator` workflow with the actual hackathon CVS (`git::https://github.com/bitrise-silver/steps-extend-pipeline.git@main`) so the new visualization shows up across all PipelinesPage Storybook stories.

## Test plan

- [x] `npx jest --testPathPattern='PipelineService|transformWorkflowsToGraphEntities'` — green (107 specs across the two suites).
- [x] `npx jest` — full suite green (1195/1195).
- [x] `npx eslint` on the changed files — clean (0 errors).
- [ ] In Storybook (`npm run storybook` → Pages/PipelinesPage/GraphPipelineWithEditing), confirm the `generator` workflow's downstream placeholder renders with the dashed border, correct text alignment with sibling cards, and tooltip on hover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)