### PR TITLE
feat(modular): Containers merged per-file grouping + read-only view-details + usage jump arrows [BIVS-3689]

### DIFF
--- a/source/javascripts/hooks/useTree.ts
+++ b/source/javascripts/hooks/useTree.ts
@@ -111,6 +111,43 @@ export function useCrossFileEntity(kind: EntityKind, id: string): CrossFileEntit
   });
 }
 
+export type FileEntityGroup = { nodeId: string; path: string; ids: string[] };
+
+/**
+ * Group entity ids by the file that defines them (top-most layer), in tree pre-order — for the merged
+ * view's per-file sections. Ids with no definition in the index are dropped. `ids` order is preserved
+ * within each group.
+ */
+export function useEntitiesGroupedByFile(kind: EntityKind, ids: string[]): FileEntityGroup[] {
+  return useBitriseYmlStore((s) => {
+    if (!s.tree) {
+      return [];
+    }
+    const byNode = new Map<string, string[]>();
+    ids.forEach((id) => {
+      const nodeId = EntityIndexService.definingNodeId(s.entityIndex, kind, id);
+      if (!nodeId) {
+        return;
+      }
+      const bucket = byNode.get(nodeId);
+      if (bucket) {
+        bucket.push(id);
+      } else {
+        byNode.set(nodeId, [id]);
+      }
+    });
+
+    const groups: FileEntityGroup[] = [];
+    TreeService.walk(s.tree, (node) => {
+      const groupIds = byNode.get(node.nodeId);
+      if (groupIds?.length) {
+        groups.push({ nodeId: node.nodeId, path: s.files[node.nodeId]?.path ?? node.path, ids: groupIds });
+      }
+    });
+    return groups;
+  });
+}
+
 export type RootMetaDefinition = { nodeId: string; path: string };
 
 /**

--- a/source/javascripts/pages/ContainersPage/components/ContainerUsageTable.tsx
+++ b/source/javascripts/pages/ContainersPage/components/ContainerUsageTable.tsx
@@ -1,6 +1,8 @@
 import { ControlButton, Table, Tbody, Td, Text, Th, Thead, Tr } from '@bitrise/bitkit';
 
+import CrossFileJumpButton from '@/components/JumpToDefinitionLink/CrossFileJumpButton';
 import useNavigation from '@/hooks/useNavigation';
+import { useTree } from '@/hooks/useTree';
 
 type Props = {
   workflows: string[];
@@ -8,6 +10,9 @@ type Props = {
 
 const ContainerUsageTable = ({ workflows }: Props) => {
   const { replace } = useNavigation();
+  // Modular: jump to the workflow's definition (opens its file tab, with a file picker when it's
+  // defined in several files). Non-modular: plain navigation to the Workflows page.
+  const isModular = Boolean(useTree());
 
   return (
     <Table isFixed variant="borderless" mt="24">
@@ -24,11 +29,15 @@ const ContainerUsageTable = ({ workflows }: Props) => {
               <Text textStyle="body/md/regular">{workflowId}</Text>
             </Td>
             <Td>
-              <ControlButton
-                aria-label="Go to Workflow"
-                iconName="ArrowNorthEast"
-                onClick={() => replace('/workflows', { workflow_id: workflowId })}
-              />
+              {isModular ? (
+                <CrossFileJumpButton kind="workflows" id={workflowId} />
+              ) : (
+                <ControlButton
+                  aria-label="Go to Workflow"
+                  iconName="ArrowNorthEast"
+                  onClick={() => replace('/workflows', { workflow_id: workflowId })}
+                />
+              )}
             </Td>
           </Tr>
         ))}

--- a/source/javascripts/pages/ContainersPage/components/ContainersTable.tsx
+++ b/source/javascripts/pages/ContainersPage/components/ContainersTable.tsx
@@ -107,33 +107,46 @@ const ContainersTable = ({
                   )}
                 </Td>
                 <Td textAlign="right">
-                  <ControlButton
-                    aria-label="Edit container"
-                    iconName="Pencil"
-                    color="icon/primary"
-                    isDisabled={isReadOnlyView}
-                    onClick={() => {
-                      setEditedContainer(container);
-                      openDialog();
-                    }}
-                    mr={['0', '8']}
-                  />
-                  <ControlButton
-                    aria-label="Delete container"
-                    iconName="MinusCircle"
-                    color="icon/negative"
-                    isDisabled={isReadOnlyView}
-                    onClick={() => {
-                      setSelectedContainerId(container.id);
-                      onDeleteContainerDialogOpen();
-                      segmentTrack('Container Usage Popup Shown', {
-                        app_slug: PageProps.appSlug(),
-                        workspace_slug: GlobalProps.workspaceSlug(),
-                        number_of_containers_in_use: workflowCount,
-                        source: 'container_deletion_dialog',
-                      });
-                    }}
-                  />
+                  {isReadOnlyView ? (
+                    // Merged/cross-file (read-only) view: edit + delete collapse to a single read-only detail view.
+                    <ControlButton
+                      aria-label="View container details"
+                      iconName="Details"
+                      color="icon/primary"
+                      onClick={() => {
+                        setEditedContainer(container);
+                        openDialog();
+                      }}
+                    />
+                  ) : (
+                    <>
+                      <ControlButton
+                        aria-label="Edit container"
+                        iconName="Pencil"
+                        color="icon/primary"
+                        onClick={() => {
+                          setEditedContainer(container);
+                          openDialog();
+                        }}
+                        mr={['0', '8']}
+                      />
+                      <ControlButton
+                        aria-label="Delete container"
+                        iconName="MinusCircle"
+                        color="icon/negative"
+                        onClick={() => {
+                          setSelectedContainerId(container.id);
+                          onDeleteContainerDialogOpen();
+                          segmentTrack('Container Usage Popup Shown', {
+                            app_slug: PageProps.appSlug(),
+                            workspace_slug: GlobalProps.workspaceSlug(),
+                            number_of_containers_in_use: workflowCount,
+                            source: 'container_deletion_dialog',
+                          });
+                        }}
+                      />
+                    </>
+                  )}
                 </Td>
               </Tr>
             );

--- a/source/javascripts/pages/ContainersPage/components/CreateOrEditContainerDialog.tsx
+++ b/source/javascripts/pages/ContainersPage/components/CreateOrEditContainerDialog.tsx
@@ -48,8 +48,16 @@ const CreateOrEditContainerDialog = (props: CreateOrEditContainerDialogProps) =>
   const { editedContainer, isOpen, onClose, onCloseComplete, type, readOnly = false } = props;
 
   const containerIds = useContainers().all.map((container) => container.id);
-  // In read-only "view details" mode, expand the extra options so everything is visible at a glance.
-  const { isOpen: isShowMore, onToggle } = useDisclosure({ defaultIsOpen: readOnly });
+  const { isOpen: isShowMore, onToggle, onOpen: expandShowMore } = useDisclosure();
+
+  // In read-only "view details" mode, expand the extra options on open so everything is visible at a
+  // glance. Done on each open (not via defaultIsOpen, which only applies on first mount) because the
+  // dialog stays mounted while `readOnly` can flip between editable and merged/cross-file views.
+  useEffect(() => {
+    if (isOpen && readOnly) {
+      expandShowMore();
+    }
+  }, [isOpen, readOnly, expandShowMore]);
 
   const { control, formState, handleSubmit, reset } = useForm<FormData>({
     defaultValues: {

--- a/source/javascripts/pages/ContainersPage/components/CreateOrEditContainerDialog.tsx
+++ b/source/javascripts/pages/ContainersPage/components/CreateOrEditContainerDialog.tsx
@@ -84,6 +84,12 @@ const CreateOrEditContainerDialog = (props: CreateOrEditContainerDialogProps) =>
   });
 
   const onSubmit = (formData: FormData) => {
+    // Read-only "view details" never mutates — guard here so no submit path (Enter key, an
+    // implicit form submit) can reach ContainerService even though the inputs are disabled.
+    if (readOnly) {
+      return;
+    }
+
     const convertedPorts = formData.userValues.ports
       .split(',')
       .map((port) => port.trim())

--- a/source/javascripts/pages/ContainersPage/components/CreateOrEditContainerDialog.tsx
+++ b/source/javascripts/pages/ContainersPage/components/CreateOrEditContainerDialog.tsx
@@ -33,6 +33,8 @@ import useContainers from '@/hooks/useContainers';
 type CreateOrEditContainerDialogProps = Omit<DialogProps, 'title'> & {
   editedContainer: Container | null;
   type: 'execution' | 'service';
+  /** Read-only "view details" mode (merged/cross-file view): every field disabled, no save. */
+  readOnly?: boolean;
 };
 
 type FormData = Omit<Container, 'userValues'> & {
@@ -43,10 +45,11 @@ type FormData = Omit<Container, 'userValues'> & {
 };
 
 const CreateOrEditContainerDialog = (props: CreateOrEditContainerDialogProps) => {
-  const { editedContainer, isOpen, onClose, onCloseComplete, type } = props;
+  const { editedContainer, isOpen, onClose, onCloseComplete, type, readOnly = false } = props;
 
   const containerIds = useContainers().all.map((container) => container.id);
-  const { isOpen: isShowMore, onToggle } = useDisclosure();
+  // In read-only "view details" mode, expand the extra options so everything is visible at a glance.
+  const { isOpen: isShowMore, onToggle } = useDisclosure({ defaultIsOpen: readOnly });
 
   const { control, formState, handleSubmit, reset } = useForm<FormData>({
     defaultValues: {
@@ -153,7 +156,13 @@ const CreateOrEditContainerDialog = (props: CreateOrEditContainerDialogProps) =>
 
   return (
     <Dialog
-      title={editedContainer ? `Edit ${type} container` : `Create ${type} container`}
+      title={
+        readOnly
+          ? `${type === 'execution' ? 'Execution' : 'Service'} container details`
+          : editedContainer
+            ? `Edit ${type} container`
+            : `Create ${type} container`
+      }
       isOpen={isOpen}
       onClose={onClose}
       onCloseComplete={() => {
@@ -178,6 +187,7 @@ const CreateOrEditContainerDialog = (props: CreateOrEditContainerDialogProps) =>
               placeholder="e.g. node, postgres, redis"
               errorText={formState.errors.id?.message}
               isRequired
+              isDisabled={readOnly}
               data-1p-ignore
               onChange={(e) => {
                 const sanitizedValue = ContainerService.sanitizeName(e.target.value);
@@ -198,6 +208,7 @@ const CreateOrEditContainerDialog = (props: CreateOrEditContainerDialogProps) =>
               placeholder="e.g. node:18-alpine, ghcr.io/your-github-user/your-private-image:v1.1"
               errorText={formState.errors.userValues?.image?.message}
               isRequired
+              isDisabled={readOnly}
               {...field}
             />
           )}
@@ -223,6 +234,7 @@ const CreateOrEditContainerDialog = (props: CreateOrEditContainerDialogProps) =>
               helperText="List of port mappings in the format of [HostPort01]:[ContainerPort01]. Separate multiple with commas."
               placeholder="e.g. 3000:3000, 5432:5432"
               errorText={formState.errors.userValues?.ports?.message}
+              isDisabled={readOnly}
               {...field}
             />
           )}
@@ -258,6 +270,7 @@ const CreateOrEditContainerDialog = (props: CreateOrEditContainerDialogProps) =>
                   label="Registry server"
                   helperText="Fully qualified registry server URL to be used by docker login command."
                   placeholder="e.g. ghcr.io"
+                  isDisabled={readOnly}
                   {...field}
                 />
               )}
@@ -265,12 +278,16 @@ const CreateOrEditContainerDialog = (props: CreateOrEditContainerDialogProps) =>
             <Controller
               control={control}
               name="userValues.credentials.username"
-              render={({ field }) => <StepInput label="Username" isSensitive size="lg" {...field} />}
+              render={({ field }) => (
+                <StepInput label="Username" isSensitive size="lg" isDisabled={readOnly} {...field} />
+              )}
             />
             <Controller
               control={control}
               name="userValues.credentials.password"
-              render={({ field }) => <StepInput label="Password" isSensitive size="lg" {...field} />}
+              render={({ field }) => (
+                <StepInput label="Password" isSensitive size="lg" isDisabled={readOnly} {...field} />
+              )}
             />
             <Divider mt="8" />
             {fields.map((item, index) => (
@@ -284,6 +301,7 @@ const CreateOrEditContainerDialog = (props: CreateOrEditContainerDialogProps) =>
                       placeholder="Key"
                       width="100%"
                       value={value || ''}
+                      isDisabled={readOnly}
                       {...fieldProps}
                     />
                   )}
@@ -292,35 +310,39 @@ const CreateOrEditContainerDialog = (props: CreateOrEditContainerDialogProps) =>
                   control={control}
                   name={`userValues.envs.${index}.value`}
                   render={({ field: { value, ...fieldProps } }) => (
-                    <Input placeholder="Value" width="100%" value={value || ''} {...fieldProps} />
+                    <Input placeholder="Value" width="100%" value={value || ''} isDisabled={readOnly} {...fieldProps} />
                   )}
                 />
-                <ButtonGroup>
-                  <EnvVarPopover
-                    size="lg"
-                    onSelect={(envVar) => update(index, { ...fields[index], value: `$${envVar.key}` })}
-                    showCreate={false}
-                  />
-                  <ControlButton
-                    iconName="Trash"
-                    isDanger
-                    isDisabled={fields.length === 1}
-                    size="lg"
-                    aria-label="Remove environment variable"
-                    onClick={() => remove(index)}
-                  />
-                </ButtonGroup>
+                {!readOnly && (
+                  <ButtonGroup>
+                    <EnvVarPopover
+                      size="lg"
+                      onSelect={(envVar) => update(index, { ...fields[index], value: `$${envVar.key}` })}
+                      showCreate={false}
+                    />
+                    <ControlButton
+                      iconName="Trash"
+                      isDanger
+                      isDisabled={fields.length === 1}
+                      size="lg"
+                      aria-label="Remove environment variable"
+                      onClick={() => remove(index)}
+                    />
+                  </ButtonGroup>
+                )}
               </Box>
             ))}
-            <Button
-              variant="tertiary"
-              leftIconName="Plus"
-              size="md"
-              width="fit-content"
-              onClick={() => append({ key: '', value: '', source: '' })}
-            >
-              Add Env Var
-            </Button>
+            {!readOnly && (
+              <Button
+                variant="tertiary"
+                leftIconName="Plus"
+                size="md"
+                width="fit-content"
+                onClick={() => append({ key: '', value: '', source: '' })}
+              >
+                Add Env Var
+              </Button>
+            )}
             <Divider />
             <Controller
               control={control}
@@ -341,6 +363,7 @@ const CreateOrEditContainerDialog = (props: CreateOrEditContainerDialogProps) =>
                     </>
                   }
                   placeholder='e.g. --privileged --health-cmd "redis-cli ping" --health-interval 1s --health-timeout 3s --health-retries 2'
+                  isDisabled={readOnly}
                   {...field}
                 />
               )}
@@ -352,12 +375,20 @@ const CreateOrEditContainerDialog = (props: CreateOrEditContainerDialogProps) =>
         </Link>
       </DialogBody>
       <DialogFooter>
-        <Button variant="secondary" onClick={onClose}>
-          Cancel
-        </Button>
-        <Button type="submit" isDisabled={!formState.isValid || !formState.isDirty}>
-          {editedContainer ? 'Save' : 'Create container'}
-        </Button>
+        {readOnly ? (
+          <Button variant="secondary" onClick={onClose}>
+            Close
+          </Button>
+        ) : (
+          <>
+            <Button variant="secondary" onClick={onClose}>
+              Cancel
+            </Button>
+            <Button type="submit" isDisabled={!formState.isValid || !formState.isDirty}>
+              {editedContainer ? 'Save' : 'Create container'}
+            </Button>
+          </>
+        )}
       </DialogFooter>
     </Dialog>
   );

--- a/source/javascripts/pages/ContainersPage/components/ExecutionContainersTab.tsx
+++ b/source/javascripts/pages/ContainersPage/components/ExecutionContainersTab.tsx
@@ -9,8 +9,8 @@ import useContainers from '@/hooks/useContainers';
 import useContainerWorkflowUsage from '@/hooks/useContainerWorkflowUsage';
 import { useIsReadOnlyView } from '@/hooks/useTree';
 
-import ContainersTable from './ContainersTable';
 import CreateOrEditContainerDialog from './CreateOrEditContainerDialog';
+import GroupedContainersTables from './GroupedContainersTables';
 
 const ExecutionContainersTab = () => {
   const isReadOnlyView = useIsReadOnlyView();
@@ -52,7 +52,7 @@ const ExecutionContainersTab = () => {
         </Button>
       </Box>
       {containers.length > 0 ? (
-        <ContainersTable
+        <GroupedContainersTables
           containers={containers}
           containerUsageLookup={containerUsageLookup}
           openDialog={onDialogOpen}
@@ -72,6 +72,7 @@ const ExecutionContainersTab = () => {
         onClose={onDialogClose}
         onCloseComplete={() => setEditedContainer(null)}
         type="execution"
+        readOnly={isReadOnlyView}
       />
     </>
   );

--- a/source/javascripts/pages/ContainersPage/components/GroupedContainersTables.tsx
+++ b/source/javascripts/pages/ContainersPage/components/GroupedContainersTables.tsx
@@ -1,0 +1,52 @@
+import { Box, Text } from '@bitrise/bitkit';
+
+import { Container, ContainerType } from '@/core/models/Container';
+import { useEntitiesGroupedByFile, useIsMergedConfigSelected } from '@/hooks/useTree';
+
+import ContainersTable from './ContainersTable';
+
+type Props = {
+  containers: Container[];
+  containerUsageLookup: Map<string, string[]>;
+  openDialog: () => void;
+  setEditedContainer: (value: Container | null) => void;
+  source: ContainerType;
+};
+
+/**
+ * Renders the containers as a single table (single module-file tab / non-modular), or — on the merged
+ * (Effective config) tab — one titled table per source file. `containers` is already scoped to the
+ * active document, so single-file tabs need no extra filtering.
+ */
+const GroupedContainersTables = ({ containers, ...tableProps }: Props) => {
+  const isMergedView = useIsMergedConfigSelected();
+  const groups = useEntitiesGroupedByFile(
+    'containers',
+    containers.map((container) => container.id),
+  );
+
+  // Single-file / non-modular, or a not-yet-built index: one plain table.
+  if (!isMergedView || groups.length === 0) {
+    return <ContainersTable containers={containers} {...tableProps} />;
+  }
+
+  const byId = new Map(containers.map((container) => [container.id, container]));
+
+  return (
+    <>
+      {groups.map((group) => (
+        <Box key={group.nodeId} marginBlockEnd="32">
+          <Text as="h3" textStyle="heading/h4" marginBlockEnd="12">
+            {group.path}
+          </Text>
+          <ContainersTable
+            containers={group.ids.map((id) => byId.get(id)).filter((c): c is Container => Boolean(c))}
+            {...tableProps}
+          />
+        </Box>
+      ))}
+    </>
+  );
+};
+
+export default GroupedContainersTables;

--- a/source/javascripts/pages/ContainersPage/components/ServiceContainersTab.tsx
+++ b/source/javascripts/pages/ContainersPage/components/ServiceContainersTab.tsx
@@ -9,8 +9,8 @@ import useContainers from '@/hooks/useContainers';
 import useContainerWorkflowUsage from '@/hooks/useContainerWorkflowUsage';
 import { useIsReadOnlyView } from '@/hooks/useTree';
 
-import ContainersTable from './ContainersTable';
 import CreateOrEditContainerDialog from './CreateOrEditContainerDialog';
+import GroupedContainersTables from './GroupedContainersTables';
 
 const ServiceContainersTab = () => {
   const isReadOnlyView = useIsReadOnlyView();
@@ -52,7 +52,7 @@ const ServiceContainersTab = () => {
         </Button>
       </Box>
       {containers.length > 0 ? (
-        <ContainersTable
+        <GroupedContainersTables
           containers={containers}
           containerUsageLookup={containerUsageLookup}
           openDialog={onDialogOpen}
@@ -72,6 +72,7 @@ const ServiceContainersTab = () => {
         onClose={onDialogClose}
         onCloseComplete={() => setEditedContainer(null)}
         type="service"
+        readOnly={isReadOnlyView}
       />
     </>
   );


### PR DESCRIPTION
Part of epic **BIVS-3664** — Jira **BIVS-3689**. Stacked on #1800 (stacks).

On the merged (Effective config) tab — gated by the modular path:
- **Per-file grouping**: `GroupedContainersTables` renders one titled table per source file (grouped via the new containers entity index, filtered by container type). Single module-file / non-modular tabs render one plain table.
- **View details**: in read-only views the edit + delete row actions collapse to a single "View details" (Details icon) opening `CreateOrEditContainerDialog` in a new `readOnly` mode — every field disabled, mutation controls hidden, footer is just Close, title "<Type> container details".
- **Usage modal arrows** jump to the using workflow's definition (file tab + multi-file picker) in modular mode; plain navigation otherwise.

**Non-modular path unchanged.**

> Review after #1800 merges (base will retarget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)