### PR TITLE
feat(modular): Triggers merged per-file grouping + read-only rows + jump-to-definition [BIVS-3690]

### DIFF
--- a/source/javascripts/hooks/useTargetBasedTriggers.ts
+++ b/source/javascripts/hooks/useTargetBasedTriggers.ts
@@ -58,6 +58,11 @@ function useTriggersGroupedByFile(triggers: TargetBasedTrigger[]): TriggerFileGr
       }
     });
 
+    // Nothing groupable (empty input or no indexed targets) → skip the O(tree) walk.
+    if (byNode.size === 0) {
+      return [];
+    }
+
     const groups: TriggerFileGroup[] = [];
     TreeService.walk(s.tree, (node) => {
       const groupTriggers = byNode.get(node.nodeId);

--- a/source/javascripts/hooks/useTargetBasedTriggers.ts
+++ b/source/javascripts/hooks/useTargetBasedTriggers.ts
@@ -1,7 +1,11 @@
 import { TargetBasedTrigger, TriggerSource } from '@/core/models/Trigger';
+import EntityIndexService from '@/core/services/EntityIndexService';
+import TreeService from '@/core/services/TreeService';
 import TriggerService from '@/core/services/TriggerService';
 
 import useBitriseYmlStore from './useBitriseYmlStore';
+
+export type TriggerFileGroup = { nodeId: string; path: string; triggers: TargetBasedTrigger[] };
 
 function useAllTargetBasedTriggers() {
   const pipelines = useBitriseYmlStore((state) => state.yml.pipelines || {});
@@ -29,5 +33,41 @@ function useTargetBasedTriggers(source: TriggerSource, sourceId: string) {
   };
 }
 
-export { useAllTargetBasedTriggers };
+/**
+ * Group triggers by the source file of their target workflow/pipeline (top-most defining layer), in
+ * tree pre-order — for the merged view's per-file sections. Triggers whose target isn't in the index
+ * are dropped. Input order is preserved within each group.
+ */
+function useTriggersGroupedByFile(triggers: TargetBasedTrigger[]): TriggerFileGroup[] {
+  return useBitriseYmlStore((s) => {
+    if (!s.tree) {
+      return [];
+    }
+    const byNode = new Map<string, TargetBasedTrigger[]>();
+    triggers.forEach((trigger) => {
+      const [source, sourceId] = trigger.source.split('#') as [TriggerSource, string];
+      const nodeId = EntityIndexService.definingNodeId(s.entityIndex, source, sourceId);
+      if (!nodeId) {
+        return;
+      }
+      const bucket = byNode.get(nodeId);
+      if (bucket) {
+        bucket.push(trigger);
+      } else {
+        byNode.set(nodeId, [trigger]);
+      }
+    });
+
+    const groups: TriggerFileGroup[] = [];
+    TreeService.walk(s.tree, (node) => {
+      const groupTriggers = byNode.get(node.nodeId);
+      if (groupTriggers?.length) {
+        groups.push({ nodeId: node.nodeId, path: s.files[node.nodeId]?.path ?? node.path, triggers: groupTriggers });
+      }
+    });
+    return groups;
+  });
+}
+
+export { useAllTargetBasedTriggers, useTriggersGroupedByFile };
 export default useTargetBasedTriggers;

--- a/source/javascripts/pages/TriggersPage/components/TargetBasedTriggers/TargetBasedTriggers.tsx
+++ b/source/javascripts/pages/TriggersPage/components/TargetBasedTriggers/TargetBasedTriggers.tsx
@@ -75,7 +75,8 @@ const TargetBasedTriggers = () => {
   }, [filteredTriggers, sortProps]);
 
   // Merged (read-only) view: group by the source file of each trigger's target.
-  const fileGroups = useTriggersGroupedByFile(sortedFilteredTriggers);
+  // Only group on the merged tab; elsewhere there's nothing to group, so skip the work entirely.
+  const fileGroups = useTriggersGroupedByFile(isMergedView ? sortedFilteredTriggers : []);
 
   const handleOpenDialog = (trigger: TargetBasedTrigger) => {
     setEditedItem(trigger);
@@ -111,7 +112,7 @@ const TargetBasedTriggers = () => {
     TriggerService.removeTrigger(trigger);
   };
 
-  const renderRow = (trigger: TargetBasedTrigger) => {
+  const renderRow = (trigger: TargetBasedTrigger, useJump: boolean) => {
     const [source, sourceId] = trigger.source.split('#') as [TriggerSource, string];
     return (
       <Tr key={JSON.stringify(trigger)}>
@@ -141,15 +142,18 @@ const TargetBasedTriggers = () => {
             >
               Active
             </Checkbox>
-            {isReadOnlyView ? (
-              // Merged/cross-file view: edit + delete collapse to a jump-to-definition arrow to the target.
+            {isReadOnlyView && useJump ? (
+              // Merged grouped view: edit + delete collapse to a jump-to-definition arrow to the target.
               <CrossFileJumpButton kind={source} id={sourceId} />
             ) : (
+              // Editable, or a read-only view without grouping data (cross-repo/ref file tab, or merged
+              // before the index is built) → keep edit + delete, disabled when read-only.
               <>
                 <IconButton
                   iconName="Pencil"
                   variant="tertiary"
                   aria-label="Edit trigger"
+                  isDisabled={isReadOnlyView}
                   onClick={() => handleOpenDialog(trigger)}
                 />
                 <IconButton
@@ -157,6 +161,7 @@ const TargetBasedTriggers = () => {
                   variant="tertiary"
                   iconName="MinusCircle"
                   aria-label="Delete trigger"
+                  isDisabled={isReadOnlyView}
                   onClick={() => handleDeleteTrigger(trigger)}
                 />
               </>
@@ -167,7 +172,7 @@ const TargetBasedTriggers = () => {
     );
   };
 
-  const renderTable = (triggers: TargetBasedTrigger[]) => (
+  const renderTable = (triggers: TargetBasedTrigger[], useJump: boolean) => (
     <TableContainer marginBlockEnd="32">
       <Table>
         <Thead>
@@ -194,7 +199,7 @@ const TargetBasedTriggers = () => {
             <Th />
           </Tr>
         </Thead>
-        <Tbody>{triggers.map(renderRow)}</Tbody>
+        <Tbody>{triggers.map((trigger) => renderRow(trigger, useJump))}</Tbody>
       </Table>
     </TableContainer>
   );
@@ -221,10 +226,10 @@ const TargetBasedTriggers = () => {
                   <Text as="h3" textStyle="heading/h4" marginBlockEnd="12">
                     {group.path}
                   </Text>
-                  {renderTable(group.triggers)}
+                  {renderTable(group.triggers, true)}
                 </Box>
               ))
-            : renderTable(sortedFilteredTriggers)}
+            : renderTable(sortedFilteredTriggers, false)}
         </>
       ) : (
         <EmptyState

--- a/source/javascripts/pages/TriggersPage/components/TargetBasedTriggers/TargetBasedTriggers.tsx
+++ b/source/javascripts/pages/TriggersPage/components/TargetBasedTriggers/TargetBasedTriggers.tsx
@@ -16,18 +16,20 @@ import {
 } from '@bitrise/bitkit';
 import { AriaAttributes, useMemo, useState } from 'react';
 
+import CrossFileJumpButton from '@/components/JumpToDefinitionLink/CrossFileJumpButton';
 import AddOrEditTriggerDialog from '@/components/unified-editor/Triggers/TargetBasedTriggers/AddOrEditTriggerDialog';
 import TriggerConditions from '@/components/unified-editor/Triggers/TriggerConditions';
 import { trackEditTrigger, trackTriggerEnabledToggled } from '@/core/analytics/TriggerAnalytics';
 import { TargetBasedTrigger, TriggerSource, TriggerType, TYPE_MAP } from '@/core/models/Trigger';
 import TriggerService from '@/core/services/TriggerService';
-import { useAllTargetBasedTriggers } from '@/hooks/useTargetBasedTriggers';
-import { useIsReadOnlyView } from '@/hooks/useTree';
+import { useAllTargetBasedTriggers, useTriggersGroupedByFile } from '@/hooks/useTargetBasedTriggers';
+import { useIsMergedConfigSelected, useIsReadOnlyView } from '@/hooks/useTree';
 
 import AddTriggerButton from './AddTriggerButton';
 
 const TargetBasedTriggers = () => {
   const isReadOnlyView = useIsReadOnlyView();
+  const isMergedView = useIsMergedConfigSelected();
   const [triggerType, setTriggerType] = useState<TriggerType | null>(null);
   const [editedItem, setEditedItem] = useState<TargetBasedTrigger | undefined>(undefined);
 
@@ -72,6 +74,9 @@ const TargetBasedTriggers = () => {
     });
   }, [filteredTriggers, sortProps]);
 
+  // Merged (read-only) view: group by the source file of each trigger's target.
+  const fileGroups = useTriggersGroupedByFile(sortedFilteredTriggers);
+
   const handleOpenDialog = (trigger: TargetBasedTrigger) => {
     setEditedItem(trigger);
     setTriggerType(trigger.triggerType);
@@ -106,6 +111,94 @@ const TargetBasedTriggers = () => {
     TriggerService.removeTrigger(trigger);
   };
 
+  const renderRow = (trigger: TargetBasedTrigger) => {
+    const [source, sourceId] = trigger.source.split('#') as [TriggerSource, string];
+    return (
+      <Tr key={JSON.stringify(trigger)}>
+        <Td>
+          <Text>{sourceId}</Text>
+          <Text textStyle="body/md/regular" color="text/secondary">
+            {source === 'workflows' ? 'Workflow' : 'Pipeline'}
+          </Text>
+        </Td>
+        <Td>{TYPE_MAP[trigger.triggerType]}</Td>
+        <Td>
+          <TriggerConditions
+            conditions={trigger.conditions}
+            isDraftPr={trigger.isDraftPr}
+            priority={trigger.priority}
+            triggerType={trigger.triggerType}
+            triggerDisabled={!trigger.isActive || !trigger.isTriggersModelActive}
+          />
+        </Td>
+        <Td display="flex" justifyContent="flex-end" alignItems="center">
+          <Box display="flex" alignItems="center">
+            <Checkbox
+              marginRight="16"
+              isChecked={trigger.isActive}
+              isDisabled={isReadOnlyView}
+              onChange={() => handleActiveChange(trigger)}
+            >
+              Active
+            </Checkbox>
+            {isReadOnlyView ? (
+              // Merged/cross-file view: edit + delete collapse to a jump-to-definition arrow to the target.
+              <CrossFileJumpButton kind={source} id={sourceId} />
+            ) : (
+              <>
+                <IconButton
+                  iconName="Pencil"
+                  variant="tertiary"
+                  aria-label="Edit trigger"
+                  onClick={() => handleOpenDialog(trigger)}
+                />
+                <IconButton
+                  isDanger
+                  variant="tertiary"
+                  iconName="MinusCircle"
+                  aria-label="Delete trigger"
+                  onClick={() => handleDeleteTrigger(trigger)}
+                />
+              </>
+            )}
+          </Box>
+        </Td>
+      </Tr>
+    );
+  };
+
+  const renderTable = (triggers: TargetBasedTrigger[]) => (
+    <TableContainer marginBlockEnd="32">
+      <Table>
+        <Thead>
+          <Tr>
+            <Th
+              isSortable
+              onSortClick={(sortDirection) => {
+                setSortProps({ direction: sortDirection, condition: 'sourceId' });
+              }}
+              sortedBy={sortProps.condition === 'sourceId' ? sortProps.direction : undefined}
+            >
+              Target
+            </Th>
+            <Th
+              isSortable
+              onSortClick={(sortDirection) => {
+                setSortProps({ direction: sortDirection, condition: 'triggerType' });
+              }}
+              sortedBy={sortProps.condition === 'triggerType' ? sortProps.direction : undefined}
+            >
+              Type
+            </Th>
+            <Th>Conditions</Th>
+            <Th />
+          </Tr>
+        </Thead>
+        <Tbody>{triggers.map(renderRow)}</Tbody>
+      </Table>
+    </TableContainer>
+  );
+
   return (
     <>
       {pipelineableTriggers.length > 0 ? (
@@ -122,86 +215,16 @@ const TargetBasedTriggers = () => {
             />
             <AddTriggerButton onAddTrigger={setTriggerType} />
           </Box>
-          <TableContainer marginBlockEnd="32">
-            <Table>
-              <Thead>
-                <Tr>
-                  <Th
-                    isSortable
-                    onSortClick={(sortDirection) => {
-                      setSortProps({ direction: sortDirection, condition: 'sourceId' });
-                    }}
-                    sortedBy={sortProps.condition === 'sourceId' ? sortProps.direction : undefined}
-                  >
-                    Target
-                  </Th>
-                  <Th
-                    isSortable
-                    onSortClick={(sortDirection) => {
-                      setSortProps({ direction: sortDirection, condition: 'triggerType' });
-                    }}
-                    sortedBy={sortProps.condition === 'triggerType' ? sortProps.direction : undefined}
-                  >
-                    Type
-                  </Th>
-                  <Th>Conditions</Th>
-                  <Th />
-                </Tr>
-              </Thead>
-              <Tbody>
-                {sortedFilteredTriggers.map((trigger) => {
-                  const [source, sourceId] = trigger.source.split('#') as [TriggerSource, string];
-                  return (
-                    <Tr key={JSON.stringify(trigger)}>
-                      <Td>
-                        <Text>{sourceId}</Text>
-                        <Text textStyle="body/md/regular" color="text/secondary">
-                          {source === 'workflows' ? 'Workflow' : 'Pipeline'}
-                        </Text>
-                      </Td>
-                      <Td>{TYPE_MAP[trigger.triggerType]}</Td>
-                      <Td>
-                        <TriggerConditions
-                          conditions={trigger.conditions}
-                          isDraftPr={trigger.isDraftPr}
-                          priority={trigger.priority}
-                          triggerType={trigger.triggerType}
-                          triggerDisabled={!trigger.isActive || !trigger.isTriggersModelActive}
-                        />
-                      </Td>
-                      <Td display="flex" justifyContent="flex-end" alignItems="center">
-                        <Box display="flex" alignItems="center">
-                          <Checkbox
-                            marginRight="16"
-                            isChecked={trigger.isActive}
-                            isDisabled={isReadOnlyView}
-                            onChange={() => handleActiveChange(trigger)}
-                          >
-                            Active
-                          </Checkbox>
-                          <IconButton
-                            iconName="Pencil"
-                            variant="tertiary"
-                            aria-label="Edit trigger"
-                            isDisabled={isReadOnlyView}
-                            onClick={() => handleOpenDialog(trigger)}
-                          />
-                          <IconButton
-                            isDanger
-                            variant="tertiary"
-                            iconName="MinusCircle"
-                            aria-label="Delete trigger"
-                            isDisabled={isReadOnlyView}
-                            onClick={() => handleDeleteTrigger(trigger)}
-                          />
-                        </Box>
-                      </Td>
-                    </Tr>
-                  );
-                })}
-              </Tbody>
-            </Table>
-          </TableContainer>
+          {isMergedView && fileGroups.length > 0
+            ? fileGroups.map((group) => (
+                <Box key={group.nodeId}>
+                  <Text as="h3" textStyle="heading/h4" marginBlockEnd="12">
+                    {group.path}
+                  </Text>
+                  {renderTable(group.triggers)}
+                </Box>
+              ))
+            : renderTable(sortedFilteredTriggers)}
         </>
       ) : (
         <EmptyState


### PR DESCRIPTION
Part of epic **BIVS-3664** — Jira **BIVS-3690**. Stacked on #1801 (containers).

On the merged (Effective config) tab — gated by the modular path:
- Group triggers by the source file of their target workflow/pipeline (`useTriggersGroupedByFile`, tree pre-order), one titled table per file.
- Per row: the **Active** toggle is disabled and edit + delete collapse to a single jump-to-definition arrow to the target (multi-file picker via the workflows/pipelines index).

Single module-file / non-modular tabs render the existing single sortable/filterable table, editable. **Non-modular path unchanged.**

> Review after the parent PRs merge (base retargets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)