### PR TITLE
fix: keep new ToolRow as pending state until a valid ID is entered

### DIFF
--- a/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
+++ b/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
@@ -27,6 +27,7 @@ type Props = {
   withMachineFallbacks?: boolean;
   stackRollbackVersion?: string;
   withoutDefaultOptions?: boolean;
+  workflowId?: string;
 };
 
 const StackAndMachine = ({
@@ -37,6 +38,7 @@ const StackAndMachine = ({
   withMachineFallbacks,
   stackRollbackVersion,
   withoutDefaultOptions,
+  workflowId,
 }: Props) => {
   const isToolVersionsEnabled = useFeatureFlag('enable-wfe-tool-versions');
   const ref = useRef<HTMLDivElement>(null);
@@ -149,7 +151,7 @@ const StackAndMachine = ({
         </Notification>
       )}
       <DeprecatedMachineNotification machineTypeId={selectedMachineType.id} />
-      {isToolVersionsEnabled && <ToolVersions />}
+      {isToolVersionsEnabled && <ToolVersions workflowId={workflowId} />}
     </StackAndMachineWrapper>
   );
 };

--- a/source/javascripts/components/StacksAndMachine/WorkflowStackAndMachine.tsx
+++ b/source/javascripts/components/StacksAndMachine/WorkflowStackAndMachine.tsx
@@ -22,6 +22,7 @@ const WorkflowStackAndMachine = ({ workflowId }: Props) => {
       stackId={stackId}
       machineTypeId={machineTypeId}
       stackRollbackVersion={stackRollbackVersion}
+      workflowId={workflowId}
       onChange={updateWorkflowMeta}
     />
   );

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -54,48 +54,47 @@ const ToolRow = ({ toolId, versionString, existingToolIds, scope, autoFocus, onR
 
   return (
     <Box display="flex" alignItems="flex-start" gap="12">
-      <Box width="160px" flexShrink={0}>
-        <BitkitTextInput
-          size="md"
-          placeholder="Tool (ruby, node, etc.)"
-          errorText={idError}
-          inputProps={{ defaultValue: toolId, autoFocus, onBlur: handleIdBlur }}
-        />
-      </Box>
+      <BitkitTextInput
+        size="md"
+        width="160px"
+        flexShrink="0"
+        placeholder="Tool (ruby, node, etc.)"
+        errorText={idError}
+        inputProps={{ defaultValue: toolId, autoFocus, onBlur: handleIdBlur }}
+      />
 
       <Box display="flex" flex="1" alignItems="flex-start" gap="8">
-        <Box flex="1">
-          <BitkitNativeSelect
-            size="md"
-            value={parsed.strategy}
-            onChange={(e) => {
-              const newStrategy = e.target.value as VersionStrategy;
-              const isPrefix = (s: VersionStrategy) => s === 'latest-released' || s === 'latest-installed';
-              const newInputValue = isPrefix(parsed.strategy) && isPrefix(newStrategy) ? inputValue : '';
-              ToolsService.setTool(toolId, newStrategy, newInputValue, scope);
-            }}
-          >
-            {Object.entries(STRATEGY_LABELS)
-              .filter(([value]) => !(value === 'unset' && scope.type === 'root'))
-              .map(([value, label]) => (
-                <option key={value} value={value}>
-                  {label}
-                </option>
-              ))}
-          </BitkitNativeSelect>
-        </Box>
+        <BitkitNativeSelect
+          flex="1"
+          size="md"
+          value={parsed.strategy}
+          onChange={(e) => {
+            const newStrategy = e.target.value as VersionStrategy;
+            const isPrefix = (s: VersionStrategy) => s === 'latest-released' || s === 'latest-installed';
+            const newInputValue = isPrefix(parsed.strategy) && isPrefix(newStrategy) ? inputValue : '';
+            ToolsService.setTool(toolId, newStrategy, newInputValue, scope);
+          }}
+        >
+          {Object.entries(STRATEGY_LABELS)
+            .filter(([value]) => !(value === 'unset' && scope.type === 'root'))
+            .map(([value, label]) => (
+              <option key={value} value={value}>
+                {label}
+              </option>
+            ))}
+        </BitkitNativeSelect>
 
         {parsed.strategy !== 'unset' && (
-          <Box width="160px" flexShrink={0}>
-            <BitkitTextInput
-              size="md"
-              placeholder={parsed.strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
-              inputProps={{
-                value: inputValue,
-                onChange: (e) => ToolsService.setTool(toolId, parsed.strategy, e.target.value, scope),
-              }}
-            />
-          </Box>
+          <BitkitTextInput
+            size="md"
+            width="160px"
+            flexShrink="0"
+            placeholder={parsed.strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
+            inputProps={{
+              value: inputValue,
+              onChange: (e) => ToolsService.setTool(toolId, parsed.strategy, e.target.value, scope),
+            }}
+          />
         )}
       </Box>
 

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -1,0 +1,107 @@
+import { BitkitIconButton, BitkitNativeSelect, BitkitTextInput, IconMinusCircle } from '@bitrise/bitkit-v2';
+import { Box } from '@chakra-ui/react/box';
+import { FocusEventHandler, useState } from 'react';
+
+import { VersionStrategy } from '@/core/models/Tools';
+import ToolsService, { ToolScope } from '@/core/services/ToolsService';
+
+const STRATEGY_LABELS: Record<VersionStrategy, string> = {
+  'latest-released': 'Latest released version',
+  'latest-installed': 'Latest preinstalled version',
+  exact: 'Exact version',
+  unset: 'Do nothing (unset global setting)',
+};
+
+type ToolRowProps = {
+  toolId: string;
+  versionString: string;
+  existingToolIds: string[];
+  scope: ToolScope;
+  autoFocus?: boolean;
+  onRemove: () => void;
+};
+
+const ToolRow = ({ toolId, versionString, existingToolIds, scope, autoFocus, onRemove }: ToolRowProps) => {
+  const [idError, setIdError] = useState<string | undefined>();
+  const parsed = ToolsService.parseToolVersion(versionString);
+  let inputValue: string;
+  switch (parsed.strategy) {
+    case 'exact':
+      inputValue = parsed.version;
+      break;
+    case 'unset':
+      inputValue = '';
+      break;
+    default:
+      inputValue = parsed.prefix ?? '';
+  }
+
+  const handleIdBlur: FocusEventHandler<HTMLInputElement> = (e) => {
+    const newId = e.target.value.trim();
+    if (newId === toolId) {
+      setIdError(undefined);
+      return;
+    }
+    const validation = ToolsService.validateToolId(newId, toolId, existingToolIds);
+    if (validation !== true) {
+      setIdError(validation);
+      return;
+    }
+    setIdError(undefined);
+    ToolsService.deleteTool(toolId, scope);
+    ToolsService.setTool(newId, parsed.strategy, inputValue, scope);
+  };
+
+  return (
+    <Box display="flex" alignItems="flex-start" gap="12">
+      <Box width="160px" flexShrink={0}>
+        <BitkitTextInput
+          size="md"
+          placeholder="Tool (ruby, node, etc.)"
+          errorText={idError}
+          inputProps={{ defaultValue: toolId, autoFocus, onBlur: handleIdBlur }}
+        />
+      </Box>
+
+      <Box display="flex" flex="1" alignItems="flex-start" gap="8">
+        <Box flex="1">
+          <BitkitNativeSelect
+            size="md"
+            value={parsed.strategy}
+            onChange={(e) => {
+              const newStrategy = e.target.value as VersionStrategy;
+              const isPrefix = (s: VersionStrategy) => s === 'latest-released' || s === 'latest-installed';
+              const newInputValue = isPrefix(parsed.strategy) && isPrefix(newStrategy) ? inputValue : '';
+              ToolsService.setTool(toolId, newStrategy, newInputValue, scope);
+            }}
+          >
+            {Object.entries(STRATEGY_LABELS)
+              .filter(([value]) => !(value === 'unset' && scope.type === 'root'))
+              .map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+          </BitkitNativeSelect>
+        </Box>
+
+        {parsed.strategy !== 'unset' && (
+          <Box width="160px" flexShrink={0}>
+            <BitkitTextInput
+              size="md"
+              placeholder={parsed.strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
+              inputProps={{
+                value: inputValue,
+                onChange: (e) => ToolsService.setTool(toolId, parsed.strategy, e.target.value, scope),
+              }}
+            />
+          </Box>
+        )}
+      </Box>
+
+      <BitkitIconButton variant="tertiary" icon={IconMinusCircle} label="Remove tool" onClick={onRemove} />
+    </Box>
+  );
+};
+
+export default ToolRow;

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -3,7 +3,7 @@ import { Box } from '@chakra-ui/react/box';
 import { FocusEventHandler, useState } from 'react';
 
 import { VersionStrategy } from '@/core/models/Tools';
-import ToolsService, { ToolScope } from '@/core/services/ToolsService';
+import ToolsService from '@/core/services/ToolsService';
 
 const STRATEGY_LABELS: Record<VersionStrategy, string> = {
   'latest-released': 'Latest released version',
@@ -14,42 +14,48 @@ const STRATEGY_LABELS: Record<VersionStrategy, string> = {
 
 type ToolRowProps = {
   toolId: string;
-  versionString: string;
+  strategy: VersionStrategy;
+  version: string;
   existingToolIds: string[];
-  scope: ToolScope;
+  allowUnset?: boolean;
   autoFocus?: boolean;
+  onIdChange: (newId: string) => void;
+  onStrategyChange: (strategy: VersionStrategy, version: string) => void;
+  onVersionChange: (version: string) => void;
   onRemove: () => void;
 };
 
-const ToolRow = ({ toolId, versionString, existingToolIds, scope, autoFocus, onRemove }: ToolRowProps) => {
+const ToolRow = ({
+  toolId,
+  strategy,
+  version,
+  existingToolIds,
+  allowUnset,
+  autoFocus,
+  onIdChange,
+  onStrategyChange,
+  onVersionChange,
+  onRemove,
+}: ToolRowProps) => {
   const [idError, setIdError] = useState<string | undefined>();
-  const parsed = ToolsService.parseToolVersion(versionString);
-  let inputValue: string;
-  switch (parsed.strategy) {
-    case 'exact':
-      inputValue = parsed.version;
-      break;
-    case 'unset':
-      inputValue = '';
-      break;
-    default:
-      inputValue = parsed.prefix ?? '';
-  }
 
   const handleIdBlur: FocusEventHandler<HTMLInputElement> = (e) => {
     const newId = e.target.value.trim();
-    if (newId === toolId) {
-      setIdError(undefined);
-      return;
-    }
     const validation = ToolsService.validateToolId(newId, toolId, existingToolIds);
     if (validation !== true) {
       setIdError(validation);
       return;
     }
     setIdError(undefined);
-    ToolsService.deleteTool(toolId, scope);
-    ToolsService.setTool(newId, parsed.strategy, inputValue, scope);
+    if (newId !== toolId) {
+      onIdChange(newId);
+    }
+  };
+
+  const handleStrategyChange = (newStrategy: VersionStrategy) => {
+    const isPrefix = (s: VersionStrategy) => s === 'latest-released' || s === 'latest-installed';
+    const newVersion = isPrefix(strategy) && isPrefix(newStrategy) ? version : '';
+    onStrategyChange(newStrategy, newVersion);
   };
 
   return (
@@ -67,16 +73,11 @@ const ToolRow = ({ toolId, versionString, existingToolIds, scope, autoFocus, onR
         <BitkitNativeSelect
           flex="1"
           size="md"
-          value={parsed.strategy}
-          onChange={(e) => {
-            const newStrategy = e.target.value as VersionStrategy;
-            const isPrefix = (s: VersionStrategy) => s === 'latest-released' || s === 'latest-installed';
-            const newInputValue = isPrefix(parsed.strategy) && isPrefix(newStrategy) ? inputValue : '';
-            ToolsService.setTool(toolId, newStrategy, newInputValue, scope);
-          }}
+          value={strategy}
+          onChange={(e) => handleStrategyChange(e.target.value as VersionStrategy)}
         >
           {Object.entries(STRATEGY_LABELS)
-            .filter(([value]) => !(value === 'unset' && scope.type === 'root'))
+            .filter(([value]) => allowUnset || value !== 'unset')
             .map(([value, label]) => (
               <option key={value} value={value}>
                 {label}
@@ -84,15 +85,15 @@ const ToolRow = ({ toolId, versionString, existingToolIds, scope, autoFocus, onR
             ))}
         </BitkitNativeSelect>
 
-        {parsed.strategy !== 'unset' && (
+        {strategy !== 'unset' && (
           <BitkitTextInput
             size="md"
             width="160px"
             flexShrink="0"
-            placeholder={parsed.strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
+            placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
             inputProps={{
-              value: inputValue,
-              onChange: (e) => ToolsService.setTool(toolId, parsed.strategy, e.target.value, scope),
+              value: version,
+              onChange: (e) => onVersionChange(e.target.value),
             }}
           />
         )}

--- a/source/javascripts/components/ToolVersions/ToolVersions.stories.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.stories.tsx
@@ -1,0 +1,54 @@
+import { Box } from '@chakra-ui/react/box';
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { set } from 'es-toolkit/compat';
+import { stringify } from 'yaml';
+
+import YmlUtils from '@/core/utils/YmlUtils';
+
+import ToolVersions from './ToolVersions';
+
+const meta: Meta<typeof ToolVersions> = {
+  component: ToolVersions,
+  decorators: [
+    (Story) => (
+      <Box padding="24">
+        <Story />
+      </Box>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ToolVersions>;
+
+export const RootScope: Story = {
+  parameters: {
+    bitriseYmlStore: (() => {
+      const yml = set({ ...TEST_BITRISE_YML }, 'tools', {
+        go: '1.23.0',
+        node: '22:latest',
+        ruby: 'installed',
+        python: '3.13.4',
+      });
+      return { yml, ymlDocument: YmlUtils.toDoc(stringify(yml)) };
+    })(),
+  },
+};
+
+export const WorkflowScope: Story = {
+  args: {
+    workflowId: 'generator',
+  },
+  parameters: {
+    bitriseYmlStore: (() => {
+      const yml = set({ ...TEST_BITRISE_YML }, 'workflows.generator.tools', {
+        node: '22:latest',
+        python: '3.13.4',
+      });
+      return { yml, ymlDocument: YmlUtils.toDoc(stringify(yml)) };
+    })(),
+  },
+};
+
+export const Empty: Story = {};

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -1,7 +1,9 @@
 import { BitkitButton, BitkitLink } from '@bitrise/bitkit-v2';
 import { Box } from '@chakra-ui/react/box';
 import { Text } from '@chakra-ui/react/text';
+import { useState } from 'react';
 
+import { VersionStrategy } from '@/core/models/Tools';
 import ToolsService, { ToolScope } from '@/core/services/ToolsService';
 import { useToolsForScope } from '@/hooks/useTools';
 
@@ -10,6 +12,17 @@ import ToolRow from './ToolRow';
 const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
   const scope: ToolScope = workflowId ? { type: 'workflow', workflowId } : { type: 'root' };
   const tools = useToolsForScope(scope);
+  const [hasPendingRow, setHasPendingRow] = useState(false);
+  const [pendingStrategy, setPendingStrategy] = useState<VersionStrategy>('latest-released');
+  const [pendingVersion, setPendingVersion] = useState('');
+
+  const allowUnset = scope.type === 'workflow';
+
+  const handleAddNew = () => {
+    setPendingStrategy('latest-released');
+    setPendingVersion('');
+    setHasPendingRow(true);
+  };
 
   return (
     <Box display="flex" flexDirection="column" gap="24" marginBlockStart="24" maxWidth={640}>
@@ -21,28 +34,57 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
         </Text>
       </Box>
 
-      {Object.keys(tools).length > 0 && (
-        <Box display="flex" flexDirection="column" gap="16">
-          {Object.entries(tools).map(([toolId, versionString]) => (
+      <Box display="flex" flexDirection="column" gap="16">
+        {Object.entries(tools).map(([toolId, versionString]) => {
+          const parsed = ToolsService.parseToolVersion(versionString);
+          const versionValue =
+            parsed.strategy === 'exact' ? parsed.version : parsed.strategy === 'unset' ? '' : (parsed.prefix ?? '');
+          return (
             <ToolRow
               key={toolId}
               toolId={toolId}
-              versionString={versionString}
+              strategy={parsed.strategy}
+              version={versionValue}
               existingToolIds={Object.keys(tools)}
-              scope={scope}
-              autoFocus={toolId === ''}
+              allowUnset={allowUnset}
+              onIdChange={(newId) => {
+                ToolsService.deleteTool(toolId, scope);
+                ToolsService.setTool(newId, parsed.strategy, versionValue, scope);
+              }}
+              onStrategyChange={(strategy, ver) => ToolsService.setTool(toolId, strategy, ver, scope)}
+              onVersionChange={(ver) => ToolsService.setTool(toolId, parsed.strategy, ver, scope)}
               onRemove={() => ToolsService.deleteTool(toolId, scope)}
             />
-          ))}
-        </Box>
-      )}
+          );
+        })}
+        {hasPendingRow && (
+          <ToolRow
+            toolId=""
+            strategy={pendingStrategy}
+            version={pendingVersion}
+            existingToolIds={Object.keys(tools)}
+            allowUnset={allowUnset}
+            autoFocus
+            onIdChange={(newId) => {
+              ToolsService.setTool(newId, pendingStrategy, pendingVersion, scope);
+              setHasPendingRow(false);
+            }}
+            onStrategyChange={(strategy, ver) => {
+              setPendingStrategy(strategy);
+              setPendingVersion(ver);
+            }}
+            onVersionChange={(ver) => setPendingVersion(ver)}
+            onRemove={() => setHasPendingRow(false)}
+          />
+        )}
+      </Box>
 
       <BitkitButton
         variant="secondary"
         size="md"
         alignSelf="flex-start"
-        state={'' in tools ? 'disabled' : undefined}
-        onClick={() => ToolsService.setTool('', 'latest-released', '', scope)}
+        state={hasPendingRow ? 'disabled' : undefined}
+        onClick={handleAddNew}
       >
         Add new
       </BitkitButton>

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -1,14 +1,52 @@
-import { Box, Text } from '@bitrise/bitkit';
+import { BitkitButton, BitkitLink } from '@bitrise/bitkit-v2';
+import { Box } from '@chakra-ui/react/box';
+import { Text } from '@chakra-ui/react/text';
 
-const ToolVersions = () => {
+import ToolsService, { ToolScope } from '@/core/services/ToolsService';
+import { useToolsForScope } from '@/hooks/useTools';
+
+import ToolRow from './ToolRow';
+
+const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
+  const scope: ToolScope = workflowId ? { type: 'workflow', workflowId } : { type: 'root' };
+  const tools = useToolsForScope(scope);
+
   return (
-    <Box marginBlockStart="12">
-      <Text as="h5" textStyle="heading/h5" mb="12">
-        Tool setup
-      </Text>
-      <Text textStyle="body/md/regular" color="text/secondary">
-        Tool version setup coming soon.
-      </Text>
+    <Box display="flex" flexDirection="column" gap="24" marginBlockStart="24">
+      <Box display="flex" flexDirection="column" gap="8">
+        <Text textStyle="heading/h3">Tool setup</Text>
+        <Text textStyle="body/md/regular" color="text/secondary">
+          Configure what tools and versions are required for this workflow to work. Tool setup runs before the first
+          step. <BitkitLink href="#">Learn more</BitkitLink>
+        </Text>
+      </Box>
+
+      {Object.keys(tools).length > 0 && (
+        <Box display="flex" flexDirection="column" gap="16" maxWidth={640}>
+          {Object.entries(tools).map(([toolId, versionString]) => (
+            <ToolRow
+              key={toolId}
+              toolId={toolId}
+              versionString={versionString}
+              existingToolIds={Object.keys(tools)}
+              scope={scope}
+              autoFocus={toolId === ''}
+              onRemove={() => ToolsService.deleteTool(toolId, scope)}
+            />
+          ))}
+        </Box>
+      )}
+
+      <Box>
+        <BitkitButton
+          variant="secondary"
+          size="md"
+          state={'' in tools ? 'disabled' : undefined}
+          onClick={() => ToolsService.setTool('', 'latest-released', '', scope)}
+        >
+          Add new
+        </BitkitButton>
+      </Box>
     </Box>
   );
 };

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -12,7 +12,7 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
   const tools = useToolsForScope(scope);
 
   return (
-    <Box display="flex" flexDirection="column" gap="24" marginBlockStart="24">
+    <Box display="flex" flexDirection="column" gap="24" marginBlockStart="24" maxWidth={640}>
       <Box display="flex" flexDirection="column" gap="8">
         <Text textStyle="heading/h3">Tool setup</Text>
         <Text textStyle="body/md/regular" color="text/secondary">
@@ -22,7 +22,7 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
       </Box>
 
       {Object.keys(tools).length > 0 && (
-        <Box display="flex" flexDirection="column" gap="16" maxWidth={640}>
+        <Box display="flex" flexDirection="column" gap="16">
           {Object.entries(tools).map(([toolId, versionString]) => (
             <ToolRow
               key={toolId}
@@ -37,16 +37,15 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
         </Box>
       )}
 
-      <Box>
-        <BitkitButton
-          variant="secondary"
-          size="md"
-          state={'' in tools ? 'disabled' : undefined}
-          onClick={() => ToolsService.setTool('', 'latest-released', '', scope)}
-        >
-          Add new
-        </BitkitButton>
-      </Box>
+      <BitkitButton
+        variant="secondary"
+        size="md"
+        alignSelf="flex-start"
+        state={'' in tools ? 'disabled' : undefined}
+        onClick={() => ToolsService.setTool('', 'latest-released', '', scope)}
+      >
+        Add new
+      </BitkitButton>
     </Box>
   );
 };

--- a/source/javascripts/core/services/ToolsService.spec.ts
+++ b/source/javascripts/core/services/ToolsService.spec.ts
@@ -21,14 +21,11 @@ describe('ToolsService', () => {
       expect(ToolsService.parseToolVersion('installed')).toEqual({ strategy: 'latest-installed' });
     });
 
-    it('parses bare partial versions as latest-installed with that prefix', () => {
-      expect(ToolsService.parseToolVersion('3')).toEqual({ strategy: 'latest-installed', prefix: '3' });
-      expect(ToolsService.parseToolVersion('3.3')).toEqual({ strategy: 'latest-installed', prefix: '3.3' });
-    });
-
-    it('parses "x"-suffixed partial versions by stripping ".x" segments', () => {
-      expect(ToolsService.parseToolVersion('3.3.x')).toEqual({ strategy: 'latest-installed', prefix: '3.3' });
-      expect(ToolsService.parseToolVersion('3.x.x')).toEqual({ strategy: 'latest-installed', prefix: '3' });
+    it('parses bare partial versions as exact', () => {
+      expect(ToolsService.parseToolVersion('3')).toEqual({ strategy: 'exact', version: '3' });
+      expect(ToolsService.parseToolVersion('3.3')).toEqual({ strategy: 'exact', version: '3.3' });
+      expect(ToolsService.parseToolVersion('3.3.x')).toEqual({ strategy: 'exact', version: '3.3.x' });
+      expect(ToolsService.parseToolVersion('3.x.x')).toEqual({ strategy: 'exact', version: '3.x.x' });
     });
 
     it('parses a bare complete semver triple as exact', () => {

--- a/source/javascripts/core/services/ToolsService.spec.ts
+++ b/source/javascripts/core/services/ToolsService.spec.ts
@@ -62,45 +62,6 @@ describe('ToolsService', () => {
     });
   });
 
-  describe('serializeToolVersion', () => {
-    it('serializes latest-released without prefix', () => {
-      expect(ToolsService.serializeToolVersion({ strategy: 'latest-released' })).toBe('latest');
-    });
-
-    it('serializes latest-released with prefix', () => {
-      expect(ToolsService.serializeToolVersion({ strategy: 'latest-released', prefix: '22' })).toBe('22:latest');
-    });
-
-    it('serializes latest-installed with prefix', () => {
-      expect(ToolsService.serializeToolVersion({ strategy: 'latest-installed', prefix: '3.3' })).toBe('3.3:installed');
-    });
-
-    it('serializes latest-installed without prefix', () => {
-      expect(ToolsService.serializeToolVersion({ strategy: 'latest-installed' })).toBe('installed');
-    });
-
-    it('serializes exact', () => {
-      expect(ToolsService.serializeToolVersion({ strategy: 'exact', version: '3.13.4' })).toBe('3.13.4');
-    });
-
-    it('serializes unset', () => {
-      expect(ToolsService.serializeToolVersion({ strategy: 'unset' })).toBe('unset');
-    });
-
-    it.each([['latest'], ['installed'], ['22:latest'], ['3.3:installed'], ['3.13.4'], ['unset']])(
-      'round-trips %p',
-      (raw: string) => {
-        expect(ToolsService.serializeToolVersion(ToolsService.parseToolVersion(raw))).toBe(raw);
-      },
-    );
-
-    it('normalizes "x"-suffixed partials when round-tripping', () => {
-      expect(ToolsService.serializeToolVersion(ToolsService.parseToolVersion('3.x.x'))).toBe('3:installed');
-      expect(ToolsService.serializeToolVersion(ToolsService.parseToolVersion('3.3.x'))).toBe('3.3:installed');
-      expect(ToolsService.serializeToolVersion(ToolsService.parseToolVersion('3'))).toBe('3:installed');
-    });
-  });
-
   describe('validateToolId', () => {
     it('rejects empty and whitespace-only IDs', () => {
       expect(ToolsService.validateToolId('', '')).toBe('Tool ID is required');
@@ -150,11 +111,15 @@ describe('ToolsService', () => {
   });
 
   describe('setTool', () => {
+    it('throws when using "unset" strategy at root scope', () => {
+      expect(() => ToolsService.setTool('node', 'unset', '', { type: 'root' })).toThrow();
+    });
+
     describe('root-level', () => {
       it('creates the tools block when absent', () => {
         updateBitriseYmlDocumentByString(yaml`format_version: '13'`);
 
-        ToolsService.setTool('node', '22:latest', { type: 'root' });
+        ToolsService.setTool('node', 'latest-released', '22', { type: 'root' });
 
         expect(getYmlString()).toEqual(yaml`
           format_version: '13'
@@ -169,7 +134,7 @@ describe('ToolsService', () => {
             node: 22:latest
         `);
 
-        ToolsService.setTool('python', '3.13.4', { type: 'root' });
+        ToolsService.setTool('python', 'exact', '3.13.4', { type: 'root' });
 
         expect(getYmlString()).toEqual(yaml`
           tools:
@@ -185,12 +150,36 @@ describe('ToolsService', () => {
             python: "3.13.4"
         `);
 
-        ToolsService.setTool('node', 'latest', { type: 'root' });
+        ToolsService.setTool('node', 'latest-released', '', { type: 'root' });
 
         expect(getYmlString()).toEqual(yaml`
           tools:
             node: latest
             python: "3.13.4"
+        `);
+      });
+
+      it('sets latest-installed with prefix', () => {
+        updateBitriseYmlDocumentByString(yaml`format_version: '13'`);
+
+        ToolsService.setTool('ruby', 'latest-installed', '3.3', { type: 'root' });
+
+        expect(getYmlString()).toEqual(yaml`
+          format_version: '13'
+          tools:
+            ruby: 3.3:installed
+        `);
+      });
+
+      it('sets latest-installed without prefix', () => {
+        updateBitriseYmlDocumentByString(yaml`format_version: '13'`);
+
+        ToolsService.setTool('ruby', 'latest-installed', '', { type: 'root' });
+
+        expect(getYmlString()).toEqual(yaml`
+          format_version: '13'
+          tools:
+            ruby: installed
         `);
       });
     });
@@ -203,7 +192,7 @@ describe('ToolsService', () => {
               steps: []
         `);
 
-        ToolsService.setTool('node', '22:latest', { type: 'workflow', workflowId: 'primary' });
+        ToolsService.setTool('node', 'latest-released', '22', { type: 'workflow', workflowId: 'primary' });
 
         expect(getYmlString()).toEqual(yaml`
           workflows:
@@ -222,7 +211,7 @@ describe('ToolsService', () => {
                 node: 22:latest
         `);
 
-        ToolsService.setTool('python', '3.13.4', { type: 'workflow', workflowId: 'primary' });
+        ToolsService.setTool('python', 'exact', '3.13.4', { type: 'workflow', workflowId: 'primary' });
 
         expect(getYmlString()).toEqual(yaml`
           workflows:
@@ -241,7 +230,7 @@ describe('ToolsService', () => {
                 node: 22:latest
         `);
 
-        ToolsService.setTool('node', 'unset', { type: 'workflow', workflowId: 'primary' });
+        ToolsService.setTool('node', 'unset', '', { type: 'workflow', workflowId: 'primary' });
 
         expect(getYmlString()).toEqual(yaml`
           workflows:
@@ -261,7 +250,7 @@ describe('ToolsService', () => {
               steps: []
         `);
 
-        ToolsService.setTool('python', '3.13.4', { type: 'workflow', workflowId: 'secondary' });
+        ToolsService.setTool('python', 'exact', '3.13.4', { type: 'workflow', workflowId: 'secondary' });
 
         expect(getYmlString()).toEqual(yaml`
           workflows:
@@ -278,7 +267,9 @@ describe('ToolsService', () => {
       it('throws when workflow does not exist', () => {
         updateBitriseYmlDocumentByString(yaml`format_version: '13'`);
 
-        expect(() => ToolsService.setTool('node', 'latest', { type: 'workflow', workflowId: 'missing' })).toThrow();
+        expect(() =>
+          ToolsService.setTool('node', 'latest-released', '', { type: 'workflow', workflowId: 'missing' }),
+        ).toThrow();
       });
     });
   });

--- a/source/javascripts/core/services/ToolsService.ts
+++ b/source/javascripts/core/services/ToolsService.ts
@@ -1,4 +1,4 @@
-import { ParsedToolVersion } from '../models/Tools';
+import { ParsedToolVersion, VersionStrategy } from '../models/Tools';
 import { bitriseYmlStore, updateBitriseYmlDocument } from '../stores/BitriseYmlStore';
 import YmlUtils from '../utils/YmlUtils';
 import WorkflowService from './WorkflowService';
@@ -106,7 +106,24 @@ function validateToolVersion(raw: string) {
   return true;
 }
 
-function setTool(toolId: string, versionString: string, scope: ToolScope) {
+function setTool(toolId: string, strategy: VersionStrategy, inputValue: string, scope: ToolScope) {
+  if (strategy === 'unset' && scope.type === 'root') {
+    throw new Error('Cannot use "unset" strategy at root scope');
+  }
+
+  let parsed: ParsedToolVersion;
+  switch (strategy) {
+    case 'exact':
+      parsed = { strategy, version: inputValue };
+      break;
+    case 'unset':
+      parsed = { strategy };
+      break;
+    default:
+      parsed = { strategy, prefix: inputValue };
+  }
+  const versionString = serializeToolVersion(parsed);
+
   updateBitriseYmlDocument(({ doc }) => {
     validateScope(scope, doc);
 
@@ -129,7 +146,6 @@ function deleteTool(toolId: string, scope: ToolScope) {
 export type { ToolScope };
 export default {
   parseToolVersion,
-  serializeToolVersion,
   setTool,
   deleteTool,
   validateToolId,

--- a/source/javascripts/core/services/ToolsService.ts
+++ b/source/javascripts/core/services/ToolsService.ts
@@ -5,9 +5,6 @@ import WorkflowService from './WorkflowService';
 
 type ToolScope = { type: 'root' } | { type: 'workflow'; workflowId: string };
 
-const PARTIAL_VERSION_REGEX = /^\d+(\.\d+)*(\.x)*$/;
-const COMPLETE_SEMVER_REGEX = /^\d+\.\d+\.\d+$/;
-
 function parseToolVersion(raw: string): ParsedToolVersion {
   const lower = raw.toLowerCase();
 
@@ -35,11 +32,6 @@ function parseToolVersion(raw: string): ParsedToolVersion {
     if (suffix === 'installed') {
       return { strategy: 'latest-installed', prefix };
     }
-  }
-
-  if (colonIndex < 0 && PARTIAL_VERSION_REGEX.test(raw) && !COMPLETE_SEMVER_REGEX.test(raw)) {
-    const prefix = raw.replace(/(\.x)+$/, '');
-    return { strategy: 'latest-installed', prefix };
   }
 
   return { strategy: 'exact', version: raw };

--- a/source/javascripts/hooks/useTools.ts
+++ b/source/javascripts/hooks/useTools.ts
@@ -1,14 +1,12 @@
 import { Tools } from '@/core/models/BitriseYml';
+import { ToolScope } from '@/core/services/ToolsService';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
 
-export function useTools(): Tools {
-  return useBitriseYmlStore(({ yml }) => yml.tools ?? {});
-}
-
-export function useWorkflowTools(workflowId: string): Tools | undefined {
+export function useToolsForScope(scope: ToolScope): Tools {
   return useBitriseYmlStore(({ yml }) => {
-    const workflow = yml.workflows?.[workflowId];
-    if (!workflow) return undefined;
-    return workflow.tools ?? {};
+    if (scope.type === 'workflow') {
+      return yml.workflows?.[scope.workflowId]?.tools ?? {};
+    }
+    return yml.tools ?? {};
   });
 }


### PR DESCRIPTION
## Summary

Fixes a bug where clicking "Add new" in the Tool Versions UI immediately wrote an empty-keyed entry (`'': latest`) into the YAML document, marking it dirty and leaving a placeholder if the user navigated away without filling in the tool ID.

## Changes

- `ToolVersions`: tracks a `hasPendingRow` flag in component state; only calls `ToolsService.setTool` on blur once a valid, non-empty ID is entered. Removing the row without saving just clears the flag — no YAML mutation
- `ToolRow`: refactored into a pure controlled component — receives `strategy`, `version`, and callbacks (`onIdChange`, `onStrategyChange`, `onVersionChange`) instead of calling the service directly or holding its own strategy/version state. Removes the `isPending` branching entirely

## Test plan

- [ ] Click "Add new", navigate away without entering an ID — YAML should not be dirtied
- [ ] Click "Add new", fill in a valid tool ID, blur — entry appears in YAML
- [ ] Click "Add new", change strategy/version before entering ID — values are preserved when ID is committed
- [ ] Click "Add new", click the remove button without entering ID — row disappears, YAML unchanged
- [ ] Edit an existing tool row — strategy and version changes still write to YAML immediately