### PR TITLE
Add local Dockerfile and improve HTTP listener configuration

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 nodejs 24.15.0
-golang 1.25.5
+golang 1.25.7

--- a/apiserver/api_server.go
+++ b/apiserver/api_server.go
@@ -75,7 +75,7 @@ func LaunchServer() error {
 		}
 	}
 
-	if err := http.ListenAndServe("localhost:"+port, nil); err != nil {
+	if err := http.ListenAndServe(":"+port, nil); err != nil {
 		return fmt.Errorf("Can't start HTTP listener: %v", err)
 	}
 	return nil

--- a/deployments/local/Dockerfile
+++ b/deployments/local/Dockerfile
@@ -1,0 +1,35 @@
+FROM node:24.15.0-bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl git openssh-client && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install Go
+RUN curl -fsSL https://go.dev/dl/go1.25.7.linux-amd64.tar.gz | tar -C /usr/local -xz
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+# Copy ONLY Go dependency files
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/root/.cache/go-build \
+    --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+ARG WEBSITEBOT_GITHUB_TOKEN
+RUN git config --global url."https://${WEBSITEBOT_GITHUB_TOKEN}@github.com/".insteadOf "ssh://git@github.com/"
+
+# Copy ONLY npm dependency files
+COPY package.json package-lock.json ./
+RUN --mount=type=ssh \
+    --mount=type=cache,target=/root/.npm \
+    npm ci
+
+# NOW copy the rest of the source
+COPY . .
+
+# Build steps that use the source
+RUN go install
+RUN npm install
+
+CMD ["npm", "run", "start:website"]
+
+EXPOSE 4000

--- a/deployments/local/Dockerfile
+++ b/deployments/local/Dockerfile
@@ -28,7 +28,6 @@ COPY . .
 
 # Build steps that use the source
 RUN go install
-RUN npm install
 
 CMD ["npm", "run", "start:website"]
 


### PR DESCRIPTION
- Add `deployments/local/Dockerfile` to support local development and testing.
- Update `.tool-versions` with Go version upgrade to 1.25.7.
- Modify `http.ListenAndServe` in `api_server.go` to bind to all interfaces instead of `localhost` for better accessibility.