### PR TITLE
[BIVS-3678] Visual / YAML switch in WFE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bitrise/bitkit": "^13.356.0",
-        "@bitrise/bitkit-v2": "^0.3.214",
+        "@bitrise/bitkit-v2": "^0.3.237",
         "@bitrise/languageserver": "git+https://github.com/bitrise-io/bitrise-yml-language-server.git#833b15995769404349b63986ea779b60fccce531",
         "@dagrejs/dagre": "^3.0.0",
         "@datadog/browser-rum": "^6.33.0",
@@ -292,6 +292,7 @@
       "resolved": "https://registry.npmjs.org/@ark-ui/react/-/react-5.36.2.tgz",
       "integrity": "sha512-2lrZ7+Qtlj7hGx4qU2jZkE892JNrkULg/fUxqUuqmQfv9UGAXhdcw1Hr3N+zBgMDVz3aqip0Qa4v0Mox09MMvg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@internationalized/date": "3.12.0",
         "@zag-js/accordion": "1.40.0",
@@ -371,6 +372,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -380,6 +382,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.40.0.tgz",
       "integrity": "sha512-63byl/kLVzDYlnHFma4HKEKrqB1Vx2zg0sBmUSENPyh+Ia1xhEVVC5vu6GX7nu4t/8QRy3Jn0q7T5og81FGb1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -494,6 +497,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
       "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.27.3"
       },
@@ -531,6 +535,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.29.3.tgz",
       "integrity": "sha512-RpLYy2sb51oNLjuu1iD3bwBqCBWUzjO0ocp+iaCP/lJtb2CPLcnC2Fftw+4sAzaMELGeWTgExSKADbdo0GFVzA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-member-expression-to-functions": "^7.28.5",
@@ -552,6 +557,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "license": "ISC",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -570,6 +576,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.28.5.tgz",
       "integrity": "sha512-cwM7SBRZcPCLgl8a7cY0soT1SptSzAlMH39vwiRpOQkJlh53r5hdHwLSCZpQdVLT39sZt+CRpNwYG4Y2v77atg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.28.5",
         "@babel/types": "^7.28.5"
@@ -613,6 +620,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.27.1.tgz",
       "integrity": "sha512-URMGH08NzYFhubNSGJrpUEphGKQwMQYBySzat5cAByY1/YgIRkULnIy3tAMeszlL/so2HbeilYloUmSpd7GdVw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.27.1"
       },
@@ -634,6 +642,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
       "integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-member-expression-to-functions": "^7.28.5",
         "@babel/helper-optimise-call-expression": "^7.27.1",
@@ -651,6 +660,7 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.27.1.tgz",
       "integrity": "sha512-Tub4ZKEXqbPjXgWLl2+3JpQAYBJ8+ikpQ2Ocj/q/r0LwE3UhENh7EUabyHjz2kCEsrRY83ew2DQdHluuiDQFzg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/traverse": "^7.27.1",
         "@babel/types": "^7.27.1"
@@ -957,6 +967,7 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
       "integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.27.3",
         "@babel/helper-create-class-features-plugin": "^7.28.6",
@@ -1075,22 +1086,22 @@
       }
     },
     "node_modules/@bitrise/bitkit-v2": {
-      "version": "0.3.214",
-      "resolved": "https://registry.npmjs.org/@bitrise/bitkit-v2/-/bitkit-v2-0.3.214.tgz",
-      "integrity": "sha512-CO1STIrJ6x6HUbHrZQcPquZqTtsDcP1d0+C4PHy+pqPwXBkermWCzNfKEkjO1a142ehbO4HNQB3RTBaOcMbrsA==",
+      "version": "0.3.237",
+      "resolved": "https://registry.npmjs.org/@bitrise/bitkit-v2/-/bitkit-v2-0.3.237.tgz",
+      "integrity": "sha512-6YWgxL2+uPH3EnXhZvWFt4jSj5hKmWwPl70VS6PKf7RDQ9x8GsWajKoTmc+56T6eWCab6hKzzm44KqEWi5n2JA==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@chakra-ui/cli": "^3.35.0",
-        "@chakra-ui/react": "^3.35.0",
-        "@emotion/react": "^11.14.0",
-        "@emotion/styled": "^11.14.1",
         "@fontsource-variable/figtree": "^5.2.10",
         "@fontsource-variable/source-code-pro": "^5.2.7",
-        "es-toolkit": "^1.46.0",
+        "es-toolkit": "^1.46.1",
         "react-markdown": "^10.1.0"
       },
       "peerDependencies": {
+        "@chakra-ui/cli": "3.35.0",
+        "@chakra-ui/react": "3.35.0",
+        "@emotion/react": "11.14.0",
+        "@emotion/styled": "11.14.1",
         "react": ">=18",
         "react-dom": ">=18"
       }
@@ -1148,6 +1159,7 @@
       "resolved": "https://registry.npmjs.org/@chakra-ui/cli/-/cli-3.35.0.tgz",
       "integrity": "sha512-QZzMuLPKZJMdI6wgtTT3muDtTYXcqyT+pmB8fkS6pHSzRZ5bxiq+vI6F9qvAW2VpjvbhcsRXGW2VLgaAI6BfDw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.26.0",
         "@babel/parser": "^7.26.0",
@@ -1194,6 +1206,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1210,6 +1223,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1226,6 +1240,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1242,6 +1257,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1258,6 +1274,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1274,6 +1291,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1290,6 +1308,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1306,6 +1325,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1322,6 +1342,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1338,6 +1359,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1354,6 +1376,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1370,6 +1393,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1386,6 +1410,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1402,6 +1427,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1418,6 +1444,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1434,6 +1461,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1450,6 +1478,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1466,6 +1495,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1482,6 +1512,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1498,6 +1529,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1514,6 +1546,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1530,6 +1563,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1546,6 +1580,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1562,6 +1597,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1578,6 +1614,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1594,6 +1631,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1603,6 +1641,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -1618,6 +1657,7 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -1627,6 +1667,7 @@
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
       "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1640,6 +1681,7 @@
       "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1680,6 +1722,7 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -1698,6 +1741,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -1713,6 +1757,7 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -1726,6 +1771,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -1750,6 +1796,7 @@
       "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-3.35.0.tgz",
       "integrity": "sha512-qzfRNLwxKjxx2IXjBj6uz1nYI+pKsq6uwHxO619+hx1OzNNuwLIjEHJxnDfBzoynO7sPCBlubMwFWb1e1PrXzw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ark-ui/react": "5.36.2",
         "@emotion/is-prop-valid": "^1.4.0",
@@ -1821,6 +1868,7 @@
       "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.1.tgz",
       "integrity": "sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "picocolors": "^1.0.0",
         "sisteransi": "^1.0.5"
@@ -1831,6 +1879,7 @@
       "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.1.tgz",
       "integrity": "sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@clack/core": "1.0.1",
         "picocolors": "^1.0.0",
@@ -3880,6 +3929,7 @@
       "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.12.0.tgz",
       "integrity": "sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -3889,6 +3939,7 @@
       "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.6.5.tgz",
       "integrity": "sha512-6hY4Kl4HPBvtfS62asS/R22JzNNy8vi/Ssev7x6EobfCp+9QIB2hKvI2EtbdJ0VSQacxVNtqhE/NmF/NZ0gm6g==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/helpers": "^0.5.0"
       }
@@ -5496,7 +5547,8 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/@pandacss/is-valid-prop/-/is-valid-prop-1.10.0.tgz",
       "integrity": "sha512-OmEHkDj3BRkHYLxHwNFYJkcwF84c7PuHsWHmmmNLJnmk8z0RVlDQei4GxWjfW1bnvCihCwakJ8Xq6GDRlmcDiQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@pkgr/core": {
       "version": "0.2.9",
@@ -6108,6 +6160,7 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
       "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -6589,6 +6642,7 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
       "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -6918,7 +6972,8 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@types/cli-table/-/cli-table-0.3.4.tgz",
       "integrity": "sha512-GsALrTL69mlwbAw/MHF1IPTadSLZQnsxe7a80G8l4inN/iEXCOcVeT/S7aRc6hbhqzL9qZ314kHPDQnQ3ev+HA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
@@ -7839,6 +7894,7 @@
         "linux",
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=20.18 <=25.x"
       }
@@ -7990,6 +8046,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/accordion/-/accordion-1.40.0.tgz",
       "integrity": "sha512-YDdyvZJ6fr92RZazyXQq+juT3ZA0ubjDISptb5YPgMoTPdnjKNiICPpMeCeVj1ncYRDkHXrOdChS/5CtuX/K6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8003,6 +8060,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8011,13 +8069,15 @@
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/anatomy/-/anatomy-1.40.0.tgz",
       "integrity": "sha512-oiB4uAaV//L38JluLVPtOHO3xvqambrfrXVOoq4kmNrBv1LLlCmFvrXA2HOR9lakn4ExK27XSUrKhUN7YlKjfQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@zag-js/angle-slider": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/angle-slider/-/angle-slider-1.40.0.tgz",
       "integrity": "sha512-6X6bOBoCyYG0/lFY0Y+AXJZZG6CeYQiWkcMXvegxCC2zxthodqOVzkVOASW+6rzLjn2bru+V5O9RMjNgmCumKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8032,6 +8092,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8041,6 +8102,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/aria-hidden/-/aria-hidden-1.40.0.tgz",
       "integrity": "sha512-lNWujEIlfGKwMQIcgfXuOZSsJD2avrgPsQHrXNVF9mkXygjLFcIRKz2pEexTSCqFh/HuUZJ6rG4pM/hJ/BiVCw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -8050,6 +8112,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8059,6 +8122,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/async-list/-/async-list-1.40.0.tgz",
       "integrity": "sha512-hLGUTtwRFl6FIdYxSIYSeLQjJeG4isKpdmGCUvtWNnKr7ayf1yAkkSwX10SdBMWOCldbtvKCZXumKvP6dDwNvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/core": "1.40.0",
         "@zag-js/utils": "1.40.0"
@@ -8069,6 +8133,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/auto-resize/-/auto-resize-1.40.0.tgz",
       "integrity": "sha512-eZC+AGKUip7UMu41/ApeT1wCIgn2fmo63FJeGAdMMD8E9M8M7QLsfISMIoieNNGBAYWhSyqELQ3jPgkUf6xReA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -8078,6 +8143,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8087,6 +8153,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/avatar/-/avatar-1.40.0.tgz",
       "integrity": "sha512-DayZDsNXbipT+1GUkX29tVhO4hZonDnidwE3SjEQv9Ic9vCdnwP95+B0FPEuaca03F5ZXFqVXjnPmRVbRMyDYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8100,6 +8167,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8109,6 +8177,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/carousel/-/carousel-1.40.0.tgz",
       "integrity": "sha512-9svWc2jjvUP8iQ0afuu/ZAI75PuPLm4qB7h+10rmDrAgUPn7fwUBVzyATKubJPdtmaYQQvTTIiZU2B8mV88oGg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8123,6 +8192,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8132,6 +8202,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/cascade-select/-/cascade-select-1.40.0.tgz",
       "integrity": "sha512-0fkE0Fd2VQ4QsaWXHdgQxHWiaef3UWW0l6Jd47frtMNnrvg5t5Xfqowa7c2S23hcduOUfz2WC0xEuGXnO4UVDQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/collection": "1.40.0",
@@ -8150,6 +8221,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8159,6 +8231,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.40.0.tgz",
       "integrity": "sha512-63byl/kLVzDYlnHFma4HKEKrqB1Vx2zg0sBmUSENPyh+Ia1xhEVVC5vu6GX7nu4t/8QRy3Jn0q7T5og81FGb1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -8168,6 +8241,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/checkbox/-/checkbox-1.40.0.tgz",
       "integrity": "sha512-oFCgnkOjrUDejB1wEp5s3cyJ+uFe/GoI3+wqNyckqOtcdKL1MBxy193GYVdj0LDfuCNrk8V0aIJGTdusCD2b4A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8182,6 +8256,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8191,6 +8266,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.40.0.tgz",
       "integrity": "sha512-63byl/kLVzDYlnHFma4HKEKrqB1Vx2zg0sBmUSENPyh+Ia1xhEVVC5vu6GX7nu4t/8QRy3Jn0q7T5og81FGb1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -8200,6 +8276,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/clipboard/-/clipboard-1.40.0.tgz",
       "integrity": "sha512-QbFhJMwwUxTKcbWyb9ZrKgAp13U4+IzfHSLhPxbDVSQ15mIrjIkjW68gS6ElzhRDwGr1qawkZVApsqcToUqSaQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8213,6 +8290,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8222,6 +8300,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/collapsible/-/collapsible-1.40.0.tgz",
       "integrity": "sha512-xDLY4j9D3gdoTirkwzMaCtelfCjnMhBzPyY6c/mh4oPvD3RB6dr3V3kI80i3yxHaUUeDCIUm/XAxK0InPsRBug==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8235,6 +8314,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8244,6 +8324,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/collection/-/collection-1.40.0.tgz",
       "integrity": "sha512-+3o1nvbcA9Kz2hDDFf8Kngpd+of33S4TS5Tb9KvrHlU5ieQdvEUtc7/pWG2aCTkGpmgda+j91akB6ZB8+oVkvA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/utils": "1.40.0"
       }
@@ -8253,6 +8334,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/color-picker/-/color-picker-1.40.0.tgz",
       "integrity": "sha512-lT93xd1BlNBbitl2RxST8ARYE6q/HZD5a0QhMIT1RbndB8F4e9j/NxkStgE9f0QqgpC/rO+nKHLoR+H1xs/EkA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/color-utils": "1.40.0",
@@ -8269,6 +8351,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8278,6 +8361,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/color-utils/-/color-utils-1.40.0.tgz",
       "integrity": "sha512-PZihcGheb5bn0/cEUwozjJjPoKkEwlJNpTA5mUxj/+sOElLaZM+zY2AnGYeMl6w5zIyZZUDoJMIT5rcb5sN87g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/utils": "1.40.0"
       }
@@ -8287,6 +8371,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/combobox/-/combobox-1.40.0.tgz",
       "integrity": "sha512-5IVCDrB8m7XrKBu28j7bIRE5KiyKJLPDZB3AJ+PLJyL69D+9z1anhLDmkUYcPseyCasszLKzIejby+kYQJgHlA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/collection": "1.40.0",
@@ -8305,6 +8390,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8314,6 +8400,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.40.0.tgz",
       "integrity": "sha512-63byl/kLVzDYlnHFma4HKEKrqB1Vx2zg0sBmUSENPyh+Ia1xhEVVC5vu6GX7nu4t/8QRy3Jn0q7T5og81FGb1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -8323,6 +8410,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/core/-/core-1.40.0.tgz",
       "integrity": "sha512-0YcqCh7TmhSonkbKM/7NWolxlaQgvvXgqedocW9oeRYiDJIpBZyRqnHPoGAS2XwbBPkCnrqSosxSF5yBjhZpgw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0",
         "@zag-js/utils": "1.40.0"
@@ -8333,6 +8421,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8342,6 +8431,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/date-input/-/date-input-1.40.0.tgz",
       "integrity": "sha512-/VU8g3dugggC5xW2OJW1KONWzPkEbK/yLA0lPxymW/Uo0ixh2mKJUVTOTqDFWf1b0vzLX2XlYoLL+I2ryUyPvA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8360,6 +8450,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8369,6 +8460,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/date-picker/-/date-picker-1.40.0.tgz",
       "integrity": "sha512-Nm3aSKn/5tGOZk8rIddLyBk+oeE0zr/ZsJuuTc3rysd04owVy1UhmUh6X9CqfTJtwTDpUZe+orHaIvKlE3Rd0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8389,6 +8481,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8398,6 +8491,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/date-utils/-/date-utils-1.40.0.tgz",
       "integrity": "sha512-nuB1QM3X7yY0k2JiZbHHm6wigY+Cl1QK6sRlh+C7mOyzEKnNEqNSVIqgSionCtWO6zAZh1R8Znp5ZeCdbbc27w==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@internationalized/date": ">=3.0.0"
       }
@@ -8407,6 +8501,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dialog/-/dialog-1.40.0.tgz",
       "integrity": "sha512-1FHxR7/Kuu+9K2dxH7dKlSckCZ26n5ec79qWr0aMSSs2DF+ypQf5GUlaS6z2UqroZvIoJCvABVMm9OMko/qxlA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/aria-hidden": "1.40.0",
@@ -8424,6 +8519,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8433,6 +8529,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dismissable/-/dismissable-1.40.0.tgz",
       "integrity": "sha512-bBkFvPg/zbYn31ZgEfx8not6s2Ekx7zU2sO8tGXb8rYPnHBfGDYEzVQansUStJn0Atzw+y7XR7B3G3u5AFQJKw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0",
         "@zag-js/interact-outside": "1.40.0",
@@ -8444,6 +8541,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8459,6 +8557,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/drawer/-/drawer-1.40.0.tgz",
       "integrity": "sha512-N2OR5ZYuTsWkYYmwsNgmL+wfuM3qUxB8GAfo53AWvOh07QUVz1Dvh1WP4km5L6Tkz4UBQZACu8T/ZLyeZ+PdWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/aria-hidden": "1.40.0",
@@ -8476,6 +8575,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8485,6 +8585,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/editable/-/editable-1.40.0.tgz",
       "integrity": "sha512-X23wOg42BPvFWfJQi3yd8HiL8xtisrpL5ouFEzba56SQIxWZHDRpeWoqXqyLODq2/z2+SsZ0wV3laRD3ZH0C2g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8499,6 +8600,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8514,6 +8616,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/file-upload/-/file-upload-1.40.0.tgz",
       "integrity": "sha512-hUZlJYjSGk7SAflTmQIjZv6M+icujaHS6I+dik2LM48rLWwNa/GYTNx+uY4zJLd9oW1eEj+6NcCYZpPWzKku4Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8529,6 +8632,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8538,6 +8642,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/file-utils/-/file-utils-1.40.0.tgz",
       "integrity": "sha512-BGny4rafiBQ5TPCBXfzbH7lSyFdnoix7brq/+FllKpDqpWPQz0tIsgSZueF/Z8GPTrAkwMKOFI99P7OVhAhRig==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/i18n-utils": "1.40.0"
       }
@@ -8547,6 +8652,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/floating-panel/-/floating-panel-1.40.0.tgz",
       "integrity": "sha512-e2QXwapCbjLJnU+MAz06CoByj4XJ3sdSBgWF+PSe2X2T8dd/FkZUnaDPaX0yyfyTWKzBbyRRNyon2LMAs8ndHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8563,6 +8669,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8572,6 +8679,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/focus-trap/-/focus-trap-1.40.0.tgz",
       "integrity": "sha512-Q6W+DU7pix5rtRwoDnYzTYMkUV2kMWrFV0/EdNN3spFSvnUSkDWRmcNpzf+56AuCNeqsAZxaLJpsHLZkcT2xrw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -8581,6 +8689,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8598,13 +8707,15 @@
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/highlight-word/-/highlight-word-1.40.0.tgz",
       "integrity": "sha512-+aeVn3S5NPG6Tk4Sanl0VZk/0atjnF7Xy7POPs1HD5SBui29/6i3vn3bUBNXJXrnhUoNrUhuySVYVhgkffcQ7w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@zag-js/hover-card": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/hover-card/-/hover-card-1.40.0.tgz",
       "integrity": "sha512-lkuLaikPLBIOnR0X75kSXdDYgv3ritAsn4TF1eGs12iYnZVX4PTL3J39tVNm9QrEXZ+iKcA1D2cUXNhEteCTyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8620,6 +8731,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8629,6 +8741,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/i18n-utils/-/i18n-utils-1.40.0.tgz",
       "integrity": "sha512-8D3ki9V81gMKZvtRfNVoHCBDVYjr+WJLBvdfSv3cdOsVM2/E8//xAfYbYzl5Fdmeny3H71fxBNqOX05GN4K6OA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -8638,6 +8751,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8647,6 +8761,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/image-cropper/-/image-cropper-1.40.0.tgz",
       "integrity": "sha512-bpTCaiUXM0Mh6ddoJ1fA1B/YXp5Fc8LA0hg8CuEByDwGRVKPJ0KotL6QXMF6cEJZ1fcHF3Lcmpbj5Xotfkr4mA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8660,6 +8775,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8669,6 +8785,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/interact-outside/-/interact-outside-1.40.0.tgz",
       "integrity": "sha512-Fws+O4uD9vS0I5KVcf3U2tNjLKvqlv+RExFbTywckDLOCJ145M/pMQWTr1FHil04jk5PFyM1iGfsbom8tozHpQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0",
         "@zag-js/utils": "1.40.0"
@@ -8679,6 +8796,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8687,13 +8805,15 @@
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/json-tree-utils/-/json-tree-utils-1.40.0.tgz",
       "integrity": "sha512-7zEzU59Gz76nV7n3l70uMB5yAOOQMmt1PTAni6S97uw7/6KzPktsEWBcw7ocC4IIA42PKdT7akpq721H0vthbA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@zag-js/listbox": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/listbox/-/listbox-1.40.0.tgz",
       "integrity": "sha512-zB33y+dk6/e0ZTs3wun2KsuPaH/wygOuD8scnH2a2Y/W9a2P1rq503Kgm5d5kVXBKQLxOBwievWJ8Blajv8LnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/collection": "1.40.0",
@@ -8709,6 +8829,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8718,6 +8839,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.40.0.tgz",
       "integrity": "sha512-63byl/kLVzDYlnHFma4HKEKrqB1Vx2zg0sBmUSENPyh+Ia1xhEVVC5vu6GX7nu4t/8QRy3Jn0q7T5og81FGb1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -8726,13 +8848,15 @@
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/live-region/-/live-region-1.40.0.tgz",
       "integrity": "sha512-i1Dx02KGcQOAZGNhkFe8kz26gYJcn7KsT/M1UovjS9RTbl9diY8ShiyfIAhqruoaHQyqsHMRh/f7Idu45HdiDA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@zag-js/marquee": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/marquee/-/marquee-1.40.0.tgz",
       "integrity": "sha512-XfvAwSNYXV3fEIRc44a9sAsoJoLKt+CWbpSPgQBpiFPpWh0rZ8frUZCslevTzBB3ifIWoSg+svDHQOGsDa8wGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8746,6 +8870,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8755,6 +8880,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/menu/-/menu-1.40.0.tgz",
       "integrity": "sha512-FRBqwsOjxBi0eSwqwrOw2td1rd0Xxl0f41J2lGc8E7z+2PabbBcJ/poqSiEn8YoaCT4mAWNjt4QQU/Pe1bRJ/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8772,6 +8898,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8781,6 +8908,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.40.0.tgz",
       "integrity": "sha512-63byl/kLVzDYlnHFma4HKEKrqB1Vx2zg0sBmUSENPyh+Ia1xhEVVC5vu6GX7nu4t/8QRy3Jn0q7T5og81FGb1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -8790,6 +8918,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/navigation-menu/-/navigation-menu-1.40.0.tgz",
       "integrity": "sha512-aJkEGYH8P9NfsQOjxMzxuF4YrrV2N1GQj6Y5Ow19MKuLh42o35bUhwoGsYjFbxgEcImabINtZJqtAPAkOdJXmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8804,6 +8933,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8813,6 +8943,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/number-input/-/number-input-1.40.0.tgz",
       "integrity": "sha512-WffdeqSOpsKmgPzBkNZl9nAolQPlyl9dIabaPguGgXdYtZW/OGCGj8jCYqyEu4VL3kDPPVVQRWEqC/XzwzVCRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@internationalized/number": "3.6.5",
         "@zag-js/anatomy": "1.40.0",
@@ -8827,6 +8958,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8836,6 +8968,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/pagination/-/pagination-1.40.0.tgz",
       "integrity": "sha512-Ykotky0A/7rswb6BfOD9aXL1EssKwUYfBRbdWGe52uhVc7dGagMSTUDRVeNhVsP/MEdtwqys7urvDbAlEqq+GA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8849,6 +8982,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8858,6 +8992,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/password-input/-/password-input-1.40.0.tgz",
       "integrity": "sha512-mD4tbA4m82oV+0NbJ+P00Q4Gwz+zf1kZEZ3Z48ohICfK/WO1KhCgviY7vu/7bCMnRiD3dbi+nEeym8Kb29wRHw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8871,6 +9006,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8880,6 +9016,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/pin-input/-/pin-input-1.40.0.tgz",
       "integrity": "sha512-iJIXDJC+9DUx+A3sRdTmHV7vPZXCw9O6le3R0lKf/8kQOgj7FKjbVw2SkUMAoOZ0u5J7Zwg2oZc7ddt1pwUk9w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8893,6 +9030,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8902,6 +9040,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/popover/-/popover-1.40.0.tgz",
       "integrity": "sha512-bjvOep1YNlsvIYGh/rPsFCHjH2cCt2aKsVLyRvzTT1jhGZJvBdQKQBJjSuG5Nh4y1PUqtrrz69ZMWRrJGQ3rNg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/aria-hidden": "1.40.0",
@@ -8920,6 +9059,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8929,6 +9069,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/popper/-/popper-1.40.0.tgz",
       "integrity": "sha512-rCkgqgwlpgMwcnuSVrZK2xXl1Mvptpuw3cZy6rC2C5F3yE1GmWohdts5VkeQNro+sd/xHTdVovOqY6cU9Htj1w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.7.6",
         "@zag-js/dom-query": "1.40.0",
@@ -8940,6 +9081,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8949,6 +9091,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/presence/-/presence-1.40.0.tgz",
       "integrity": "sha512-P0bAuzEIDuMglE1xfmW5xTuSBlWjNZ8nOGXoIksKOKb+b+jy2Vys6WjZjKipV/jop4u85wfzKchcPc3C+cXuog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/core": "1.40.0",
         "@zag-js/dom-query": "1.40.0",
@@ -8960,6 +9103,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8969,6 +9113,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/progress/-/progress-1.40.0.tgz",
       "integrity": "sha512-V61a5CHEs8suevQVS+/1ENj1RDVYNOUUTawK6uriCA6Ol59xe30DmF+eV6Y9miM7L/pN3YjZRq9uEDJMXXK32g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -8982,6 +9127,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -8991,6 +9137,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/qr-code/-/qr-code-1.40.0.tgz",
       "integrity": "sha512-xD37tVrQ46CeqVLqkSm61kURoJ4Z/uOFcB8z7Hu3UX+1OFTfkhgrns6iLUneoRjO3hsqQaTaVkxVOQeLYWb+wA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9006,6 +9153,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9015,6 +9163,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/radio-group/-/radio-group-1.40.0.tgz",
       "integrity": "sha512-sFJCdyOKzQC9hylSP19R71yv44by/C78D9EHfsxQJtvOgDv9E+h13NNX4n9wWyubC20xftlxkja8sNT5NfJKUw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9029,6 +9178,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9038,6 +9188,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.40.0.tgz",
       "integrity": "sha512-63byl/kLVzDYlnHFma4HKEKrqB1Vx2zg0sBmUSENPyh+Ia1xhEVVC5vu6GX7nu4t/8QRy3Jn0q7T5og81FGb1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -9047,6 +9198,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/rating-group/-/rating-group-1.40.0.tgz",
       "integrity": "sha512-UMBI3xAMcm7otpAczMGPEA7jC1hvV8NhnZ4mN3oftJB0bc1winoXxJdCkrXN58TTNWrGNSRzjtm048G+HPCdpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9060,6 +9212,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9069,6 +9222,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/react/-/react-1.40.0.tgz",
       "integrity": "sha512-2TFS1HYABYGc0lurC+4WEXvKkpxsVv6vKm+t8QAL7wfoeZnw6HDQWLc91kINp89vln+A2kwCfYqIq8HSm+9EeA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/core": "1.40.0",
         "@zag-js/store": "1.40.0",
@@ -9084,13 +9238,15 @@
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/rect-utils/-/rect-utils-1.40.0.tgz",
       "integrity": "sha512-ikgLuE4rLlACm4mGLp6Ga8sJA44uFwohA1nVmb95sQ+VIyx2naf91CEF7SMrZVEwFKHaHpxdKVQSZLRjJqO/dw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@zag-js/remove-scroll": {
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/remove-scroll/-/remove-scroll-1.40.0.tgz",
       "integrity": "sha512-f6EgODnJMRtkbgdJCgyllND8jui+RtPrCZy6JYhhOg7KQ+bFfV36KzWQMty38ZdOyrh23UUO7MJ3WGcFXPvk3g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -9100,6 +9256,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9109,6 +9266,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/scroll-area/-/scroll-area-1.40.0.tgz",
       "integrity": "sha512-7EtWETRIn8dY7xqAeMOlnEuzhOrtc65mN/0YvT3XYcBz/CzmHzyZTmos3UXBJGnKHSGj61aEpP9g3RK+x/w63A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9122,6 +9280,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9131,6 +9290,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/scroll-snap/-/scroll-snap-1.40.0.tgz",
       "integrity": "sha512-XtjeOd+pwGX0+K7NvsQncrKwV8CTSzHfVVJrdQ+MweiWBpGNeAh43ySN4L+KSTgtnUiZbuwBIxlKK0tX+WupgQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -9140,6 +9300,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9149,6 +9310,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/select/-/select-1.40.0.tgz",
       "integrity": "sha512-auMI9SvocVvKHNWF2DobyQN6+1k3OO6UsQTdkofvbHxX7maosy8ZXA6k1r9Ndt4qLUu7CbdAAQ+qJ4VkgJyvxA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/collection": "1.40.0",
@@ -9166,6 +9328,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9175,6 +9338,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.40.0.tgz",
       "integrity": "sha512-63byl/kLVzDYlnHFma4HKEKrqB1Vx2zg0sBmUSENPyh+Ia1xhEVVC5vu6GX7nu4t/8QRy3Jn0q7T5og81FGb1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -9184,6 +9348,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/signature-pad/-/signature-pad-1.40.0.tgz",
       "integrity": "sha512-L0LTxcpdckaGdDDXcQCr4AG+J9xUHH+lsenH7NG4ZI7rSr4nRmHMdDH0GR7nBa6MMdPIIimjWIE/TwZ1OuHzCQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9198,6 +9363,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9207,6 +9373,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/slider/-/slider-1.40.0.tgz",
       "integrity": "sha512-xZGycm+ghGFG3kTYq8g0t1Av1moxg45WiFz5E3bRgP7YU9beSTaFZI8h6f65NiC5P3YuwA0RoYxA46GH22qoZg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9220,6 +9387,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9229,6 +9397,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/splitter/-/splitter-1.40.0.tgz",
       "integrity": "sha512-64KNKwlIjyUIjp7i/whDCpREiSFrNI/cF7MpBJvBGRPUWq8NpNxMGKWD+vBCV+JC61QF9xg/NgNoigFycS9sYw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9242,6 +9411,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9251,6 +9421,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/steps/-/steps-1.40.0.tgz",
       "integrity": "sha512-5sVFzcIYubCn1nJSQIx9WWNlJuFoOJMpkD/ZMwNp0LzpnmnspsCOmdnQUWEftMQ1KdwZ+qNgfo/+kHclb9cBjg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9264,6 +9435,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9273,6 +9445,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/store/-/store-1.40.0.tgz",
       "integrity": "sha512-EmgYIdbNZ4TN4Qht/jugY4UVkaWx69l8P1qiX23U4YwqNLq10tyOJmcXWbvsrprU1dGb24B+xq0WBm/RIjw4WA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "proxy-compare": "3.0.1"
       }
@@ -9282,6 +9455,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/switch/-/switch-1.40.0.tgz",
       "integrity": "sha512-hUH3AF79ndSFZxt7Plw7mVZV0QlM0kFqKwrAGBEOE77P3rKpOsMJ3wWgMb3w6nwlxGQsbwmMgAFvYUslLpM4Lg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9296,6 +9470,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9305,6 +9480,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.40.0.tgz",
       "integrity": "sha512-63byl/kLVzDYlnHFma4HKEKrqB1Vx2zg0sBmUSENPyh+Ia1xhEVVC5vu6GX7nu4t/8QRy3Jn0q7T5og81FGb1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -9314,6 +9490,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/tabs/-/tabs-1.40.0.tgz",
       "integrity": "sha512-xqfPC2nQ6Bn4nqy1L+1CVcQcg/Z7K2q753OvsX2C8Wtu+7tF//HyMbOpF6fGikqlLkUzCkvjkqDjdOXcfWN9ZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9327,6 +9504,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9336,6 +9514,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/tags-input/-/tags-input-1.40.0.tgz",
       "integrity": "sha512-3cB7nPlUvzZNZwQw5AaTuxwcRn1n2qkDCjLEb2NEwtmI+YxHbK3k1MtXjTccjcYjU8cAkv+jaeyZPs6KFKQcHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/auto-resize": "1.40.0",
@@ -9352,6 +9531,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9361,6 +9541,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/timer/-/timer-1.40.0.tgz",
       "integrity": "sha512-Rvet226fhUtZnItjHpUYV7MH0uEFZfXT9PSRrX5jdiU4/P0eWKbirwi//AVeqcWFexXvw6ajYSfQN7EVyr2x4w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9374,6 +9555,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9383,6 +9565,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/toast/-/toast-1.40.0.tgz",
       "integrity": "sha512-EDH43zdiH4Bz30cE6YI9g//qXGOOfWObM3dFLG8I0q/cJRf7/6jO82rwZAHPwfOSfKhUDxStirD8F6eoY6BWXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9397,6 +9580,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9406,6 +9590,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/toggle/-/toggle-1.40.0.tgz",
       "integrity": "sha512-DW7682lzTP2eDlMvrS7tUX3zAm7ufrrKr7VDiX8BB6oXBRETXrVIxCYNuoIdqjwXebdjAoxaCiUZEreRVucYQg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9419,6 +9604,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/toggle-group/-/toggle-group-1.40.0.tgz",
       "integrity": "sha512-+JKcnfEbdQnr5p7uRvYLdivhUsM6iio71UC10tK74nXYRnYm0/Uvxg3oQzvbNTq9WdcU/DIh3gZVZ2Vex9nBnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9432,6 +9618,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9441,6 +9628,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9450,6 +9638,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/tooltip/-/tooltip-1.40.0.tgz",
       "integrity": "sha512-pyrvit+nB8dIwVNTGBRlHPsh7yMJGAxxM1zfY7HOTJqF+n6+6xYTQ4gQ/Ocy1Q7I5kO88+m16naEh0qLFiTZww==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9465,6 +9654,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9474,6 +9664,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/focus-visible/-/focus-visible-1.40.0.tgz",
       "integrity": "sha512-63byl/kLVzDYlnHFma4HKEKrqB1Vx2zg0sBmUSENPyh+Ia1xhEVVC5vu6GX7nu4t/8QRy3Jn0q7T5og81FGb1A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/dom-query": "1.40.0"
       }
@@ -9483,6 +9674,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/tour/-/tour-1.40.0.tgz",
       "integrity": "sha512-VczYGFQM9xsSbfy5N0NP91GdKxbYvfPCDAguD+WQSs1umEIgAAozSKPUdV3NNCX5Pq6B1F3dBxi6gYPdNqrAHg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/core": "1.40.0",
@@ -9500,6 +9692,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9509,6 +9702,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/tree-view/-/tree-view-1.40.0.tgz",
       "integrity": "sha512-v/20ekjbM+HXDEkpHAz6k8WpoZRmZmdCApDIkIgXVHPRQk+kwAiiIPY20ZDG+DjRu7Lh0MUdQavdZtGj6Ihwkw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/anatomy": "1.40.0",
         "@zag-js/collection": "1.40.0",
@@ -9523,6 +9717,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/dom-query/-/dom-query-1.40.0.tgz",
       "integrity": "sha512-4J3EO2gHpZ1VZiGLuMlH6G1Tsp4gKB8PPt2yKeNQWYGEXyrHUXrvMhRUzv7Z4/2I1s1tnxlFG4F8ovB3kTpz/Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@zag-js/types": "1.40.0"
       }
@@ -9532,6 +9727,7 @@
       "resolved": "https://registry.npmjs.org/@zag-js/types/-/types-1.40.0.tgz",
       "integrity": "sha512-LVvxEyqFv/u9SEe5xdivvG2vYb9cCmbkD+5r6s+IGljpDLaRgv4BYyxEh40ri1ai070tL08ZKmoLfx2/xfvY/A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "3.2.3"
       }
@@ -9540,7 +9736,8 @@
       "version": "1.40.0",
       "resolved": "https://registry.npmjs.org/@zag-js/utils/-/utils-1.40.0.tgz",
       "integrity": "sha512-XUpqDtXfHe7CySjOhLPLj9H8rxbiFUJAGgmBzNdpsGPP4wx12cpOXrpSjRXZ2kMwooMPz/P7RPDBteto8sqhAQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -10971,6 +11168,7 @@
       "version": "0.3.11",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.11.tgz",
       "integrity": "sha512-IqLQi4lO0nIB4tcdTpN4LCB9FI3uqrJZK7RC515EnhZ6qBaglkIgICb1wjeAqpdoOabm1+SuQtkXIPdYC93jhQ==",
+      "peer": true,
       "dependencies": {
         "colors": "1.0.3"
       },
@@ -11264,6 +11462,7 @@
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
       "integrity": "sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -11729,6 +11928,7 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -13562,6 +13762,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -13575,6 +13776,7 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -13756,6 +13958,7 @@
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -14159,6 +14362,7 @@
       "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.1.tgz",
       "integrity": "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sindresorhus/merge-streams": "^4.0.0",
         "fast-glob": "^3.3.3",
@@ -14179,6 +14383,7 @@
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
       "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -14191,6 +14396,7 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
       "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=14.16"
       },
@@ -17975,7 +18181,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/look-it-up/-/look-it-up-2.1.0.tgz",
       "integrity": "sha512-nMoGWW2HurtuJf6XAL56FWTDCWLOTSsanrgwOyaR5Y4e3zfG5N/0cU5xWZSEU3tBxhQugRbV1xL9jb+ug7yZww==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/loose-envify": {
       "version": "1.4.0",
@@ -19707,7 +19914,8 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -19899,7 +20107,8 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/perfect-freehand/-/perfect-freehand-1.2.3.tgz",
       "integrity": "sha512-bHZSfqDHGNlPpgH2yxXgPHlQSPpEbo+qg7li0M78J9vNAi2yjwLeA4x79BEQhX44lEWpCLSFCeRZwpw0niiXPA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -20224,13 +20433,15 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/proxy-compare/-/proxy-compare-3.0.1.tgz",
       "integrity": "sha512-V9plBAt3qjMlS1+nC8771KNf6oJ12gExvaxnNzN/9yVRLdTv/lc+oJlnSzrdYDAvBfTStPCoiaCOTmTs0adv7Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/proxy-memoize": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/proxy-memoize/-/proxy-memoize-3.0.1.tgz",
       "integrity": "sha512-VDdG/VYtOgdGkWJx7y0o7p+zArSf2383Isci8C+BP3YXgMYDoPd3cCBjw0JdWb6YBb9sFiOPbAADDVTPJnh+9g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "proxy-compare": "^3.0.0"
       }
@@ -21200,7 +21411,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
       "integrity": "sha512-6FtHJEvt+pVMIB9IBY+IcCJ6Z5f1iQnytgyfKMhDKgmzYG+TeH/wx1y3l27rshSbLiSanrR9ffZDrEsmjlQF2g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/search-insights": {
       "version": "2.17.3",
@@ -22514,6 +22726,7 @@
       "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
       "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "tsconfck": "bin/tsconfck.js"
       },
@@ -22757,6 +22970,7 @@
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
       "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20"
       },
@@ -23014,7 +23228,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/uqr/-/uqr-0.1.2.tgz",
       "integrity": "sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/uri-js": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@bitrise/bitkit": "^13.356.0",
-    "@bitrise/bitkit-v2": "^0.3.214",
+    "@bitrise/bitkit-v2": "^0.3.237",
     "@bitrise/languageserver": "git+https://github.com/bitrise-io/bitrise-yml-language-server.git#833b15995769404349b63986ea779b60fccce531",
     "@dagrejs/dagre": "^3.0.0",
     "@datadog/browser-rum": "^6.33.0",

--- a/source/javascripts/components/Header.tsx
+++ b/source/javascripts/components/Header.tsx
@@ -8,7 +8,7 @@ import {
   useResponsive,
   useToast,
 } from '@bitrise/bitkit';
-import { BitkitSegmentedControl } from '@bitrise/bitkit-v2';
+import { BitkitSegmentedControl, IconCode, IconWebUi } from '@bitrise/bitkit-v2';
 import { useCallback, useRef, useState } from 'react';
 import { useEventListener } from 'usehooks-ts';
 
@@ -293,8 +293,12 @@ const Header = () => {
         value={editorView}
         onValueChange={(details) => handleEditorViewChange(details.value)}
       >
-        <BitkitSegmentedControl.Item value="visual">Visual</BitkitSegmentedControl.Item>
-        <BitkitSegmentedControl.Item value="yaml">YAML</BitkitSegmentedControl.Item>
+        <BitkitSegmentedControl.Item icon={IconWebUi} value="visual">
+          Visual
+        </BitkitSegmentedControl.Item>
+        <BitkitSegmentedControl.Item icon={IconCode} value="yaml">
+          YAML
+        </BitkitSegmentedControl.Item>
       </BitkitSegmentedControl>
 
       <Box

--- a/source/javascripts/components/Header.tsx
+++ b/source/javascripts/components/Header.tsx
@@ -68,10 +68,10 @@ const Header = () => {
   const editorView = isYmlPage ? 'yaml' : 'visual';
 
   // Remember the last visual page so switching back from YAML returns to it.
-  const lastVisualPathRef = useRef<string>(paths.workflows);
+  const lastVisualPathnameRef = useRef<string>(paths.workflows);
   useEffect(() => {
     if (!isYmlPage) {
-      lastVisualPathRef.current = path;
+      lastVisualPathnameRef.current = path.split('?')[0];
     }
   }, [isYmlPage, path]);
 
@@ -95,7 +95,10 @@ const Header = () => {
           return;
         }
 
-        navigate(lastVisualPathRef.current);
+        const searchParamsString = new URLSearchParams(searchParams).toString();
+        navigate(
+          searchParamsString ? `${lastVisualPathnameRef.current}?${searchParamsString}` : lastVisualPathnameRef.current,
+        );
       }
     },
     [searchParams, navigate, ymlStatus, toast],
@@ -293,6 +296,7 @@ const Header = () => {
       <BitkitSegmentedControl
         size="sm"
         value={editorView}
+        aria-label="Editor view"
         onValueChange={(details) => handleEditorViewChange(details.value)}
       >
         <BitkitSegmentedControl.Item icon={IconWebUi} value="visual">

--- a/source/javascripts/components/Header.tsx
+++ b/source/javascripts/components/Header.tsx
@@ -8,7 +8,8 @@ import {
   useResponsive,
   useToast,
 } from '@bitrise/bitkit';
-import { useCallback, useState } from 'react';
+import { BitkitSegmentedControl } from '@bitrise/bitkit-v2';
+import { useCallback, useRef, useState } from 'react';
 import { useEventListener } from 'usehooks-ts';
 
 import {
@@ -32,12 +33,15 @@ import { useCiConfigSettings } from '@/hooks/useCiConfigSettings';
 import { closeAIDrawer } from '@/hooks/useCloseAIDrawer';
 import useCurrentPage from '@/hooks/useCurrentPage';
 import useFeatureFlag from '@/hooks/useFeatureFlag';
+import useHashLocation from '@/hooks/useHashLocation';
 import usePushBranch, { PushBranchPayload } from '@/hooks/usePushBranch';
+import useSearchParams from '@/hooks/useSearchParams';
 import useYmlHasChanges from '@/hooks/useYmlHasChanges';
 import useYmlValidationStatus from '@/hooks/useYmlValidationStatus';
 import { usePipelinesPageStore } from '@/pages/PipelinesPage/PipelinesPage.store';
 import { useStepBundlesPageStore } from '@/pages/StepBundlesPage/StepBundlesPage.store';
 import { useWorkflowsPageStore } from '@/pages/WorkflowsPage/WorkflowsPage.store';
+import { paths } from '@/routes';
 
 import ConfigMergeDialog from './ConfigMergeDialog/ConfigMergeDialog';
 import DiffEditorDialog from './DiffEditor/DiffEditorDialog';
@@ -56,6 +60,44 @@ const Header = () => {
   const currentPage = useCurrentPage();
   const hasChanges = useYmlHasChanges();
   const ymlStatus = useYmlValidationStatus();
+
+  const [path, navigate] = useHashLocation();
+  const [searchParams] = useSearchParams();
+
+  const isYmlPage = currentPage === 'yml';
+  const editorView = isYmlPage ? 'yaml' : 'visual';
+
+  // Remember the last visual page so switching back from YAML returns to it.
+  const lastVisualPathRef = useRef<string>(paths.workflows);
+  if (!isYmlPage) {
+    lastVisualPathRef.current = path;
+  }
+
+  const handleEditorViewChange = useCallback(
+    (value: string | null) => {
+      if (value === 'yaml') {
+        const searchParamsString = new URLSearchParams(searchParams).toString();
+        navigate(searchParamsString ? `${paths.yml}?${searchParamsString}` : paths.yml);
+        return;
+      }
+
+      if (value === 'visual') {
+        if (ymlStatus === 'invalid') {
+          toast({
+            status: 'error',
+            title: 'Invalid YAML',
+            description: 'Please fix the errors in your YAML configuration before navigating.',
+            duration: null,
+            isClosable: true,
+          });
+          return;
+        }
+
+        navigate(lastVisualPathRef.current);
+      }
+    },
+    [searchParams, navigate, ymlStatus, toast],
+  );
 
   const conversationId = useCiConfigExpertStore((s) => s.conversationId);
   const turnIndex = useCiConfigExpertStore((s) => s.turnIndex);
@@ -245,6 +287,15 @@ const Header = () => {
         {isWebsiteMode && appPath && appName && <BreadcrumbLink href={appPath}>{appName}</BreadcrumbLink>}
         {(!isWebsiteMode || !isMobile) && <BreadcrumbLink isCurrentPage>Workflow Editor</BreadcrumbLink>}
       </Breadcrumb>
+
+      <BitkitSegmentedControl
+        size="sm"
+        value={editorView}
+        onValueChange={(details) => handleEditorViewChange(details.value)}
+      >
+        <BitkitSegmentedControl.Item value="visual">Visual</BitkitSegmentedControl.Item>
+        <BitkitSegmentedControl.Item value="yaml">YAML</BitkitSegmentedControl.Item>
+      </BitkitSegmentedControl>
 
       <Box
         gap="8"

--- a/source/javascripts/components/Header.tsx
+++ b/source/javascripts/components/Header.tsx
@@ -9,7 +9,7 @@ import {
   useToast,
 } from '@bitrise/bitkit';
 import { BitkitSegmentedControl, IconCode, IconWebUi } from '@bitrise/bitkit-v2';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useEventListener } from 'usehooks-ts';
 
 import {
@@ -69,9 +69,11 @@ const Header = () => {
 
   // Remember the last visual page so switching back from YAML returns to it.
   const lastVisualPathRef = useRef<string>(paths.workflows);
-  if (!isYmlPage) {
-    lastVisualPathRef.current = path;
-  }
+  useEffect(() => {
+    if (!isYmlPage) {
+      lastVisualPathRef.current = path;
+    }
+  }, [isYmlPage, path]);
 
   const handleEditorViewChange = useCallback(
     (value: string | null) => {

--- a/source/javascripts/components/Navigation.stories.tsx
+++ b/source/javascripts/components/Navigation.stories.tsx
@@ -18,7 +18,7 @@ export default {
   decorators: [
     (Story) => (
       <>
-        <ConfigSettingsBar />
+        <ConfigSettingsBar borderRight="1px solid" borderRightColor="border/minimal" />
         <Story />
       </>
     ),

--- a/source/javascripts/components/Navigation.stories.tsx
+++ b/source/javascripts/components/Navigation.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { set } from 'es-toolkit/compat';
 import { delay, http, HttpResponse } from 'msw';
 
+import ConfigSettingsBar from '@/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar';
 import {
   getBranches,
   getBranchesError,
@@ -14,6 +15,14 @@ import Navigation from './Navigation';
 
 export default {
   component: Navigation,
+  decorators: [
+    (Story) => (
+      <>
+        <ConfigSettingsBar />
+        <Story />
+      </>
+    ),
+  ],
   beforeEach: () => {
     set(window, 'parent.globalProps.featureFlags.account.enable-branch-switching', true);
   },

--- a/source/javascripts/components/Navigation.tsx
+++ b/source/javascripts/components/Navigation.tsx
@@ -1,7 +1,6 @@
 import {
   Sidebar,
   SidebarContainer,
-  SidebarDivider,
   SidebarFooter,
   SidebarItem,
   SidebarItemIcon,
@@ -189,14 +188,6 @@ const Navigation = (props: Props) => {
             Licenses
           </NavigationItem>
         )}
-        <SidebarDivider />
-        <NavigationItem
-          path={withSearchParams(paths.yml)}
-          icon="Code"
-          intercomTarget="Configuration YAML Page Navigation Item"
-        >
-          Configuration YAML
-        </NavigationItem>
       </SidebarContainer>
       <SidebarFooter>
         <SidebarItem

--- a/source/javascripts/components/Navigation.tsx
+++ b/source/javascripts/components/Navigation.tsx
@@ -118,7 +118,7 @@ const Navigation = (props: Props) => {
   }, [currentPage, data?.usesRepositoryYml]);
 
   return (
-    <Sidebar minW={['88px', '256px']} {...props}>
+    <Sidebar width={['88px', '256px']} flexShrink={0} {...props}>
       {RuntimeUtils.isWebsiteMode() && <ConfigSettingsBar />}
       <SidebarContainer>
         <NavigationItem

--- a/source/javascripts/components/Navigation.tsx
+++ b/source/javascripts/components/Navigation.tsx
@@ -12,7 +12,6 @@ import {
 } from '@bitrise/bitkit';
 import { PropsWithChildren, useCallback, useEffect, useRef } from 'react';
 
-import ConfigSettingsBar from '@/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar';
 import { segmentTrack } from '@/core/analytics/SegmentBaseTracking';
 import { getYmlString, updateBitriseYmlDocumentByString } from '@/core/stores/BitriseYmlStore';
 import { useCiConfigExpertStore } from '@/core/stores/CiConfigExpertStore';
@@ -119,7 +118,6 @@ const Navigation = (props: Props) => {
 
   return (
     <Sidebar width={['88px', '256px']} flexShrink={0} {...props}>
-      {RuntimeUtils.isWebsiteMode() && <ConfigSettingsBar />}
       <SidebarContainer>
         <NavigationItem
           path={withSearchParams(paths.workflows)}

--- a/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
+++ b/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
@@ -8,7 +8,6 @@ import {
   IconDownload,
   IconFolder,
   IconMoreVertical,
-  rem,
 } from '@bitrise/bitkit-v2';
 import { Box } from '@chakra-ui/react/box';
 import { Skeleton } from '@chakra-ui/react/skeleton';
@@ -73,7 +72,7 @@ const ConfigSettingsBar = () => {
       display="flex"
       alignItems="center"
       justifyContent={isYmlPage ? 'flex-start' : 'space-between'}
-      gap={isYmlPage ? rem(14) : '8'}
+      gap="12"
     >
       <Box minWidth={0}>
         <BitkitList variant="inline" textColor="body" size="md">

--- a/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
+++ b/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  BoxProps,
   ControlButton,
   DefinitionTooltip,
   Dot,
@@ -32,7 +33,7 @@ import useSearchParams from '@/hooks/useSearchParams';
 import useYmlHasChanges from '@/hooks/useYmlHasChanges';
 import ConfigurationYmlSourceDialog from '@/pages/YmlPage/components/ConfigurationYmlStorageDialog';
 
-const ConfigSettingsBar = () => {
+const ConfigSettingsBar = (props: BoxProps) => {
   const {
     isOpen: isSwitchBranchDialogOpen,
     onClose: onSwitchBranchDialogClose,
@@ -74,6 +75,7 @@ const ConfigSettingsBar = () => {
       alignItems="center"
       justifyContent="space-between"
       gap="8"
+      {...props}
     >
       <Box minW={0}>
         <Box display="flex" alignItems="center">

--- a/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
+++ b/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
@@ -8,6 +8,7 @@ import {
   IconDownload,
   IconFolder,
   IconMoreVertical,
+  rem,
 } from '@bitrise/bitkit-v2';
 import { Box } from '@chakra-ui/react/box';
 import { Skeleton } from '@chakra-ui/react/skeleton';
@@ -66,14 +67,13 @@ const ConfigSettingsBar = () => {
       paddingRight="12"
       paddingBlock="12"
       marginBottom={isYmlPage ? undefined : '24'}
-      width={['88', '256']}
       minHeight="64"
       borderBottom="1px solid"
       borderColor="border/minimal"
       display="flex"
       alignItems="center"
-      justifyContent="space-between"
-      gap="8"
+      justifyContent={isYmlPage ? 'flex-start' : 'space-between'}
+      gap={isYmlPage ? '8' : rem(14)}
     >
       <Box minWidth={0}>
         <BitkitList variant="inline" textColor="body" size="md">

--- a/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
+++ b/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
@@ -66,12 +66,13 @@ const ConfigSettingsBar = () => {
       paddingRight="12"
       paddingBlock="12"
       marginBottom={isYmlPage ? undefined : '24'}
+      width={['88', '256']}
       minHeight="64"
       borderBottom="1px solid"
       borderColor="border/minimal"
       display="flex"
       alignItems="center"
-      justifyContent={isYmlPage ? 'flex-start' : 'space-between'}
+      justifyContent="space-between"
       gap="8"
     >
       <Box minWidth={0}>

--- a/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
+++ b/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
@@ -1,22 +1,19 @@
 import {
-  Box,
-  BoxProps,
-  ControlButton,
-  DefinitionTooltip,
-  Dot,
-  Icon,
-  Menu,
-  MenuButton,
-  MenuItem,
-  MenuList,
-  Skeleton,
-  SkeletonBox,
-  Text,
-  Tooltip,
-  useDisclosure,
-} from '@bitrise/bitkit';
+  BitkitActionMenu,
+  BitkitControlButton,
+  BitkitList,
+  BitkitOverflowTooltip,
+  BitkitTooltip,
+  IconBranch,
+  IconDownload,
+  IconFolder,
+  IconMoreVertical,
+} from '@bitrise/bitkit-v2';
+import { Box } from '@chakra-ui/react/box';
+import { Skeleton } from '@chakra-ui/react/skeleton';
+import { Text } from '@chakra-ui/react/text';
+import { useState } from 'react';
 
-import SwitchBranchDialog from '@/components/unified-editor/SwitchBranchDialog/SwitchBranchDialog';
 import {
   trackBranchSwitchPopupShown,
   trackChangeStorageButtonClicked,
@@ -33,13 +30,12 @@ import useSearchParams from '@/hooks/useSearchParams';
 import useYmlHasChanges from '@/hooks/useYmlHasChanges';
 import ConfigurationYmlSourceDialog from '@/pages/YmlPage/components/ConfigurationYmlStorageDialog';
 
-const ConfigSettingsBar = (props: BoxProps) => {
-  const {
-    isOpen: isSwitchBranchDialogOpen,
-    onClose: onSwitchBranchDialogClose,
-    onOpen: onSwitchBranchDialogOpen,
-  } = useDisclosure();
-  const { isOpen: isStorageDialogOpen, onClose: onStorageDialogClose, onOpen: onStorageDialogOpen } = useDisclosure();
+import SwitchBranchDialog from '../SwitchBranchDialog/SwitchBranchDialog';
+
+const ConfigSettingsBar = () => {
+  const [isSwitchBranchDialogOpen, setIsSwitchBranchDialogOpen] = useState(false);
+  const [isStorageDialogOpen, setIsStorageDialogOpen] = useState(false);
+
   const enableBranchSwitching = useFeatureFlag('enable-branch-switching');
   const hasChanges = useYmlHasChanges();
 
@@ -59,85 +55,71 @@ const ConfigSettingsBar = (props: BoxProps) => {
 
   const handleStorageChange = () => {
     trackChangeStorageButtonClicked(data?.usesRepositoryYml ? 'git' : 'bitrise');
-    onStorageDialogOpen();
+    setIsStorageDialogOpen(true);
   };
 
   return (
     <Box
       paddingLeft="32"
       paddingRight="12"
-      py="12"
-      mb="24"
-      minH="65"
+      paddingBlock="12"
+      marginBottom="24"
+      minHeight="64"
       borderBottom="1px solid"
       borderColor="border/minimal"
       display="flex"
       alignItems="center"
       justifyContent="space-between"
       gap="8"
-      {...props}
     >
-      <Box minW={0}>
-        <Box display="flex" alignItems="center">
-          <Text as="h5" textStyle="body/md/semibold" color="text/primary">
-            bitrise.yml
-          </Text>
-          <Dot backgroundColor="text/primary" size="4" mx="6"></Dot>
-          {isPending ? (
-            <Skeleton>
-              <SkeletonBox height="20px" width="75px" />
-            </Skeleton>
-          ) : (
-            <Text as="h5" textStyle="body/md/semibold" color="text/primary">
-              {data?.usesRepositoryYml ? 'in repository' : 'on bitrise.io'}
-            </Text>
-          )}
-        </Box>
+      <Box minWidth={0}>
+        <BitkitList variant="inline" textColor="body" size="md">
+          <BitkitList.Item>bitrise.yml</BitkitList.Item>
+          <BitkitList.Item>
+            <Skeleton loading={isPending}>{data?.usesRepositoryYml ? 'in repository' : 'on bitrise.io'}</Skeleton>
+          </BitkitList.Item>
+        </BitkitList>
         {enableBranchSwitching && data?.usesRepositoryYml && branchLabel && (
-          <Box display="flex" alignItems="center" gap="4" mt="4">
-            <Icon name="Branch" size="16" color="icon/tertiary" />
-            <DefinitionTooltip
-              label={`Editing bitrise.yml from ${branchLabel}.`}
-              triggerProps={{
-                textStyle: 'body/sm/regular',
-                color: 'text/secondary',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              {branchLabel}
-            </DefinitionTooltip>
+          <Box display="flex" alignItems="center" gap="4" marginTop="4">
+            <IconBranch size="16" color="icon/tertiary" flexShrink="0" />
+            <BitkitOverflowTooltip text={branchLabel}>
+              <Text textStyle="body/sm/regular" color="text/secondary" truncate flex={1} minWidth={0}>
+                {branchLabel}
+              </Text>
+            </BitkitOverflowTooltip>
           </Box>
         )}
       </Box>
-      <Menu size="md">
-        <MenuButton as={ControlButton} iconName="MoreVertical" color="icon/secondary" size="xs" aria-label="More" />
-        <MenuList zIndex="5">
-          {enableBranchSwitching && data?.usesRepositoryYml && (
-            <Tooltip isDisabled={!hasChanges} label="Unsaved changes, save or discard first.">
-              <MenuItem
-                leftIconName="Branch"
-                onClick={() => {
-                  onSwitchBranchDialogOpen();
-                  trackBranchSwitchPopupShown();
-                }}
-                isDisabled={hasChanges}
-              >
-                Switch branch...
-              </MenuItem>
-            </Tooltip>
-          )}
-          <MenuItem leftIconName="Download" onClick={handleDownload}>
-            Download YAML file
-          </MenuItem>
-          <MenuItem leftIconName="Folder" onClick={handleStorageChange} isDisabled={isPending}>
-            Change storage...
-          </MenuItem>
-        </MenuList>
-      </Menu>
-      <SwitchBranchDialog isOpen={isSwitchBranchDialogOpen} onClose={onSwitchBranchDialogClose} />
-      <ConfigurationYmlSourceDialog isOpen={isStorageDialogOpen} onClose={onStorageDialogClose} />
+      <BitkitActionMenu.Root size="md" trigger={<BitkitControlButton icon={IconMoreVertical} label="More" size="xs" />}>
+        {enableBranchSwitching && data?.usesRepositoryYml && (
+          <BitkitTooltip disabled={!hasChanges} text="Unsaved changes, save or discard first.">
+            <BitkitActionMenu.Item
+              value="switch-branch"
+              icon={IconBranch}
+              disabled={hasChanges}
+              onClick={() => {
+                setIsSwitchBranchDialogOpen(true);
+                trackBranchSwitchPopupShown();
+              }}
+            >
+              Switch branch...
+            </BitkitActionMenu.Item>
+          </BitkitTooltip>
+        )}
+        <BitkitActionMenu.Item value="download-yml" icon={IconDownload} onClick={handleDownload}>
+          Download YAML file
+        </BitkitActionMenu.Item>
+        <BitkitActionMenu.Item
+          value="change-storage"
+          icon={IconFolder}
+          disabled={isPending}
+          onClick={handleStorageChange}
+        >
+          Change storage...
+        </BitkitActionMenu.Item>
+      </BitkitActionMenu.Root>
+      <SwitchBranchDialog isOpen={isSwitchBranchDialogOpen} onClose={() => setIsSwitchBranchDialogOpen(false)} />
+      <ConfigurationYmlSourceDialog isOpen={isStorageDialogOpen} onClose={() => setIsStorageDialogOpen(false)} />
     </Box>
   );
 };

--- a/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
+++ b/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
@@ -10,7 +10,7 @@ import {
   IconMoreVertical,
   rem,
 } from '@bitrise/bitkit-v2';
-import { Box } from '@chakra-ui/react/box';
+import { Box, type BoxProps } from '@chakra-ui/react/box';
 import { Skeleton } from '@chakra-ui/react/skeleton';
 import { Text } from '@chakra-ui/react/text';
 import { useState } from 'react';
@@ -26,7 +26,6 @@ import PageProps from '@/core/utils/PageProps';
 import RuntimeUtils from '@/core/utils/RuntimeUtils';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
 import { useCiConfigSettings } from '@/hooks/useCiConfigSettings';
-import useCurrentPage from '@/hooks/useCurrentPage';
 import useFeatureFlag from '@/hooks/useFeatureFlag';
 import useSearchParams from '@/hooks/useSearchParams';
 import useYmlHasChanges from '@/hooks/useYmlHasChanges';
@@ -34,11 +33,10 @@ import ConfigurationYmlSourceDialog from '@/pages/YmlPage/components/Configurati
 
 import SwitchBranchDialog from '../SwitchBranchDialog/SwitchBranchDialog';
 
-const ConfigSettingsBar = () => {
+const ConfigSettingsBar = (props: BoxProps) => {
   const [isSwitchBranchDialogOpen, setIsSwitchBranchDialogOpen] = useState(false);
   const [isStorageDialogOpen, setIsStorageDialogOpen] = useState(false);
 
-  const isYmlPage = useCurrentPage() === 'yml';
   const enableBranchSwitching = useFeatureFlag('enable-branch-switching');
   const hasChanges = useYmlHasChanges();
 
@@ -66,14 +64,14 @@ const ConfigSettingsBar = () => {
       paddingLeft="32"
       paddingRight="12"
       paddingBlock="12"
-      marginBottom={isYmlPage ? undefined : '24'}
       minHeight={rem(65)}
       borderBottom="1px solid"
       borderColor="border/minimal"
       display="flex"
       alignItems="center"
-      justifyContent={isYmlPage ? 'flex-start' : 'space-between'}
+      justifyContent="space-between"
       gap="12"
+      {...props}
     >
       <Box minWidth={0}>
         <BitkitList variant="inline" textColor="body" size="md">

--- a/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
+++ b/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
@@ -25,6 +25,7 @@ import PageProps from '@/core/utils/PageProps';
 import RuntimeUtils from '@/core/utils/RuntimeUtils';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
 import { useCiConfigSettings } from '@/hooks/useCiConfigSettings';
+import useCurrentPage from '@/hooks/useCurrentPage';
 import useFeatureFlag from '@/hooks/useFeatureFlag';
 import useSearchParams from '@/hooks/useSearchParams';
 import useYmlHasChanges from '@/hooks/useYmlHasChanges';
@@ -36,6 +37,7 @@ const ConfigSettingsBar = () => {
   const [isSwitchBranchDialogOpen, setIsSwitchBranchDialogOpen] = useState(false);
   const [isStorageDialogOpen, setIsStorageDialogOpen] = useState(false);
 
+  const isYmlPage = useCurrentPage() === 'yml';
   const enableBranchSwitching = useFeatureFlag('enable-branch-switching');
   const hasChanges = useYmlHasChanges();
 
@@ -63,13 +65,13 @@ const ConfigSettingsBar = () => {
       paddingLeft="32"
       paddingRight="12"
       paddingBlock="12"
-      marginBottom="24"
+      marginBottom={isYmlPage ? undefined : '24'}
       minHeight="64"
       borderBottom="1px solid"
       borderColor="border/minimal"
       display="flex"
       alignItems="center"
-      justifyContent="space-between"
+      justifyContent={isYmlPage ? 'flex-start' : 'space-between'}
       gap="8"
     >
       <Box minWidth={0}>

--- a/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
+++ b/source/javascripts/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar.tsx
@@ -73,7 +73,7 @@ const ConfigSettingsBar = () => {
       display="flex"
       alignItems="center"
       justifyContent={isYmlPage ? 'flex-start' : 'space-between'}
-      gap={isYmlPage ? '8' : rem(14)}
+      gap={isYmlPage ? rem(14) : '8'}
     >
       <Box minWidth={0}>
         <BitkitList variant="inline" textColor="body" size="md">

--- a/source/javascripts/layouts/MainLayout.tsx
+++ b/source/javascripts/layouts/MainLayout.tsx
@@ -25,11 +25,18 @@ const InvalidYmlRedirect = () => {
 };
 
 const MainLayout = () => {
+  const [currentPath] = useHashLocation();
+  const isYmlPage = currentPath.startsWith(paths.yml);
+
   return (
     <Box h="100dvh" display="flex" flexDirection="column">
       <Header />
       <Box display="flex" flex="1" alignItems="stretch" minH={0}>
-        <Navigation borderRight="1px solid" borderColor="border/regular" />
+        <Navigation
+          borderRight="1px solid"
+          borderColor="border/regular"
+          display={isYmlPage ? 'none' : undefined}
+        />
         <Box flex="1" overflowX="hidden" overflowY="auto">
           <Router hook={useHashLocation} searchHook={useHashSearch}>
             <InvalidYmlRedirect />

--- a/source/javascripts/layouts/MainLayout.tsx
+++ b/source/javascripts/layouts/MainLayout.tsx
@@ -32,6 +32,7 @@ const MainLayout = () => {
     <Box h="100dvh" display="flex" flexDirection="column">
       <Header />
       <Box display="flex" flex="1" alignItems="stretch" minH={0}>
+        {/* style instead of conditional unmount — keeps CI_CONFIG_RECEIVED / REQUEST_AI_DRAWER_OPEN listeners alive on the YAML page. */}
         <Navigation
           borderRight="1px solid"
           borderColor="border/regular"

--- a/source/javascripts/layouts/MainLayout.tsx
+++ b/source/javascripts/layouts/MainLayout.tsx
@@ -4,6 +4,8 @@ import { Redirect, Router, Switch } from 'wouter';
 import Header from '@/components/Header';
 import LazyRoute from '@/components/LazyRoute';
 import Navigation from '@/components/Navigation';
+import ConfigSettingsBar from '@/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar';
+import RuntimeUtils from '@/core/utils/RuntimeUtils';
 import useHashLocation from '@/hooks/useHashLocation';
 import useHashSearch from '@/hooks/useHashSearch';
 import useYmlValidationStatus from '@/hooks/useYmlValidationStatus';
@@ -27,18 +29,28 @@ const InvalidYmlRedirect = () => {
 const MainLayout = () => {
   const [currentPath] = useHashLocation();
   const isYmlPage = currentPath.startsWith(paths.yml);
+  const isWebsiteMode = RuntimeUtils.isWebsiteMode();
 
   return (
     <Box h="100dvh" display="flex" flexDirection="column">
       <Header />
-      <Box display="flex" flex="1" alignItems="stretch" minH={0}>
+      <Box
+        display="grid"
+        flex="1"
+        minH={0}
+        gridTemplateColumns={isYmlPage ? '1fr' : '256px 1fr'}
+        gridTemplateRows="auto 1fr"
+        gridTemplateAreas={isYmlPage ? `"bar" "content"` : `"bar content" "nav content"`}
+      >
+        {isWebsiteMode && <ConfigSettingsBar gridArea="bar" />}
         {/* style instead of conditional unmount — keeps CI_CONFIG_RECEIVED / REQUEST_AI_DRAWER_OPEN listeners alive on the YAML page. */}
         <Navigation
+          gridArea="nav"
           borderRight="1px solid"
           borderColor="border/regular"
           style={{ display: isYmlPage ? 'none' : undefined }}
         />
-        <Box flex="1" overflowX="hidden" overflowY="auto">
+        <Box gridArea="content" overflowX="hidden" overflowY="auto">
           <Router hook={useHashLocation} searchHook={useHashSearch}>
             <InvalidYmlRedirect />
             <Switch>

--- a/source/javascripts/layouts/MainLayout.tsx
+++ b/source/javascripts/layouts/MainLayout.tsx
@@ -32,11 +32,7 @@ const MainLayout = () => {
     <Box h="100dvh" display="flex" flexDirection="column">
       <Header />
       <Box display="flex" flex="1" alignItems="stretch" minH={0}>
-        <Navigation
-          borderRight="1px solid"
-          borderColor="border/regular"
-          style={{ display: isYmlPage ? 'none' : undefined }}
-        />
+        {!isYmlPage && <Navigation borderRight="1px solid" borderColor="border/regular" />}
         <Box flex="1" overflowX="hidden" overflowY="auto">
           <Router hook={useHashLocation} searchHook={useHashSearch}>
             <InvalidYmlRedirect />

--- a/source/javascripts/layouts/MainLayout.tsx
+++ b/source/javascripts/layouts/MainLayout.tsx
@@ -32,9 +32,11 @@ const MainLayout = () => {
     <Box h="100dvh" display="flex" flexDirection="column">
       <Header />
       <Box display="flex" flex="1" alignItems="stretch" minH={0}>
-        <Box display={isYmlPage ? 'none' : undefined}>
-          <Navigation borderRight="1px solid" borderColor="border/regular" />
-        </Box>
+        <Navigation
+          borderRight="1px solid"
+          borderColor="border/regular"
+          style={{ display: isYmlPage ? 'none' : undefined }}
+        />
         <Box flex="1" overflowX="hidden" overflowY="auto">
           <Router hook={useHashLocation} searchHook={useHashSearch}>
             <InvalidYmlRedirect />

--- a/source/javascripts/layouts/MainLayout.tsx
+++ b/source/javascripts/layouts/MainLayout.tsx
@@ -42,7 +42,14 @@ const MainLayout = () => {
         gridTemplateRows="auto 1fr"
         gridTemplateAreas={isYmlPage ? `"bar" "content"` : `"bar content" "nav content"`}
       >
-        {isWebsiteMode && <ConfigSettingsBar gridArea="bar" />}
+        {isWebsiteMode && (
+          <ConfigSettingsBar
+            gridArea="bar"
+            justifyContent={isYmlPage ? 'flex-start' : 'space-between'}
+            borderRight={isYmlPage ? undefined : '1px solid'}
+            borderRightColor={isYmlPage ? undefined : 'border/regular'}
+          />
+        )}
         {/* style instead of conditional unmount — keeps CI_CONFIG_RECEIVED / REQUEST_AI_DRAWER_OPEN listeners alive on the YAML page. */}
         <Navigation
           gridArea="nav"

--- a/source/javascripts/layouts/MainLayout.tsx
+++ b/source/javascripts/layouts/MainLayout.tsx
@@ -32,7 +32,11 @@ const MainLayout = () => {
     <Box h="100dvh" display="flex" flexDirection="column">
       <Header />
       <Box display="flex" flex="1" alignItems="stretch" minH={0}>
-        {!isYmlPage && <Navigation borderRight="1px solid" borderColor="border/regular" />}
+        <Navigation
+          borderRight="1px solid"
+          borderColor="border/regular"
+          style={{ display: isYmlPage ? 'none' : undefined }}
+        />
         <Box flex="1" overflowX="hidden" overflowY="auto">
           <Router hook={useHashLocation} searchHook={useHashSearch}>
             <InvalidYmlRedirect />

--- a/source/javascripts/layouts/MainLayout.tsx
+++ b/source/javascripts/layouts/MainLayout.tsx
@@ -32,11 +32,9 @@ const MainLayout = () => {
     <Box h="100dvh" display="flex" flexDirection="column">
       <Header />
       <Box display="flex" flex="1" alignItems="stretch" minH={0}>
-        <Navigation
-          borderRight="1px solid"
-          borderColor="border/regular"
-          display={isYmlPage ? 'none' : undefined}
-        />
+        <Box display={isYmlPage ? 'none' : undefined}>
+          <Navigation borderRight="1px solid" borderColor="border/regular" />
+        </Box>
         <Box flex="1" overflowX="hidden" overflowY="auto">
           <Router hook={useHashLocation} searchHook={useHashSearch}>
             <InvalidYmlRedirect />

--- a/source/javascripts/pages/YmlPage/YmlPage.stories.tsx
+++ b/source/javascripts/pages/YmlPage/YmlPage.stories.tsx
@@ -27,7 +27,7 @@ export default {
   decorators: [
     (Story) => (
       <Box height="calc(100dvh - 2rem)" display="flex" flexDirection="column">
-        {RuntimeUtils.isWebsiteMode() && <ConfigSettingsBar />}
+        {RuntimeUtils.isWebsiteMode() && <ConfigSettingsBar justifyContent="flex-start" />}
         <Story />
       </Box>
     ),

--- a/source/javascripts/pages/YmlPage/YmlPage.stories.tsx
+++ b/source/javascripts/pages/YmlPage/YmlPage.stories.tsx
@@ -2,6 +2,9 @@ import { Box } from '@bitrise/bitkit';
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { http, HttpResponse } from 'msw';
 
+import ConfigSettingsBar from '@/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar';
+import RuntimeUtils from '@/core/utils/RuntimeUtils';
+
 import YmlPage from './YmlPage';
 
 type StoryType = StoryObj<typeof YmlPage>;
@@ -23,7 +26,8 @@ export default {
   },
   decorators: [
     (Story) => (
-      <Box height="calc(100dvh - 2rem)">
+      <Box height="calc(100dvh - 2rem)" display="flex" flexDirection="column">
+        {RuntimeUtils.isWebsiteMode() && <ConfigSettingsBar />}
         <Story />
       </Box>
     ),

--- a/source/javascripts/pages/YmlPage/YmlPage.tsx
+++ b/source/javascripts/pages/YmlPage/YmlPage.tsx
@@ -1,5 +1,6 @@
 import { Box } from '@bitrise/bitkit';
 
+import ConfigSettingsBar from '@/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar';
 import RuntimeUtils from '@/core/utils/RuntimeUtils';
 import OptimizeYouCiConfigBySplittingNotification from '@/pages/YmlPage/components/OptimizeYouCiConfigBySplittingNotification'; // TODO: implement onConfigSourceChangeSaved function
 import YourCiConfigIsSplitNotification from '@/pages/YmlPage/components/YourCiConfigIsSplitNotification';
@@ -11,6 +12,7 @@ const YmlPage = () => {
 
   return (
     <Box height="100%" display="flex" flexDirection="column">
+      {isWebsiteMode && <ConfigSettingsBar mb="0" justifyContent="flex-start" />}
       <Box flexGrow="1" flexShrink="1" paddingBlock="12" backgroundColor="#1e1e1e" position="relative">
         {isWebsiteMode && <YourCiConfigIsSplitNotification />}
         {isWebsiteMode && <OptimizeYouCiConfigBySplittingNotification />}

--- a/source/javascripts/pages/YmlPage/YmlPage.tsx
+++ b/source/javascripts/pages/YmlPage/YmlPage.tsx
@@ -12,7 +12,7 @@ const YmlPage = () => {
 
   return (
     <Box height="100%" display="flex" flexDirection="column">
-      {isWebsiteMode && <ConfigSettingsBar mb="0" justifyContent="flex-start" />}
+      {isWebsiteMode && <ConfigSettingsBar />}
       <Box flexGrow="1" flexShrink="1" paddingBlock="12" backgroundColor="#1e1e1e" position="relative">
         {isWebsiteMode && <YourCiConfigIsSplitNotification />}
         {isWebsiteMode && <OptimizeYouCiConfigBySplittingNotification />}

--- a/source/javascripts/pages/YmlPage/YmlPage.tsx
+++ b/source/javascripts/pages/YmlPage/YmlPage.tsx
@@ -1,6 +1,5 @@
 import { Box } from '@bitrise/bitkit';
 
-import ConfigSettingsBar from '@/components/unified-editor/ConfigSettingsBar/ConfigSettingsBar';
 import RuntimeUtils from '@/core/utils/RuntimeUtils';
 import OptimizeYouCiConfigBySplittingNotification from '@/pages/YmlPage/components/OptimizeYouCiConfigBySplittingNotification'; // TODO: implement onConfigSourceChangeSaved function
 import YourCiConfigIsSplitNotification from '@/pages/YmlPage/components/YourCiConfigIsSplitNotification';
@@ -12,7 +11,6 @@ const YmlPage = () => {
 
   return (
     <Box height="100%" display="flex" flexDirection="column">
-      {isWebsiteMode && <ConfigSettingsBar />}
       <Box
         flexGrow="1"
         flexShrink="1"


### PR DESCRIPTION
JIRA: https://bitrise.atlassian.net/browse/BIVS-3673

Summary
Adds a Visual / YAML segmented control to the header, replacing the old "Configuration YAML" navigation item in the sidebar. This gives users a cleaner, more prominent way to switch between the visual editor and the raw YAML view.

Changes
Header: Added a BitkitSegmentedControl (Visual / YAML) that navigates between the visual pages and the YML page. Switching back from YAML returns the user to the last visited visual page. If the YAML is invalid, switching to Visual is blocked with a toast.
Navigation: Removed the "Configuration YAML" sidebar item and its divider — the header control replaces it entirely.
MainLayout: The sidebar is hidden while on the YAML page, since the full-width editor doesn't need it.
ConfigSettingsBar: Made layout context-aware — on the YAML page it uses flex-start alignment (no spacer needed), and drops the bottom margin to avoid double-spacing with the editor.
YmlPage: Renders ConfigSettingsBar in website mode so the branch/storage controls are still accessible on the YAML page.
Dependency: Bumped @bitrise/bitkit-v2 to 0.3.237 (picks up the BitkitSegmentedControl fixes used here).