### PR TITLE
BIVS-3677 Sync FE entity index ordering with Go merger

### DIFF
--- a/source/javascripts/core/models/Tree.ts
+++ b/source/javascripts/core/models/Tree.ts
@@ -13,7 +13,7 @@ export type TreeNode = {
   path: string;
   contents: string;
   source: TreeNodeSource | null;
-  /** Full 40-char SHA the contents were read from; also the conflict token for saves. */
+  /** SHA the contents were read from — a full 40-char SHA, or a short 6–8 char hash for short-pinned includes, or empty for FE-created files; also the conflict token for saves. */
   commitSha: string;
   /** Edit-gating source of truth; the FE never re-derives this. */
   editable: boolean;
@@ -25,8 +25,9 @@ export type TreeNode = {
 export type EntityDefinition = { nodeId: string };
 
 /**
- * `{ entityId: [{ nodeId }, …] }` per kind, in pre-order merge order: index `0` is the
- * top-most/highest-precedence layer, later entries are lower layers merged underneath.
+ * `{ entityId: [{ nodeId }, …] }` per kind, ordered highest-precedence-first to match the Go
+ * merger: index `0` is the winning layer (a node outranks the files it includes, and a later
+ * include outranks an earlier sibling), later entries are lower layers merged underneath.
  */
 export type EntityIndexEntries = Record<string, EntityDefinition[]>;
 

--- a/source/javascripts/core/services/EntityIndexService.spec.ts
+++ b/source/javascripts/core/services/EntityIndexService.spec.ts
@@ -58,7 +58,7 @@ describe('EntityIndexService', () => {
       return { ymlDocument: YmlUtils.toDoc(contents) };
     }
 
-    it('accumulates multi-layer definitions in pre-order, so the top-most layer is first', () => {
+    it('orders multi-layer definitions highest-precedence-first: parent over includes, later sibling over earlier', () => {
       const tree = node('n_root', [node('n_module_a'), node('n_module_b')]);
       const files = {
         n_root: file(yaml`
@@ -80,10 +80,11 @@ describe('EntityIndexService', () => {
 
       const result = EntityIndexService.buildFromFiles(tree, files);
 
+      // Parent (n_root) wins over its includes; among siblings the later one (n_module_b) wins over the earlier (n_module_a).
       expect(result.workflows.build).toEqual([
         { nodeId: 'n_root' },
-        { nodeId: 'n_module_a' },
         { nodeId: 'n_module_b' },
+        { nodeId: 'n_module_a' },
       ]);
       expect(result.workflows.deploy).toEqual([{ nodeId: 'n_module_a' }]);
       expect(result.pipelines.release).toEqual([{ nodeId: 'n_module_b' }]);

--- a/source/javascripts/core/services/EntityIndexService.ts
+++ b/source/javascripts/core/services/EntityIndexService.ts
@@ -3,8 +3,6 @@ import { Document } from 'yaml';
 import { EntityDefinition, EntityIndex, EntityKind, TreeNode } from '@/core/models/Tree';
 import YmlUtils from '@/core/utils/YmlUtils';
 
-import TreeService from './TreeService';
-
 // YAML section key → EntityIndex key. step_bundles is camelCased in the index.
 const KIND_SECTIONS: ReadonlyArray<{ section: string; key: EntityKind }> = [
   { section: 'workflows', key: 'workflows' },
@@ -30,24 +28,36 @@ function definingNodeId(index: EntityIndex, kind: EntityKind, id: string): strin
 function buildFromFiles(tree: TreeNode | undefined, files: Record<string, { ymlDocument: Document }>): EntityIndex {
   const index = emptyEntityIndex();
 
-  TreeService.walk(tree, (node) => {
-    const doc = files[node.nodeId]?.ymlDocument;
-    if (!doc) {
+  // Highest-precedence-first DFS mirroring the Go merger: a node outranks the files it includes
+  // (visited first), and a later include outranks an earlier sibling (children walked in reverse),
+  // so index 0 is the winning layer. Cycle-guarded so a malformed tree can't recurse forever.
+  const seen = new Set<string>();
+  const visit = (node: TreeNode | undefined) => {
+    if (!node || seen.has(node.nodeId)) {
       return;
     }
+    seen.add(node.nodeId);
 
-    KIND_SECTIONS.forEach(({ section, key }) => {
-      const map = YmlUtils.getMapIn(doc, [section]);
-      map?.items.forEach((pair) => {
-        const entityId = String(pair.key);
-        if (!entityId) {
-          return;
-        }
-        // Pre-order append: first is top-most layer, later ones are lower layers.
-        (index[key][entityId] ||= []).push({ nodeId: node.nodeId });
+    const doc = files[node.nodeId]?.ymlDocument;
+    if (doc) {
+      KIND_SECTIONS.forEach(({ section, key }) => {
+        const map = YmlUtils.getMapIn(doc, [section]);
+        map?.items.forEach((pair) => {
+          const entityId = String(pair.key);
+          if (!entityId) {
+            return;
+          }
+          (index[key][entityId] ||= []).push({ nodeId: node.nodeId });
+        });
       });
-    });
-  });
+    }
+
+    for (let i = node.includes.length - 1; i >= 0; i -= 1) {
+      visit(node.includes[i]);
+    }
+  };
+
+  visit(tree);
 
   return index;
 }


### PR DESCRIPTION
The BE reworked the modular-config tree contracts. The mandatory node_id formula change does not apply here — the FE treats node_id as opaque and BE-owned, so there is no hash input to update.

Two awareness items did need FE changes:

- entity_index ordering: the live re-derivation (EntityIndexService. buildFromFiles) mirrored the BE builder via a plain pre-order walk. The Go merger now orders highest-precedence-first — a node outranks the files it includes, and a later include outranks an earlier sibling. Rewrote the walk as a reverse-sibling DFS so index 0 is the winning layer.
- commit_sha: loosened the Tree.commitSha doc to allow a short 6-8 char hash for short-pinned includes (no code path validated length).