### PR TITLE
BPS-320: Disable rollback checkbox for external-only workspaces

### DIFF
--- a/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
+++ b/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
@@ -4,6 +4,7 @@ import { useResizeObserver } from 'usehooks-ts';
 
 import ToolVersions from '@/components/ToolVersions/ToolVersions';
 import StackAndMachineService from '@/core/services/StackAndMachineService';
+import GlobalProps from '@/core/utils/GlobalProps';
 import PageProps from '@/core/utils/PageProps';
 import useFeatureFlag from '@/hooks/useFeatureFlag';
 import useProjectStackAndMachine from '@/hooks/useProjectStackAndMachine';
@@ -47,6 +48,8 @@ const StackAndMachine = ({
   const { projectStackId, projectMachineTypeId } = useProjectStackAndMachine();
 
   const rollbackType = PageProps.app()?.isOwnerPaying ? 'paying' : 'free';
+  const availableBuildHosts = GlobalProps.accountFeatureFlags()?.availableBuildHosts;
+  const disableRollbackOption = availableBuildHosts === 'external';
 
   const {
     selectedStack,
@@ -122,6 +125,7 @@ const StackAndMachine = ({
             handleChange(selectedStackValue, selectedMachineType.value, useRollbackVersionChecked)
           }
           isRollbackVersionAvailable={!!availableRollbackVersion}
+          disableRollbackOption={disableRollbackOption}
           useRollbackVersion={useRollbackVersion}
           width={orientation === 'horizontal' ? '50%' : undefined}
         />

--- a/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
+++ b/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
@@ -48,8 +48,8 @@ const StackAndMachine = ({
   const { projectStackId, projectMachineTypeId } = useProjectStackAndMachine();
 
   const rollbackType = PageProps.app()?.isOwnerPaying ? 'paying' : 'free';
-  const availableBuildHosts = GlobalProps.accountFeatureFlags()?.availableBuildHosts;
-  const disableRollbackOption = availableBuildHosts === 'external';
+  const machineTypeHosts = GlobalProps.accountFeatureFlags()?.machineTypeHosts;
+  const disableRollbackOption = machineTypeHosts === 'external';
 
   const {
     selectedStack,

--- a/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
+++ b/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
@@ -48,8 +48,8 @@ const StackAndMachine = ({
   const { projectStackId, projectMachineTypeId } = useProjectStackAndMachine();
 
   const rollbackType = PageProps.app()?.isOwnerPaying ? 'paying' : 'free';
-  const machineTypeHosts = GlobalProps.accountFeatureFlags()?.machineTypeHosts;
-  const disableRollbackOption = machineTypeHosts === 'external';
+  const rollbackVersionFeatureEnabled = GlobalProps.accountFeatureFlags()?.rollbackVersionFeatureEnabled;
+  const disableRollbackOption = rollbackVersionFeatureEnabled === false;
 
   const {
     selectedStack,

--- a/source/javascripts/components/StacksAndMachine/StackSelector.tsx
+++ b/source/javascripts/components/StacksAndMachine/StackSelector.tsx
@@ -80,6 +80,7 @@ type Props = Pick<BoxProps, 'width'> & {
   isLoading: boolean;
   isInvalid: boolean;
   isRollbackVersionAvailable: boolean;
+  disableRollbackOption?: boolean;
   useRollbackVersion?: boolean;
   stack: StackWithValue;
   optionGroups: StackOptionGroup[];
@@ -90,12 +91,15 @@ const StackSelector = ({
   isLoading,
   isInvalid,
   isRollbackVersionAvailable,
+  disableRollbackOption,
   useRollbackVersion,
   stack,
   optionGroups,
   onChange,
   ...boxProps
 }: Props) => {
+  const isRollbackDisabled = !isRollbackVersionAvailable || !!disableRollbackOption;
+
   return (
     <Box {...boxProps} flex="1">
       <Dropdown
@@ -118,14 +122,20 @@ const StackSelector = ({
             </DropdownGroup>
           ))}
       </Dropdown>
-      <Checkbox
-        isDisabled={!isRollbackVersionAvailable}
-        isChecked={isRollbackVersionAvailable && useRollbackVersion}
-        onChange={(e) => onChange(stack.value, e.target.checked)}
-        mt="16"
+      <Tooltip
+        label="Stack rollback is not available when your workspace is configured to use external hosts only."
+        isDisabled={!disableRollbackOption}
       >
-        Use previous stack version <PreviousStackVersionTip />
-      </Checkbox>
+        <Box display="inline-block" mt="16">
+          <Checkbox
+            isDisabled={isRollbackDisabled}
+            isChecked={!isRollbackDisabled && useRollbackVersion}
+            onChange={(e) => onChange(stack.value, e.target.checked)}
+          >
+            Use previous stack version <PreviousStackVersionTip />
+          </Checkbox>
+        </Box>
+      </Tooltip>
     </Box>
   );
 };

--- a/source/javascripts/typings/globals.d.ts
+++ b/source/javascripts/typings/globals.d.ts
@@ -42,7 +42,7 @@ declare global {
       featureFlags?: {
         user: { [s: string]: unknown };
         account: { [s: string]: unknown } & {
-          machineTypeHosts?: string;
+          rollbackVersionFeatureEnabled?: boolean;
         };
       };
     };

--- a/source/javascripts/typings/globals.d.ts
+++ b/source/javascripts/typings/globals.d.ts
@@ -42,7 +42,7 @@ declare global {
       featureFlags?: {
         user: { [s: string]: unknown };
         account: { [s: string]: unknown } & {
-          availableBuildHosts?: string;
+          machineTypeHosts?: string;
         };
       };
     };

--- a/source/javascripts/typings/globals.d.ts
+++ b/source/javascripts/typings/globals.d.ts
@@ -41,7 +41,9 @@ declare global {
       };
       featureFlags?: {
         user: { [s: string]: unknown };
-        account: { [s: string]: unknown };
+        account: { [s: string]: unknown } & {
+          availableBuildHosts?: string;
+        };
       };
     };
     pageProps?: {


### PR DESCRIPTION
## Summary

Implements the frontend half of [BPS-320](https://bitrise.atlassian.net/browse/BPS-320). When a workspace is configured to use external hosts only (`bps-machine-type-hosts = 'external'`), stack rollback is not supported. This PR disables the rollback checkbox in the Stack & Machine UI and explains why via a tooltip.

### What changed

**`globals.d.ts`**
- Added `rollbackVersionFeatureEnabled?: boolean` to `featureFlags.account` type

**`StackAndMachine.tsx`**
- Reads `rollbackVersionFeatureEnabled` from `GlobalProps.accountFeatureFlags()` (provided by the backend)
- Derives `disableRollbackOption = rollbackVersionFeatureEnabled === false` — `=== false` is intentional so that `undefined` (flag not yet loaded) does not disable the checkbox
- Passes `disableRollbackOption` down to `StackSelector`

**`StackSelector.tsx`**
- New optional prop `disableRollbackOption?: boolean`
- Computes `isRollbackDisabled = !isRollbackVersionAvailable || !!disableRollbackOption`
- Wraps the rollback `Checkbox` in a `Tooltip` + `<Box display="inline-block">` (required so tooltips fire on disabled controls — pointer events are suppressed on disabled form elements)
- `mt="16"` moved from `Checkbox` to the wrapper `Box` to preserve spacing
- When disabled forces `isChecked={false}` so the checkbox cannot appear checked while disabled

### Behaviour

| `rollbackVersionFeatureEnabled` | Rollback checkbox |
|---|---|
| `true` (default) | enabled as before |
| `undefined` (not loaded) | enabled as before |
| `false` | disabled + tooltip shown |

### Related

Backend PRs:
- bitrise-io/bitrise-website#19709 (BPS-319: wires `bps-machine-type-hosts` flag to DEN tags, exposes `rollbackVersionFeatureEnabled` to frontend)
- bitrise-io/bitrise-website#19715 (BPS-320: forces `--hosted-bitrise` for alpha/rollback builds)

— Claude Code

[BPS-320]: https://bitrise.atlassian.net/browse/BPS-320?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ