### PR TITLE
Fix Configuration YAML language features in built CLI plugin mode

### DIFF
--- a/source/javascripts/core/utils/MonacoUtils.ts
+++ b/source/javascripts/core/utils/MonacoUtils.ts
@@ -33,7 +33,7 @@ const configureForYaml: BeforeMountHandler = (monacoInstance) => {
       completion: true,
       yamlVersion: '1.1',
       enableSchemaRequest: true,
-      schemas: [{ fileMatch: ['*'], uri: `https://json.schemastore.org/bitrise.json?t=${Date.now()}` }],
+      schemas: [{ fileMatch: ['*'], uri: `https://www.schemastore.org/bitrise.json?t=${Date.now()}` }],
     });
   }
 

--- a/source/javascripts/hooks/useFeatureFlag.ts
+++ b/source/javascripts/hooks/useFeatureFlag.ts
@@ -3,7 +3,6 @@ import { initialize, LDClient } from 'launchdarkly-js-client-sdk';
 import GlobalProps from '@/core/utils/GlobalProps';
 
 const defaultValues = {
-  'enable-wfe-bitrise-language-server': false,
   'enable-wfe-step-bundles-when-to-run': false,
   'enable-ci-config-expert-agent': false,
   'enable-branch-switching': false,

--- a/source/javascripts/hooks/useYmlLanguageServices.ts
+++ b/source/javascripts/hooks/useYmlLanguageServices.ts
@@ -3,20 +3,15 @@ import { useEffect } from 'react';
 
 import { bitriseYmlStore, getYmlString, setValidationStatus } from '@/core/stores/BitriseYmlStore';
 import MonacoUtils from '@/core/utils/MonacoUtils';
-import useFeatureFlag from '@/hooks/useFeatureFlag';
 
 export const BACKGROUND_MODEL_URI = monaco.Uri.parse('file:///bitrise.yml');
 
 function useYmlLanguageServices() {
-  const enableBitriseLanguageServer = useFeatureFlag('enable-wfe-bitrise-language-server');
-
   useEffect(() => {
     // Configure Monaco language services (idempotent — safe to call multiple times)
     MonacoUtils.configureForYaml(monaco);
     MonacoUtils.configureEnvVarsCompletionProvider(monaco);
-    if (enableBitriseLanguageServer) {
-      MonacoUtils.configureBitriseLanguageServer(monaco);
-    }
+    MonacoUtils.configureBitriseLanguageServer(monaco);
 
     // Create or reuse the background model
     let model = monaco.editor.getModel(BACKGROUND_MODEL_URI);
@@ -84,7 +79,7 @@ function useYmlLanguageServices() {
       // Disposing it while workers are in-flight causes "Model is disposed" errors.
       // The model lives for the entire app session — monaco.editor.getModel() reuses it.
     };
-  }, [enableBitriseLanguageServer]);
+  }, []);
 }
 
 export default useYmlLanguageServices;


### PR DESCRIPTION
## What

Fixes two independent issues that broke the **Configuration YAML** editor's language features specifically in the **built CLI plugin** (`bitrise :workflow-editor`). Both features worked in dev (`npm run start`) and in website mode, which is why this was easy to miss.

### 1. Schema fetch blocked by CORS (`MonacoUtils.ts`)
`monaco-yaml` fetched the JSON schema from `https://json.schemastore.org/bitrise.json`. That host now **301-redirects** to `https://www.schemastore.org/bitrise.json`, and the redirect response carries **no `Access-Control-Allow-Origin` header**. Browsers enforce CORS on *every hop* of a redirect chain, so the fetch was blocked at the first hop:

```
Access to fetch at 'https://json.schemastore.org/bitrise.json?t=...' has been blocked by CORS policy:
No 'Access-Control-Allow-Origin' header is present on the requested resource.
```

Fix: fetch `www.schemastore.org` directly (returns `200` + `Access-Control-Allow-Origin: *`), skipping the redirect hop.

### 2. Bitrise language server disabled in CLI mode (`useFeatureFlag.ts`, `useYmlLanguageServices.ts`)
The Bitrise LS was gated behind the `enable-wfe-bitrise-language-server` feature flag. Flag resolution:

- `window.localFeatureFlags` — only present in dev (injected from `ld.local.json`).
- LaunchDarkly `client.variation(...)` — but the LD client **only initializes when `GlobalProps.workspaceSlug()` is set**, which comes from `window.parent.globalProps` (the host website).
- otherwise the `false` default.

In CLI plugin mode there is **no host website**, so `globalProps`/`workspaceSlug` is absent → the LD client never initializes; and there's no `ld.local.json` → the flag fell back to its `false` default. So `configureBitriseLanguageServer` was never called and the Bitrise LS silently never started — even though the worker bundles ship and serve correctly.

The flag has been **fully rolled out in LaunchDarkly for a while**, so this removes it entirely and always configures the language server.

## Why this only reproduced in the CLI build
- `npm run start` (dev CLI): `ld.local.json` provides the local override → flag on.
- Website mode: real `globalProps` → LD initializes → flag on (rolled out).
- **Built CLI plugin**: no host page, no local override → flag = default `false` → LS off.

## Verification
- Reproduced via the real artifact path: `npm run build:plugin` → ran the generated `_bin/workflow-editor-Darwin-arm64`.
- Confirmed the worker files (`bitrise.worker`, `yaml.worker`, `editor.worker`) are embedded by rice-box and served `200` with `text/javascript`.
- Confirmed `www.schemastore.org/bitrise.json` returns `200` + `Access-Control-Allow-Origin: *` (no redirect) vs. `json.schemastore.org` returning a `301` with no CORS header.
- Rebuilt and confirmed the `enable-wfe-bitrise-language-server` string is gone from the shipped bundle while the `bitrise.worker` is still bundled and referenced.
- `eslint` and `tsc --noEmit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)