### PR TITLE
Make dev website mode work behind the monolith asset proxy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,7 @@ spec/              # Test files (Jest unit + Playwright E2E)
 
 - Dev server available at `localhost:4000/{version}` (version from package.json)
 - Go static assets are embedded via go.rice (rice-box)
+- **Version bumps** (`package.json` + `version/version.go`): Vite hot-reloads `package.json` and starts serving at the new `/{version}/` (or `/{urlPrefix}/{version}/`) path, but the Go `go run main.go` process keeps its already-compiled binary with the old `version.VERSION` constant. The two then disagree on the route prefix and requests 404. After pulling/rebasing across a version-bump commit, restart the `workflow-editor` service (don't rely on Vite's hot-reload) so Go recompiles against the new constant.
 - Husky pre-commit hooks run lint-staged
 - The app runs inside an **iframe** on the Bitrise website — routing uses hash-based location (`useHashLocation`) and communicates with the parent window via `WindowUtils`
 - `BitriseYmlStore` always **clones the YAML document before mutations** — this is critical for `YmlUtils` caching to work correctly (WeakMap keyed by document identity)

--- a/README.md
+++ b/README.md
@@ -66,18 +66,26 @@ npm run start:website   # starts WFE in website mode
 
 You also have to make sure that the Monolith is already running before you try to execute the command above (otherwise
 every request to `http://localhost:3000` will be handled by the WFE).
-Also make sure that you change the path in the monolith to point to this version of the WFE (instead of the production
-version):
 
-- in the monolith open `workflow_controller.rb`
-- change `base_url` in method `get_workflow_editor_html_content` to the current version:
-  - if you run the monolith directly (using the umbrella repo) use `localhost:4000/{version}` (
-    e.g `base_url = 'http://localhost:4000/1.3.135`)
-  - if you run the monolith in docker (e.g with the `web-dev-env` repo) use `host.docker.internal:4000/{version}` (
-    e.g `base_url = 'http://host.docker.internal:4000/1.3.135'`)
+`start:website` defaults to `PUBLIC_URL_ROOT=/workflow_editor`, so the HTML emits asset URLs that route through the
+monolith's `/workflow_editor/*` asset proxy. Point the monolith at your local WFE by setting the env var below (no
+controller-source edits needed):
 
-Once the above steps are complete, you should be able to reach the Workflow Editor in the monolith
+- if you run the monolith directly (umbrella repo): `BITRISE_WORKFLOW_EDITOR_URL=http://localhost:4000/workflow_editor`
+- if you run the monolith in docker (`web-dev-env`): `BITRISE_WORKFLOW_EDITOR_URL=http://host.docker.internal:4000/workflow_editor`
+  (or `http://workflow-editor:4000/workflow_editor` when both run on the same compose network)
+
+Once the above is set, the Workflow Editor is reachable in the monolith
 on `localhost:3000/app/{slug}/workflow_editor`.
+
+If you want the browser to fetch assets directly from the WFE dev server (skipping the monolith proxy — faster, but
+only works when the browser is on the same host as Vite, so not for remote dev boxes), override the prefix:
+
+```bash
+PUBLIC_URL_ROOT=http://localhost:4000 npm run start:website
+```
+
+In that case set `BITRISE_WORKFLOW_EDITOR_URL=http://localhost:4000` (no trailing path) in the monolith.
 
 ### Run client tests
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ PUBLIC_URL_ROOT=http://localhost:4000 npm run start:website
 
 In that case set `BITRISE_WORKFLOW_EDITOR_URL=http://localhost:4000` (no trailing path) in the monolith.
 
+#### Restart after a version bump
+
+If you pull/rebase across a release commit (one that bumps the version in both `package.json` and
+`version/version.go`), restart the WFE — don't just rely on Vite's hot-reload. Vite picks up the new version from
+`package.json` and starts serving at the new `/{version}/` path, but `go run main.go` keeps running its already-compiled
+binary with the old `version.VERSION` constant. The two then disagree on the route prefix and requests 404 (which
+surfaces in the monolith as `OpenURI::HTTPError 404` from `WorkflowController#content`).
+
 ### Run client tests
 
 ```bash

--- a/apiserver/routes.go
+++ b/apiserver/routes.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 
 	rice "github.com/GeertJohan/go.rice"
@@ -62,6 +63,36 @@ func SetupRoutes(isServeFilesThroughMiddlemanServer bool) (*mux.Router, error) {
 
 	http.Handle("/", r)
 	http.Handle("/"+version.VERSION+"/", assetServer)
+
+	// The rest is dev-only convenience for MODE=WEBSITE running behind the
+	// website-monolith asset proxy. In the CLI plugin (prod, rice-box assets)
+	// none of this is used — users hit the Go server directly at /<version>/.
+	if isServeFilesThroughMiddlemanServer {
+		// Vite's base in website mode is /workflow_editor/<version>/; serve it
+		// at that path so the dev proxy chain can forward unchanged.
+		http.Handle("/workflow_editor/"+version.VERSION+"/", assetServer)
+
+		// The website-monolith resolves the WFE version via the
+		// workflow-editor-version LaunchDarkly flag (or the BITRISE_WORKFLOW_EDITOR_VERSION
+		// env var, default "latest"), which rarely matches the version baked into the
+		// local checkout. Rewrite the version segment to the actual local version so
+		// the WFE serves regardless of which version the caller asked for.
+		r.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			prefix := "/"
+			tail := strings.TrimPrefix(req.URL.Path, "/")
+			if strings.HasPrefix(tail, "workflow_editor/") {
+				prefix = "/workflow_editor/"
+				tail = strings.TrimPrefix(tail, "workflow_editor/")
+			}
+			slash := strings.Index(tail, "/")
+			if slash < 0 {
+				http.NotFound(w, req)
+				return
+			}
+			req.URL.Path = prefix + version.VERSION + "/" + tail[slash+1:]
+			assetServer.ServeHTTP(w, req)
+		})
+	}
 
 	return r, nil
 }

--- a/deployments/local/Dockerfile
+++ b/deployments/local/Dockerfile
@@ -8,6 +8,10 @@ RUN apt-get update && \
 RUN curl -fsSL https://go.dev/dl/go1.25.7.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:${PATH}"
 
+# Match the bind mount in web-dev-env's docker-compose override
+# (../bitrise-workflow-editor:/bitrise/src) so host edits are live.
+WORKDIR /bitrise/src
+
 # Copy ONLY Go dependency files
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/root/.cache/go-build \

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start:dev:api": "DEV=true ./_scripts/run_api.sh 4000",
     "start:base": "concurrently \"npm:start:dev\" \"npm:start:dev:api\"",
     "start": "NODE_ENV=development MODE=CLI npm run start:base",
-    "start:website": "NODE_ENV=development MODE=WEBSITE PUBLIC_URL_ROOT=http://localhost:4000 npm run start:base",
+    "start:website": "NODE_ENV=development MODE=WEBSITE PUBLIC_URL_ROOT=\"${PUBLIC_URL_ROOT:-/workflow_editor}\" npm run start:base",
     "preview": "vite preview",
     "build-storybook": "storybook build -c .storybook",
     "storybook": "storybook dev -p 6006",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,15 +33,19 @@ function localFeatureFlagsPlugin(): Plugin {
 }
 
 function absoluteUrlsPlugin(urlPrefix: string): Plugin {
+  // Skip URLs Vite already prefixed (via `base`) so a relative `urlPrefix`
+  // like "/workflow_editor" doesn't get applied twice. The regex has already
+  // consumed the leading "/", so the lookahead matches against the remainder.
+  const afterSlash = urlPrefix.startsWith('/') ? urlPrefix.slice(1) : urlPrefix;
+  const escaped = afterSlash.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const skipPrefixed = urlPrefix.startsWith('/') && afterSlash ? `(?!${escaped}/)` : '';
+  const srcRegex = new RegExp(`(src|href)="\\/${skipPrefixed}([^"/][^"]*)"`, 'g');
+  const fromRegex = new RegExp(`from "\\/${skipPrefixed}([^"]+)"`, 'g');
   return {
     name: 'absolute-urls',
     transformIndexHtml: {
       order: 'post',
-      handler: (html) => {
-        return html
-          .replace(/(src|href)="\/([^"/][^"]*)"/g, `$1="${urlPrefix}/$2"`)
-          .replace(/from "\/([^"]+)"/g, `from "${urlPrefix}/$1"`);
-      },
+      handler: (html) => html.replace(srcRegex, `$1="${urlPrefix}/$2"`).replace(fromRegex, `from "${urlPrefix}/$1"`),
     },
   };
 }
@@ -93,11 +97,26 @@ export default defineConfig(({ mode }) => {
       minify: isProd,
     },
 
+    // Pre-bundle lazy-loaded deps upfront so Vite doesn't re-optimize mid-session
+    // and delete old chunks the browser is still referencing. Mid-session reload
+    // requires HMR over WebSocket, which the monolith asset proxy doesn't carry.
+    // The `include` list covers deps Vite's entry scan misses (e.g. those used
+    // inside `?worker` modules, which Vite bundles separately).
+    optimizeDeps: {
+      entries: ['index.html', 'javascripts/**/*.{ts,tsx}'],
+      include: ['@bitrise/languageserver-core', 'monaco-yaml/yaml.worker.js'],
+    },
+
     server: {
       port: parseInt(env.DEV_SERVER_PORT || '4567', 10),
       proxy: { '/api': 'http://localhost:4000' },
-      origin: urlPrefix || undefined,
+      // server.origin must be a full URL (http://...). Skip for relative prefixes.
+      origin: /^https?:\/\//.test(urlPrefix) ? urlPrefix : undefined,
       allowedHosts: true,
+      // Vite 6+ defaults server.cors.origin to a localhost-only regex, which
+      // rejects HMR WebSocket upgrades from any other origin (e.g. when the
+      // page is loaded through a tunnel/remote dev box). Allow all in dev.
+      cors: true,
     },
 
     envPrefix: [


### PR DESCRIPTION
- routes.go: dev-only /workflow_editor/<version>/ alias for Vite's website-mode base, plus a NotFoundHandler that rewrites the version segment so any LaunchDarkly-served version resolves to the local build
- vite.config.ts: idempotent absoluteUrlsPlugin (skips URLs already prefixed by Vite's base), dev server cors:true to accept HMR WS from non-localhost origins, and optimizeDeps.entries + include so Monaco YAML deps don't trigger mid-session re-optimization (would invalidate chunks the browser still references when HMR can't push a full-reload through the proxy)
- package.json: start:website defaults PUBLIC_URL_ROOT to /workflow_editor so emitted asset URLs route back through the monolith's asset_proxy; overridable via env for direct-port dev (e.g. PUBLIC_URL_ROOT=http://localhost:4000)
- deployments/local/Dockerfile: WORKDIR /bitrise/src matches the web-dev-env bind mount so host source edits actually reach the running Go/Vite processes

Production paths are untouched: build:plugin / build:website skip every dev-gated change (optimizeDeps + dev server config are ignored by vite build, absoluteUrlsPlugin is gated on !isProd, and the extra Go route is gated on isServeFilesThroughMiddlemanServer which is only set in dev).