### PR TITLE
feat(modular): tab-close discard modal + entity-index for containers/app-envs + jump-to-def [BIVS-3686]

### DIFF
--- a/source/javascripts/core/api/BitriseYmlApi.ts
+++ b/source/javascripts/core/api/BitriseYmlApi.ts
@@ -129,6 +129,9 @@ export type WireEntityIndex = {
   workflows: WireEntityEntries;
   pipelines: WireEntityEntries;
   step_bundles: WireEntityEntries;
+  // Optional: absent on older BE responses, defaulted to `{}` on parse.
+  containers?: WireEntityEntries;
+  app_envs?: WireEntityEntries;
 };
 
 export type WireGetConfigResponse = {
@@ -196,6 +199,8 @@ function fromWireEntityIndex(index: WireEntityIndex): EntityIndex {
     workflows: fromWireEntityEntries(index.workflows),
     pipelines: fromWireEntityEntries(index.pipelines),
     stepBundles: fromWireEntityEntries(index.step_bundles),
+    containers: fromWireEntityEntries(index.containers),
+    appEnvs: fromWireEntityEntries(index.app_envs),
   };
 }
 

--- a/source/javascripts/core/models/Tree.ts
+++ b/source/javascripts/core/models/Tree.ts
@@ -37,6 +37,16 @@ export type EntityIndex = {
   pipelines: EntityIndexEntries;
   /** camelCase ← wire `step_bundles`. */
   stepBundles: EntityIndexEntries;
+  /**
+   * Execution + service containers share the one top-level `containers` map, keyed by container id.
+   * Optional: older BE snapshots omit it (defaulted to `{}` on parse); the live FE index always has it.
+   */
+  containers?: EntityIndexEntries;
+  /**
+   * Project env vars (`app.envs`), keyed by env var name. camelCase ← wire `app_envs`.
+   * Optional for the same reason as `containers`.
+   */
+  appEnvs?: EntityIndexEntries;
 };
 
 export type EntityKind = keyof EntityIndex;

--- a/source/javascripts/core/services/EntityIndexService.spec.ts
+++ b/source/javascripts/core/services/EntityIndexService.spec.ts
@@ -104,6 +104,49 @@ describe('EntityIndexService', () => {
       expect(result.stepBundles.common).toEqual([{ nodeId: 'n_root' }]);
     });
 
+    it('indexes execution + service containers from the one containers map, layered highest-precedence-first', () => {
+      const tree = node('n_root', [node('n_module')]);
+      const files = {
+        n_root: file(yaml`
+          containers:
+            node: { type: execution, image: node:18 }
+        `),
+        n_module: file(yaml`
+          containers:
+            node: { type: execution, image: node:20 }
+            db: { type: service, image: postgres:16 }
+        `),
+      };
+
+      const result = EntityIndexService.buildFromFiles(tree, files);
+
+      // Parent (n_root) outranks the module it includes for the shared `node` id.
+      expect(result.containers?.node).toEqual([{ nodeId: 'n_root' }, { nodeId: 'n_module' }]);
+      expect(result.containers?.db).toEqual([{ nodeId: 'n_module' }]);
+    });
+
+    it('indexes project env vars (app.envs) by var name, layered across files', () => {
+      const tree = node('n_root', [node('n_module')]);
+      const files = {
+        n_root: file(yaml`
+          app:
+            envs:
+              - SHARED: from-root
+        `),
+        n_module: file(yaml`
+          app:
+            envs:
+              - SHARED: from-module
+              - MODULE_ONLY: { opts: { is_expand: false } }
+        `),
+      };
+
+      const result = EntityIndexService.buildFromFiles(tree, files);
+
+      expect(result.appEnvs?.SHARED).toEqual([{ nodeId: 'n_root' }, { nodeId: 'n_module' }]);
+      expect(result.appEnvs?.MODULE_ONLY).toEqual([{ nodeId: 'n_module' }]);
+    });
+
     it('skips nodes without a loaded document and tolerates docs without entity sections', () => {
       const tree = node('n_root', [node('n_not_loaded')]);
       const files = {
@@ -116,6 +159,8 @@ describe('EntityIndexService', () => {
         workflows: {},
         pipelines: {},
         stepBundles: {},
+        containers: {},
+        appEnvs: {},
       });
     });
 
@@ -124,6 +169,8 @@ describe('EntityIndexService', () => {
         workflows: {},
         pipelines: {},
         stepBundles: {},
+        containers: {},
+        appEnvs: {},
       });
     });
   });

--- a/source/javascripts/core/services/EntityIndexService.ts
+++ b/source/javascripts/core/services/EntityIndexService.ts
@@ -3,15 +3,18 @@ import { Document } from 'yaml';
 import { EntityDefinition, EntityIndex, EntityKind, TreeNode } from '@/core/models/Tree';
 import YmlUtils from '@/core/utils/YmlUtils';
 
-// YAML section key → EntityIndex key. step_bundles is camelCased in the index.
+// Map-shaped YAML sections (entity id → definition), generically indexed by the DFS below.
+// step_bundles is camelCased in the index; `containers` covers both execution and service
+// containers (one map, split by `type`). `app.envs` is array-shaped and handled separately.
 const KIND_SECTIONS: ReadonlyArray<{ section: string; key: EntityKind }> = [
   { section: 'workflows', key: 'workflows' },
   { section: 'pipelines', key: 'pipelines' },
   { section: 'step_bundles', key: 'stepBundles' },
+  { section: 'containers', key: 'containers' },
 ];
 
 function emptyEntityIndex(): EntityIndex {
-  return { workflows: {}, pipelines: {}, stepBundles: {} };
+  return { workflows: {}, pipelines: {}, stepBundles: {}, containers: {}, appEnvs: {} };
 }
 
 /** All places this entity is defined, in merge order (`[0]` = top-most). */
@@ -47,7 +50,21 @@ function buildFromFiles(tree: TreeNode | undefined, files: Record<string, { ymlD
           if (!entityId) {
             return;
           }
-          (index[key][entityId] ||= []).push({ nodeId: node.nodeId });
+          ((index[key] ??= {})[entityId] ||= []).push({ nodeId: node.nodeId });
+        });
+      });
+
+      // Project env vars are array-shaped (`app.envs: [{ KEY: value, opts? }]`), keyed by var name.
+      const envs = YmlUtils.getSeqIn(doc, ['app', 'envs']);
+      envs?.items.forEach((_item, i) => {
+        const envMap = YmlUtils.getMapIn(doc, ['app', 'envs', i]);
+        envMap?.items.forEach((pair) => {
+          const envKey = String(pair.key);
+          // The var name is the single non-`opts` key of the entry.
+          if (!envKey || envKey === 'opts') {
+            return;
+          }
+          ((index.appEnvs ??= {})[envKey] ||= []).push({ nodeId: node.nodeId });
         });
       });
     }
@@ -62,11 +79,15 @@ function buildFromFiles(tree: TreeNode | undefined, files: Record<string, { ymlD
   return index;
 }
 
-/** Shallow structural equality, so the store can skip no-op index updates. */
+/** Shallow structural equality, so the store can skip no-op index updates. Covers every kind (incl. appEnvs). */
 function equals(a: EntityIndex, b: EntityIndex): boolean {
-  return KIND_SECTIONS.every(({ key }) => {
-    const aEntries = a[key];
-    const bEntries = b[key];
+  const aKeys = Object.keys(a) as EntityKind[];
+  if (aKeys.length !== Object.keys(b).length) {
+    return false;
+  }
+  return aKeys.every((key) => {
+    const aEntries = a[key] ?? {};
+    const bEntries = b[key] ?? {};
     const aIds = Object.keys(aEntries);
     if (aIds.length !== Object.keys(bEntries).length) {
       return false;

--- a/source/javascripts/core/services/EntityIndexService.ts
+++ b/source/javascripts/core/services/EntityIndexService.ts
@@ -81,11 +81,11 @@ function buildFromFiles(tree: TreeNode | undefined, files: Record<string, { ymlD
 
 /** Shallow structural equality, so the store can skip no-op index updates. Covers every kind (incl. appEnvs). */
 function equals(a: EntityIndex, b: EntityIndex): boolean {
-  const aKeys = Object.keys(a) as EntityKind[];
-  if (aKeys.length !== Object.keys(b).length) {
-    return false;
-  }
-  return aKeys.every((key) => {
+  // Compare the union of keys so an optional kind (containers/appEnvs) missing on one side is
+  // treated as empty — a partial index stays equal to a full one whose extra kinds are empty,
+  // instead of a key-count check forcing a spurious "not equal" (and a redundant store update).
+  const keys = new Set<EntityKind>([...Object.keys(a), ...Object.keys(b)] as EntityKind[]);
+  return [...keys].every((key) => {
     const aEntries = a[key] ?? {};
     const bEntries = b[key] ?? {};
     const aIds = Object.keys(aEntries);

--- a/source/javascripts/core/stores/BitriseYmlStore.modular.spec.ts
+++ b/source/javascripts/core/stores/BitriseYmlStore.modular.spec.ts
@@ -8,6 +8,7 @@ import {
   closeTab,
   createFile,
   discardBitriseYmlDocument,
+  discardFile,
   getModularConfigTree,
   initializeBitriseYmlDocument,
   initializeModularConfig,
@@ -161,6 +162,47 @@ describe('BitriseYmlStore — modular tree', () => {
     });
   });
 
+  describe('discardFile', () => {
+    it('drops a session-created file and removes the include directive added for it', () => {
+      const result = createFile('modules/new.yml', 'root');
+      const nodeId = result.ok ? result.nodeId : '';
+      addInclude('root', { path: 'modules/new.yml' });
+      expect(bitriseYmlStore.getState().files[nodeId]).toBeDefined();
+
+      discardFile(nodeId);
+
+      const state = bitriseYmlStore.getState();
+      expect(state.files[nodeId]).toBeUndefined();
+      expect(state.tree?.includes.some((n) => n.nodeId === nodeId)).toBe(false);
+      expect(state.openTabs.some((t) => t.nodeId === nodeId)).toBe(false);
+      const rootIncludes = YmlUtils.getSeqIn(state.files.root!.ymlDocument, ['include'])?.toJSON() ?? [];
+      expect(rootIncludes).not.toContainEqual({ path: 'modules/new.yml' });
+    });
+
+    it('reverts an edited existing file to its saved baseline and closes its tab, keeping it in the tree', () => {
+      openTab('child-a', { preview: false });
+      updateFileDocument('child-a', ({ doc }) => {
+        YmlUtils.setIn(doc, ['workflows', 'child-a', 'title'], 'Edited');
+        return doc;
+      });
+      expect(isFileDirty(bitriseYmlStore.getState().files['child-a'])).toBe(true);
+
+      discardFile('child-a');
+
+      const state = bitriseYmlStore.getState();
+      expect(state.files['child-a']).toBeDefined();
+      expect(isFileDirty(state.files['child-a'])).toBe(false);
+      expect(state.tree?.includes.some((n) => n.nodeId === 'child-a')).toBe(true);
+      expect(state.openTabs.some((t) => t.nodeId === 'child-a')).toBe(false);
+    });
+
+    it('no-ops for an unknown node', () => {
+      const before = bitriseYmlStore.getState();
+      discardFile('does-not-exist');
+      expect(bitriseYmlStore.getState()).toBe(before);
+    });
+  });
+
   describe('initializeModularConfig', () => {
     it('flattens the tree into file slices keyed by node_id', () => {
       const { files } = bitriseYmlStore.getState();
@@ -185,6 +227,8 @@ describe('BitriseYmlStore — modular tree', () => {
         },
         pipelines: {},
         stepBundles: {},
+        containers: {},
+        appEnvs: {},
       });
     });
 
@@ -231,7 +275,7 @@ describe('BitriseYmlStore — modular tree', () => {
       expect(state.files).toEqual({});
       expect(state.openTabs).toEqual([]);
       expect(state.selectedNodeId).toBeUndefined();
-      expect(state.entityIndex).toEqual({ workflows: {}, pipelines: {}, stepBundles: {} });
+      expect(state.entityIndex).toEqual({ workflows: {}, pipelines: {}, stepBundles: {}, containers: {}, appEnvs: {} });
       expect(state.mergedYml).toBeUndefined();
       expect(state.savedMergedYml).toBeUndefined();
       // The single-file document is now the one the editor reads.

--- a/source/javascripts/core/stores/BitriseYmlStore.ts
+++ b/source/javascripts/core/stores/BitriseYmlStore.ts
@@ -763,6 +763,82 @@ export function closeTab(nodeId: string) {
   });
 }
 
+/**
+ * Discard a single file's unsaved changes and close its tab — the per-tab counterpart to
+ * {@link discardBitriseYmlDocument}. A session-created file (editable, no commit_sha ⇒ never on the
+ * branch) is dropped entirely, along with the `include:` directive that referenced it and any nested
+ * session-created includes; an edited existing file is reverted to its saved baseline and kept in
+ * the tree. No-ops for a non-modular doc (no file slice) or an unknown node.
+ */
+export function discardFile(nodeId: string) {
+  const state = bitriseYmlStore.getState();
+  const slice = state.files[nodeId];
+  if (!slice) {
+    return;
+  }
+
+  // Existing file: revert its edits, keep it in the tree, then close the tab.
+  if (!(slice.editable && !slice.commitSha)) {
+    bitriseYmlStore.setState({
+      files: { ...state.files, [nodeId]: { ...slice, ymlDocument: slice.savedYmlDocument } },
+      mergedYmlStale: true,
+    });
+    closeTab(nodeId);
+    return;
+  }
+
+  // Session-created file: remove the parent's `include:` entry that pointed at it (the inverse of the
+  // `addInclude` we ran on create), so discarding the file also discards the directive we added.
+  let parentNodeId: string | undefined;
+  TreeService.walk(state.tree, (node, parent) => {
+    if (node.nodeId === nodeId) {
+      parentNodeId = parent?.nodeId;
+    }
+  });
+  const parentSlice = parentNodeId ? state.files[parentNodeId] : undefined;
+  if (parentNodeId && parentSlice?.editable) {
+    updateFileDocument(parentNodeId, ({ doc }) => {
+      YmlUtils.deleteByPredicate(
+        doc,
+        ['include', '*'],
+        (_node, path) => YmlUtils.getMapIn(doc, path)?.get('path') === slice.path,
+      );
+      return doc;
+    });
+  }
+
+  // Then drop the file (and any nested session-created includes) from files + tree, and rebind the
+  // active document if one of the dropped tabs was active.
+  const dropNode = TreeService.findNode(state.tree, nodeId);
+  const dropIds = new Set(dropNode ? TreeService.flatten(dropNode).map((node) => node.nodeId) : [nodeId]);
+
+  // updateFileDocument above may have mutated files/openTabs — re-read before patching.
+  const next = bitriseYmlStore.getState();
+  const files: Record<string, FileSlice> = {};
+  Object.values(next.files).forEach((fileSlice) => {
+    if (!dropIds.has(fileSlice.nodeId)) {
+      files[fileSlice.nodeId] = fileSlice;
+    }
+  });
+  const tree = next.tree ? pruneNodes(next.tree, dropIds) : next.tree;
+  const closedIndex = next.openTabs.findIndex((tab) => dropIds.has(tab.nodeId));
+  const openTabs = next.openTabs.filter((tab) => !dropIds.has(tab.nodeId));
+
+  const activeDropped = !!next.selectedNodeId && dropIds.has(next.selectedNodeId);
+  const neighborNodeId = activeDropped ? (openTabs[closedIndex] ?? openTabs[closedIndex - 1])?.nodeId : undefined;
+  const selectionPatch = activeDropped
+    ? (neighborNodeId && activeFilePatch(neighborNodeId)) || mergedConfigPatch()
+    : {};
+
+  bitriseYmlStore.setState({
+    files,
+    tree,
+    openTabs,
+    ...selectionPatch,
+    mergedYmlStale: true,
+  });
+}
+
 export function setMergedConfig(mergedYml: string) {
   const { selectedNodeId, hasChanges } = bitriseYmlStore.getState();
   // A merge computed while nothing is dirty IS the saved baseline; while edits are pending it stays frozen.

--- a/source/javascripts/core/stores/BitriseYmlStore.ts
+++ b/source/javascripts/core/stores/BitriseYmlStore.ts
@@ -807,8 +807,9 @@ export function discardFile(nodeId: string) {
     });
   }
 
-  // Then drop the file (and any nested session-created includes) from files + tree, and rebind the
-  // active document if one of the dropped tabs was active.
+  // Then drop the file and the whole subtree it pulled in (its includes only exist because this
+  // session-created file referenced them) from files + tree, and rebind the active document if one
+  // of the dropped tabs was active.
   const dropNode = TreeService.findNode(state.tree, nodeId);
   const dropIds = new Set(dropNode ? TreeService.flatten(dropNode).map((node) => node.nodeId) : [nodeId]);
 

--- a/source/javascripts/hooks/useJumpToDefinition.ts
+++ b/source/javascripts/hooks/useJumpToDefinition.ts
@@ -12,9 +12,13 @@ const KIND_PATH: Record<EntityKind, string> = {
   workflows: paths.workflows,
   pipelines: paths.pipelines,
   stepBundles: paths.stepBundles,
+  containers: paths.containers,
+  appEnvs: paths.envVars,
 };
 
-const KIND_PARAM: Record<EntityKind, string> = {
+// Per-entity deep-link param. Container/appEnvs pages have no per-entity route param — opening the
+// defining file's tab (below) lands the user on the right page, so they have no entry here.
+const KIND_PARAM: Partial<Record<EntityKind, string>> = {
   workflows: 'workflow_id',
   pipelines: 'pipeline',
   stepBundles: 'step_bundle_id',
@@ -42,7 +46,11 @@ export default function useJumpToDefinition() {
 
       openTab(nodeId, { preview: false });
 
-      const params: Record<string, string> = { [KIND_PARAM[kind]]: id };
+      const params: Record<string, string> = {};
+      const param = KIND_PARAM[kind];
+      if (param) {
+        params[param] = id;
+      }
       if (searchParams.branch) {
         params.branch = searchParams.branch;
       }

--- a/source/javascripts/hooks/useTabs.ts
+++ b/source/javascripts/hooks/useTabs.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 import {
   bitriseYmlStore,
   closeTab,
+  discardFile,
   getTabLastLocation,
   isYmlPageLocation,
   MERGED_CONFIG_NODE_ID,
@@ -102,6 +103,19 @@ export function useTabs() {
     [restoreTabLocation],
   );
 
+  // Discard the file's unsaved edits and close its tab; rebinds + restores like closeTab.
+  const discardFileAndRestore = useCallback(
+    (nodeId: string) => {
+      const before = bitriseYmlStore.getState().selectedNodeId;
+      discardFile(nodeId);
+      const after = bitriseYmlStore.getState().selectedNodeId;
+      if (after && after !== before) {
+        restoreTabLocation(after);
+      }
+    },
+    [restoreTabLocation],
+  );
+
   return {
     tabs,
     activeTab,
@@ -110,6 +124,7 @@ export function useTabs() {
     selectTab,
     openFile,
     closeTab: closeTabAndRestore,
+    discardFile: discardFileAndRestore,
     selectMergedConfig: selectMerged,
   };
 }

--- a/source/javascripts/hooks/useTree.ts
+++ b/source/javascripts/hooks/useTree.ts
@@ -6,10 +6,16 @@ import TreeService from '@/core/services/TreeService';
 import { bitriseYmlStore, isFileDirty, MERGED_CONFIG_NODE_ID } from '@/core/stores/BitriseYmlStore';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
 
-const SECTION_BY_KIND: Record<EntityKind, 'workflows' | 'pipelines' | 'step_bundles'> = {
+// Map-keyed kinds → their top-level YAML section (for the local-definition check). `appEnvs` is
+// array-shaped (`app.envs`) and handled separately in useCrossFileEntity.
+const SECTION_BY_KIND: Record<
+  Exclude<EntityKind, 'appEnvs'>,
+  'workflows' | 'pipelines' | 'step_bundles' | 'containers'
+> = {
   workflows: 'workflows',
   pipelines: 'pipelines',
   stepBundles: 'step_bundles',
+  containers: 'containers',
 };
 
 /** The tree root, by reference. Walk it via `TreeService`. */
@@ -82,7 +88,10 @@ export type CrossFileEntityInfo = {
 /** Provenance for an entity: whether it's defined locally, in another file, and where. */
 export function useCrossFileEntity(kind: EntityKind, id: string): CrossFileEntityInfo {
   return useBitriseYmlStore((s) => {
-    const isLocal = Boolean(s.yml[SECTION_BY_KIND[kind]]?.[id]);
+    const isLocal =
+      kind === 'appEnvs'
+        ? Boolean(s.yml.app?.envs?.some((env) => env && id !== 'opts' && id in env))
+        : Boolean(s.yml[SECTION_BY_KIND[kind]]?.[id]);
     const nodeId = EntityIndexService.definingNodeId(s.entityIndex, kind, id);
     const hasDefinition = Boolean(nodeId);
     if (isLocal || !nodeId) {

--- a/source/javascripts/pages/YmlPage/components/OpenFileTabs/DiscardFileTabDialog.tsx
+++ b/source/javascripts/pages/YmlPage/components/OpenFileTabs/DiscardFileTabDialog.tsx
@@ -1,0 +1,35 @@
+import { BitkitButton, BitkitDialog } from '@bitrise/bitkit-v2';
+import { Text } from '@chakra-ui/react/text';
+
+type Props = {
+  isOpen: boolean;
+  fileName: string;
+  onKeepEditing: () => void;
+  onDiscard: () => void;
+};
+
+const DiscardFileTabDialog = ({ isOpen, fileName, onKeepEditing, onDiscard }: Props) => (
+  <BitkitDialog
+    title="Discard unsaved changes?"
+    open={isOpen}
+    onOpenChange={({ open }) => {
+      if (!open) onKeepEditing();
+    }}
+  >
+    <BitkitDialog.Body>
+      <Text>
+        Closing this tab discards your edits to <Text as="strong">{fileName}</Text>.
+      </Text>
+    </BitkitDialog.Body>
+    <BitkitDialog.Footer>
+      <BitkitDialog.Buttons>
+        <BitkitButton variant="secondary" onClick={onKeepEditing}>
+          Keep editing
+        </BitkitButton>
+        <BitkitButton onClick={onDiscard}>Discard and close</BitkitButton>
+      </BitkitDialog.Buttons>
+    </BitkitDialog.Footer>
+  </BitkitDialog>
+);
+
+export default DiscardFileTabDialog;

--- a/source/javascripts/pages/YmlPage/components/OpenFileTabs/DiscardFileTabDialog.tsx
+++ b/source/javascripts/pages/YmlPage/components/OpenFileTabs/DiscardFileTabDialog.tsx
@@ -26,7 +26,9 @@ const DiscardFileTabDialog = ({ isOpen, fileName, onKeepEditing, onDiscard }: Pr
         <BitkitButton variant="secondary" onClick={onKeepEditing}>
           Keep editing
         </BitkitButton>
-        <BitkitButton onClick={onDiscard}>Discard and close</BitkitButton>
+        <BitkitButton variant="danger-primary" onClick={onDiscard}>
+          Discard and close
+        </BitkitButton>
       </BitkitDialog.Buttons>
     </BitkitDialog.Footer>
   </BitkitDialog>

--- a/source/javascripts/pages/YmlPage/components/OpenFileTabs/FileTab.tsx
+++ b/source/javascripts/pages/YmlPage/components/OpenFileTabs/FileTab.tsx
@@ -1,20 +1,24 @@
 import { Tooltip } from '@bitrise/bitkit';
 import { BitkitTabs } from '@bitrise/bitkit-v2';
+import { useState } from 'react';
 
 import TreeService from '@/core/services/TreeService';
 import { useFile, useFileIsDirty } from '@/hooks/useFile';
 import { useTabs } from '@/hooks/useTabs';
 import { useTree } from '@/hooks/useTree';
 
+import DiscardFileTabDialog from './DiscardFileTabDialog';
+
 type Props = {
   nodeId: string;
 };
 
 const FileTab = ({ nodeId }: Props) => {
-  const { closeTab } = useTabs();
+  const { closeTab, discardFile } = useTabs();
   const file = useFile(nodeId);
   const isDirty = useFileIsDirty(nodeId);
   const tree = useTree();
+  const [isDiscardOpen, setIsDiscardOpen] = useState(false);
 
   if (!file) {
     return null;
@@ -24,17 +28,39 @@ const FileTab = ({ nodeId }: Props) => {
   // Own ref, or inherited from a cross-ref ancestor (path-only includes carry no source).
   const refLabel = TreeService.effectiveSourceLabel(tree, nodeId);
 
+  // Closing a tab with unsaved edits prompts first; a clean tab closes immediately.
+  const handleClose = () => {
+    if (isDirty) {
+      setIsDiscardOpen(true);
+    } else {
+      closeTab(nodeId);
+    }
+  };
+
   const trigger = (
-    <BitkitTabs.Trigger value={nodeId} changed={isDirty} onClose={() => closeTab(nodeId)}>
+    <BitkitTabs.Trigger value={nodeId} changed={isDirty} onClose={handleClose}>
       {name}
     </BitkitTabs.Trigger>
   );
 
-  if (!file.editable) {
-    return <Tooltip label={refLabel ? `Read-only — included from ${refLabel}` : 'Read-only'}>{trigger}</Tooltip>;
-  }
-
-  return trigger;
+  return (
+    <>
+      {file.editable ? (
+        trigger
+      ) : (
+        <Tooltip label={refLabel ? `Read-only — included from ${refLabel}` : 'Read-only'}>{trigger}</Tooltip>
+      )}
+      <DiscardFileTabDialog
+        isOpen={isDiscardOpen}
+        fileName={name}
+        onKeepEditing={() => setIsDiscardOpen(false)}
+        onDiscard={() => {
+          setIsDiscardOpen(false);
+          discardFile(nodeId);
+        }}
+      />
+    </>
+  );
 };
 
 export default FileTab;


### PR DESCRIPTION
Part of epic **BIVS-3664** (WFE: Modular YML editing support) — Jira **BIVS-3686**.

Foundation for the modular read-only / merged-view work. **Gated entirely behind the existing `enable-wfe-modular-yaml-editing` flag** (internal/dev only — no production impact).

### What's in here
- **Tab-close "Discard unsaved changes?" modal** — closing a dirty file tab prompts; confirming discards via a new `discardFile(nodeId)` store helper. A session-created file is dropped together with the `include:` directive added for it; an edited existing file is reverted to its saved baseline.
- **Entity-index extension** — `EntityIndex` gains `containers` (one map, exec+service split by `type`) and `appEnvs` (`app.envs`, keyed by var name). Live builder + wire parsing kept in parity; new kinds optional so older BE snapshots still parse.
- **Jump-to-definition** extended for `containers` + `appEnvs` (no per-entity route param → jump opens the defining file's tab).

### Testing
- New unit tests: container/app-env indexing + `discardFile` (new + edited file paths). Type-check, lint, and unit suites green.

> Pairs with the backend index change (BIVS-3687) in `bitrise-website`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)