### PR TITLE
feat(modular): Env Vars merged per-file grouping + read-only rows + jump-to-definition [BIVS-3691]

### DIFF
--- a/source/javascripts/components/JumpToDefinitionLink/JumpToFileButton.tsx
+++ b/source/javascripts/components/JumpToDefinitionLink/JumpToFileButton.tsx
@@ -1,0 +1,41 @@
+import { ControlButton } from '@bitrise/bitkit';
+
+import { openTab } from '@/core/stores/BitriseYmlStore';
+import { useTree } from '@/hooks/useTree';
+
+import FilePickerPopover from './FilePickerPopover';
+
+type Props = {
+  nodeId: string;
+};
+
+/**
+ * Jump to a known file's tab via a confirm popover. Used by per-file grouped views where the target
+ * file is unambiguous (e.g. env var groups) — unlike {@link JumpToDefinitionLink}'s entity-index
+ * picker, this is scoped to the one file, but still opens the popover so the user sees which file
+ * they'll jump to (and can decide) before committing.
+ */
+const JumpToFileButton = ({ nodeId }: Props) => {
+  const tree = useTree();
+  if (!tree) {
+    return null;
+  }
+
+  return (
+    <FilePickerPopover
+      rootNode={tree}
+      nodeIds={[nodeId]}
+      onSelect={(id) => openTab(id, { preview: false })}
+      trigger={
+        <ControlButton
+          size="xs"
+          iconName="ArrowNorthEast"
+          aria-label="Go to definition"
+          tooltipProps={{ 'aria-label': 'Go to definition' }}
+        />
+      }
+    />
+  );
+};
+
+export default JumpToFileButton;

--- a/source/javascripts/components/JumpToDefinitionLink/JumpToFileButton.tsx
+++ b/source/javascripts/components/JumpToDefinitionLink/JumpToFileButton.tsx
@@ -1,6 +1,6 @@
 import { ControlButton } from '@bitrise/bitkit';
 
-import { openTab } from '@/core/stores/BitriseYmlStore';
+import { openTab, recordActiveTabLocation } from '@/core/stores/BitriseYmlStore';
 import { useTree } from '@/hooks/useTree';
 
 import FilePickerPopover from './FilePickerPopover';
@@ -25,7 +25,12 @@ const JumpToFileButton = ({ nodeId }: Props) => {
     <FilePickerPopover
       rootNode={tree}
       nodeIds={[nodeId]}
-      onSelect={(id) => openTab(id, { preview: false })}
+      onSelect={(id) => {
+        // Record the current tab's page before switching, so returning to it (e.g. the merged tab)
+        // restores the right page — mirrors useJumpToDefinition.
+        recordActiveTabLocation(window.parent.location.hash);
+        openTab(id, { preview: false });
+      }}
       trigger={
         <ControlButton
           size="xs"

--- a/source/javascripts/components/SortableEnvVars/SortableEnvVarItem.tsx
+++ b/source/javascripts/components/SortableEnvVars/SortableEnvVarItem.tsx
@@ -1,7 +1,7 @@
 import { Box, Checkbox, ControlButton, Input, Text } from '@bitrise/bitkit';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import { useState } from 'react';
+import { ReactNode, useState } from 'react';
 
 import AutoGrowableInput from '@/components/AutoGrowableInput';
 import DragHandle from '@/components/DragHandle/DragHandle';
@@ -20,6 +20,8 @@ export type SortableEnvVarItemProps = {
   onKeyChange?: (key: string) => void;
   onValueChange?: (value: string) => void;
   onIsExpandChange?: (isExpand: boolean) => void;
+  /** Read-only views: a jump-to-definition arrow rendered in place of the remove button. */
+  jumpButton?: ReactNode;
 };
 
 const SortableEnvVarItem = ({
@@ -29,6 +31,7 @@ const SortableEnvVarItem = ({
   onKeyChange,
   onValueChange,
   onIsExpandChange,
+  jumpButton,
 }: SortableEnvVarItemProps) => {
   const isReadOnlyView = useIsReadOnlyView();
   const sortable = useSortable({ id: env.uniqueId, data: env, disabled: isReadOnlyView });
@@ -108,16 +111,20 @@ const SortableEnvVarItem = ({
             formControlProps={{ flex: 1 }}
             onChange={(e) => handleValueChange(e.target.value)}
           />
-          <ControlButton
-            isDanger
-            ml="8"
-            size="md"
-            aria-label="Remove"
-            iconName="MinusCircle"
-            isDisabled={isReadOnlyView}
-            tooltipProps={{ 'aria-label': 'Remove' }}
-            onClick={() => onRemove?.()}
-          />
+          {isReadOnlyView && jumpButton ? (
+            <Box ml="8">{jumpButton}</Box>
+          ) : (
+            <ControlButton
+              isDanger
+              ml="8"
+              size="md"
+              aria-label="Remove"
+              iconName="MinusCircle"
+              isDisabled={isReadOnlyView}
+              tooltipProps={{ 'aria-label': 'Remove' }}
+              onClick={() => onRemove?.()}
+            />
+          )}
         </Box>
         <Checkbox
           isChecked={env.isExpand !== false}

--- a/source/javascripts/components/SortableEnvVars/SortableEnvVars.tsx
+++ b/source/javascripts/components/SortableEnvVars/SortableEnvVars.tsx
@@ -2,12 +2,12 @@ import { Box, BoxProps, Button } from '@bitrise/bitkit';
 import { DndContext, DragOverlay } from '@dnd-kit/core';
 import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifiers';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
-import { useEffect } from 'react';
+import { ReactNode, useEffect } from 'react';
 
-import { EnvVarSource } from '@/core/models/EnvVar';
+import { EnvVar, EnvVarSource } from '@/core/models/EnvVar';
 import { useIsReadOnlyView } from '@/hooks/useTree';
 
-import SortableEnvVarItem from './SortableEnvVarItem';
+import SortableEnvVarItem, { SortableEnvVar } from './SortableEnvVarItem';
 import { useSortableEnvVars } from './useSortableEnvVars';
 
 export type SortableEnvVarsProps = {
@@ -17,6 +17,10 @@ export type SortableEnvVarsProps = {
   listenForExternalChanges?: boolean;
   hideAddButton?: boolean;
   onValidationErrorsChange?: (errorCount: number) => void;
+  /** Display these env vars instead of reading from the store (merged read-only per-file grouping). */
+  initialEnvs?: EnvVar[];
+  /** Read-only views: render a jump-to-definition arrow per row in place of the remove button. */
+  renderJumpButton?: (env: SortableEnvVar) => ReactNode;
 };
 
 const SortableEnvVars = ({
@@ -26,6 +30,8 @@ const SortableEnvVars = ({
   listenForExternalChanges = false,
   hideAddButton = false,
   onValidationErrorsChange,
+  initialEnvs,
+  renderJumpButton,
 }: SortableEnvVarsProps) => {
   const isReadOnlyView = useIsReadOnlyView();
   const {
@@ -40,7 +46,7 @@ const SortableEnvVars = ({
     onValueChange,
     onIsExpandChange,
     countValidationErrors,
-  } = useSortableEnvVars({ source, sourceId, listenForExternalChanges });
+  } = useSortableEnvVars({ source, sourceId, listenForExternalChanges, initialEnvs });
 
   useEffect(() => {
     if (onValidationErrorsChange) {
@@ -66,6 +72,7 @@ const SortableEnvVars = ({
               onKeyChange={onKeyChange(index)}
               onValueChange={onValueChange(index)}
               onIsExpandChange={onIsExpandChange(index)}
+              jumpButton={renderJumpButton?.(env)}
             />
           ))}
         </SortableContext>

--- a/source/javascripts/components/SortableEnvVars/SortableEnvVars.tsx
+++ b/source/javascripts/components/SortableEnvVars/SortableEnvVars.tsx
@@ -72,7 +72,7 @@ const SortableEnvVars = ({
               onKeyChange={onKeyChange(index)}
               onValueChange={onValueChange(index)}
               onIsExpandChange={onIsExpandChange(index)}
-              jumpButton={renderJumpButton?.(env)}
+              jumpButton={isReadOnlyView ? renderJumpButton?.(env) : undefined}
             />
           ))}
         </SortableContext>

--- a/source/javascripts/components/SortableEnvVars/useSortableEnvVars.ts
+++ b/source/javascripts/components/SortableEnvVars/useSortableEnvVars.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 import { useDebounceCallback } from 'usehooks-ts';
 
 import { SortableEnvVar } from '@/components/SortableEnvVars/SortableEnvVarItem';
-import { EnvVarSource } from '@/core/models/EnvVar';
+import { EnvVar, EnvVarSource } from '@/core/models/EnvVar';
 import EnvVarService from '@/core/services/EnvVarService';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
 
@@ -14,9 +14,17 @@ type UseSortableEnvVarsProps = {
   source: EnvVarSource;
   sourceId?: string;
   listenForExternalChanges?: boolean;
+  /** Pre-resolved env vars to display instead of reading from the store — used by the merged read-only
+   * per-file grouping (where the list comes from a specific file, not the active document). */
+  initialEnvs?: EnvVar[];
 };
 
-export const useSortableEnvVars = ({ source, sourceId, listenForExternalChanges = false }: UseSortableEnvVarsProps) => {
+export const useSortableEnvVars = ({
+  source,
+  sourceId,
+  listenForExternalChanges = false,
+  initialEnvs,
+}: UseSortableEnvVarsProps) => {
   const [activeItem, setActiveItem] = useState<SortableEnvVar>();
   const [envs, setEnvs] = useState<SortableEnvVar[]>([]);
   // In modular YAML mode the same `sourceId` can exist in multiple files, so the active
@@ -27,13 +35,14 @@ export const useSortableEnvVars = ({ source, sourceId, listenForExternalChanges 
   const updateValueDebounced = useDebounceCallback(EnvVarService.updateValue, 250, { leading: false });
 
   useEffect(() => {
+    const base = initialEnvs ?? EnvVarService.getAll(source, sourceId || '');
     setEnvs(
-      EnvVarService.getAll(source, sourceId || '').map((env) => ({
+      base.map((env) => ({
         ...env,
         uniqueId: crypto.randomUUID(),
       })),
     );
-  }, [source, sourceId, activeFileId]);
+  }, [source, sourceId, activeFileId, initialEnvs]);
 
   useEffect(() => {
     if (!listenForExternalChanges) return;

--- a/source/javascripts/components/SortableEnvVars/useSortableEnvVars.ts
+++ b/source/javascripts/components/SortableEnvVars/useSortableEnvVars.ts
@@ -34,6 +34,10 @@ export const useSortableEnvVars = ({
   const updateKeyDebounced = useDebounceCallback(EnvVarService.updateKey, 250, { leading: false });
   const updateValueDebounced = useDebounceCallback(EnvVarService.updateValue, 250, { leading: false });
 
+  // `initialEnvs` is fixed to a specific file, so the active-file change must not re-seed it;
+  // only re-seed on active-file changes when the list is read from the store.
+  const reseedFileId = initialEnvs ? undefined : activeFileId;
+
   useEffect(() => {
     const base = initialEnvs ?? EnvVarService.getAll(source, sourceId || '');
     setEnvs(
@@ -42,7 +46,7 @@ export const useSortableEnvVars = ({
         uniqueId: crypto.randomUUID(),
       })),
     );
-  }, [source, sourceId, activeFileId, initialEnvs]);
+  }, [source, sourceId, reseedFileId, initialEnvs]);
 
   useEffect(() => {
     if (!listenForExternalChanges) return;

--- a/source/javascripts/pages/EnvVarsPage/components/EnvVarsTable.tsx
+++ b/source/javascripts/pages/EnvVarsPage/components/EnvVarsTable.tsx
@@ -1,7 +1,9 @@
 import { Box, Card, Text } from '@bitrise/bitkit';
+import { ReactNode } from 'react';
 
+import { SortableEnvVar } from '@/components/SortableEnvVars/SortableEnvVarItem';
 import SortableEnvVars from '@/components/SortableEnvVars/SortableEnvVars';
-import { EnvVarSource } from '@/core/models/EnvVar';
+import { EnvVar, EnvVarSource } from '@/core/models/EnvVar';
 
 const EnvVarsTableHeader = () => {
   return (
@@ -29,14 +31,23 @@ const EnvVarsTableHeader = () => {
 type Props = {
   source: EnvVarSource;
   sourceId?: string;
+  initialEnvs?: EnvVar[];
+  hideAddButton?: boolean;
+  renderJumpButton?: (env: SortableEnvVar) => ReactNode;
 };
 
-const EnvVarsTable = ({ source, sourceId }: Props) => {
+const EnvVarsTable = ({ source, sourceId, initialEnvs, hideAddButton, renderJumpButton }: Props) => {
   return (
     <Card as="section" variant="outline">
       <EnvVarsTableHeader />
       <Box>
-        <SortableEnvVars source={source} sourceId={sourceId} />
+        <SortableEnvVars
+          source={source}
+          sourceId={sourceId}
+          initialEnvs={initialEnvs}
+          hideAddButton={hideAddButton}
+          renderJumpButton={renderJumpButton}
+        />
       </Box>
     </Card>
   );

--- a/source/javascripts/pages/EnvVarsPage/tabs/ProjectTab.tsx
+++ b/source/javascripts/pages/EnvVarsPage/tabs/ProjectTab.tsx
@@ -33,7 +33,7 @@ const ProjectTab = () => {
               source={EnvVarSource.App}
               initialEnvs={group.envs}
               hideAddButton
-              renderJumpButton={() => <JumpToFileButton nodeId={group.nodeId} />}
+              renderJumpButton={(_env) => <JumpToFileButton nodeId={group.nodeId} />}
             />
           </Fragment>
         ))

--- a/source/javascripts/pages/EnvVarsPage/tabs/ProjectTab.tsx
+++ b/source/javascripts/pages/EnvVarsPage/tabs/ProjectTab.tsx
@@ -1,11 +1,20 @@
+import { Text } from '@bitrise/bitkit';
+import { Fragment } from 'react/jsx-runtime';
+
+import CrossFileJumpButton from '@/components/JumpToDefinitionLink/CrossFileJumpButton';
 import TabContainer from '@/components/tabs/TabContainer';
 import TabHeader from '@/components/tabs/TabHeader';
 import { EnvVarSource } from '@/core/models/EnvVar';
+import { useIsMergedConfigSelected } from '@/hooks/useTree';
 
 import EnvVarsTable from '../components/EnvVarsTable';
 import PrivateInfoNotification from '../components/PrivateInfoNotification';
+import { useProjectEnvVarFileGroups } from '../useProjectEnvVarFileGroups';
 
 const ProjectTab = () => {
+  const isMergedView = useIsMergedConfigSelected();
+  const fileGroups = useProjectEnvVarFileGroups();
+
   return (
     <TabContainer>
       <PrivateInfoNotification />
@@ -13,7 +22,24 @@ const ProjectTab = () => {
         title="Project Environment Variables"
         subtitle="Variables will also be available in builds triggered by pull requests"
       />
-      <EnvVarsTable source={EnvVarSource.App} />
+      {isMergedView && fileGroups.length > 0 ? (
+        // Merged (read-only) view: one table per source file, with per-row jump-to-definition arrows.
+        fileGroups.map((group) => (
+          <Fragment key={group.nodeId}>
+            <Text as="h3" textStyle="heading/h3">
+              {group.path}
+            </Text>
+            <EnvVarsTable
+              source={EnvVarSource.App}
+              initialEnvs={group.envs}
+              hideAddButton
+              renderJumpButton={(env) => <CrossFileJumpButton kind="appEnvs" id={env.key} />}
+            />
+          </Fragment>
+        ))
+      ) : (
+        <EnvVarsTable source={EnvVarSource.App} />
+      )}
     </TabContainer>
   );
 };

--- a/source/javascripts/pages/EnvVarsPage/tabs/ProjectTab.tsx
+++ b/source/javascripts/pages/EnvVarsPage/tabs/ProjectTab.tsx
@@ -1,7 +1,7 @@
 import { Text } from '@bitrise/bitkit';
 import { Fragment } from 'react/jsx-runtime';
 
-import CrossFileJumpButton from '@/components/JumpToDefinitionLink/CrossFileJumpButton';
+import JumpToFileButton from '@/components/JumpToDefinitionLink/JumpToFileButton';
 import TabContainer from '@/components/tabs/TabContainer';
 import TabHeader from '@/components/tabs/TabHeader';
 import { EnvVarSource } from '@/core/models/EnvVar';
@@ -33,7 +33,7 @@ const ProjectTab = () => {
               source={EnvVarSource.App}
               initialEnvs={group.envs}
               hideAddButton
-              renderJumpButton={(env) => <CrossFileJumpButton kind="appEnvs" id={env.key} />}
+              renderJumpButton={() => <JumpToFileButton nodeId={group.nodeId} />}
             />
           </Fragment>
         ))

--- a/source/javascripts/pages/EnvVarsPage/tabs/WorkflowsTab.tsx
+++ b/source/javascripts/pages/EnvVarsPage/tabs/WorkflowsTab.tsx
@@ -36,7 +36,7 @@ const MergedWorkflowsTab = () => {
             sourceId={group.workflowId}
             initialEnvs={group.envs}
             hideAddButton
-            renderJumpButton={() => <JumpToFileButton nodeId={group.nodeId} />}
+            renderJumpButton={(_env) => <JumpToFileButton nodeId={group.nodeId} />}
           />
           {groups.length - 1 > index && <Divider />}
         </Fragment>

--- a/source/javascripts/pages/EnvVarsPage/tabs/WorkflowsTab.tsx
+++ b/source/javascripts/pages/EnvVarsPage/tabs/WorkflowsTab.tsx
@@ -1,52 +1,69 @@
 import { Box, Divider, Text } from '@bitrise/bitkit';
 import { Fragment } from 'react/jsx-runtime';
 
-import CrossFileJumpButton from '@/components/JumpToDefinitionLink/CrossFileJumpButton';
+import JumpToFileButton from '@/components/JumpToDefinitionLink/JumpToFileButton';
 import TabContainer from '@/components/tabs/TabContainer';
 import TabHeader from '@/components/tabs/TabHeader';
 import { EnvVarSource } from '@/core/models/EnvVar';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
-import { useDefiningFilePath, useIsMergedConfigSelected } from '@/hooks/useTree';
+import { useIsMergedConfigSelected } from '@/hooks/useTree';
 
 import EnvVarsTable from '../components/EnvVarsTable';
 import PrivateInfoNotification from '../components/PrivateInfoNotification';
+import { useWorkflowEnvVarFileGroups } from '../useProjectEnvVarFileGroups';
 
-type SectionProps = {
-  workflowId: string;
-  isMergedView: boolean;
-  showDivider: boolean;
-};
-
-const WorkflowEnvVarsSection = ({ workflowId, isMergedView, showDivider }: SectionProps) => {
-  const definingPath = useDefiningFilePath('workflows', workflowId);
+const MergedWorkflowsTab = () => {
+  // One section per (workflow, source file) that actually has env vars — no empty tables, and the
+  // arrow jumps straight to the file the vars live in.
+  const groups = useWorkflowEnvVarFileGroups();
 
   return (
     <>
-      <Box display="flex" alignItems="flex-start" justifyContent="space-between" gap="8">
-        <Box>
+      {groups.map((group, index) => (
+        <Fragment key={`${group.workflowId}@${group.nodeId}`}>
+          <Box display="flex" alignItems="flex-start" justifyContent="space-between" gap="8">
+            <Box>
+              <Text as="h3" textStyle="heading/h3">
+                {group.workflowId}
+              </Text>
+              <Text textStyle="body/sm/regular" color="text/secondary">
+                Defined in {group.path}
+              </Text>
+            </Box>
+          </Box>
+          <EnvVarsTable
+            source={EnvVarSource.Workflows}
+            sourceId={group.workflowId}
+            initialEnvs={group.envs}
+            hideAddButton
+            renderJumpButton={() => <JumpToFileButton nodeId={group.nodeId} />}
+          />
+          {groups.length - 1 > index && <Divider />}
+        </Fragment>
+      ))}
+    </>
+  );
+};
+
+const EditableWorkflowsTab = () => {
+  const workflowIds = useBitriseYmlStore((state) => Object.keys(state.yml.workflows ?? {}));
+
+  return (
+    <>
+      {workflowIds.map((workflowId, index) => (
+        <Fragment key={workflowId}>
           <Text as="h3" textStyle="heading/h3">
             {workflowId}
           </Text>
-          {isMergedView && definingPath && (
-            <Text textStyle="body/sm/regular" color="text/secondary">
-              Defined in {definingPath}
-            </Text>
-          )}
-        </Box>
-      </Box>
-      <EnvVarsTable
-        source={EnvVarSource.Workflows}
-        sourceId={workflowId}
-        hideAddButton={isMergedView}
-        renderJumpButton={isMergedView ? () => <CrossFileJumpButton kind="workflows" id={workflowId} /> : undefined}
-      />
-      {showDivider && <Divider />}
+          <EnvVarsTable source={EnvVarSource.Workflows} sourceId={workflowId} />
+          {workflowIds.length - 1 > index && <Divider />}
+        </Fragment>
+      ))}
     </>
   );
 };
 
 const WorkflowsTab = () => {
-  const workflowIds = useBitriseYmlStore((state) => Object.keys(state.yml.workflows ?? {}));
   const isMergedView = useIsMergedConfigSelected();
 
   return (
@@ -56,15 +73,7 @@ const WorkflowsTab = () => {
         title="Workflows' environment variables"
         subtitle="Env Vars exclusive to the Steps within the Workflow they are defined in"
       />
-      {workflowIds.map((workflowId, index) => (
-        <Fragment key={workflowId}>
-          <WorkflowEnvVarsSection
-            workflowId={workflowId}
-            isMergedView={isMergedView}
-            showDivider={workflowIds.length - 1 > index}
-          />
-        </Fragment>
-      ))}
+      {isMergedView ? <MergedWorkflowsTab /> : <EditableWorkflowsTab />}
     </TabContainer>
   );
 };

--- a/source/javascripts/pages/EnvVarsPage/tabs/WorkflowsTab.tsx
+++ b/source/javascripts/pages/EnvVarsPage/tabs/WorkflowsTab.tsx
@@ -1,16 +1,53 @@
-import { Divider, Text } from '@bitrise/bitkit';
+import { Box, Divider, Text } from '@bitrise/bitkit';
 import { Fragment } from 'react/jsx-runtime';
 
+import CrossFileJumpButton from '@/components/JumpToDefinitionLink/CrossFileJumpButton';
 import TabContainer from '@/components/tabs/TabContainer';
 import TabHeader from '@/components/tabs/TabHeader';
 import { EnvVarSource } from '@/core/models/EnvVar';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
+import { useDefiningFilePath, useIsMergedConfigSelected } from '@/hooks/useTree';
 
 import EnvVarsTable from '../components/EnvVarsTable';
 import PrivateInfoNotification from '../components/PrivateInfoNotification';
 
+type SectionProps = {
+  workflowId: string;
+  isMergedView: boolean;
+  showDivider: boolean;
+};
+
+const WorkflowEnvVarsSection = ({ workflowId, isMergedView, showDivider }: SectionProps) => {
+  const definingPath = useDefiningFilePath('workflows', workflowId);
+
+  return (
+    <>
+      <Box display="flex" alignItems="flex-start" justifyContent="space-between" gap="8">
+        <Box>
+          <Text as="h3" textStyle="heading/h3">
+            {workflowId}
+          </Text>
+          {isMergedView && definingPath && (
+            <Text textStyle="body/sm/regular" color="text/secondary">
+              Defined in {definingPath}
+            </Text>
+          )}
+        </Box>
+      </Box>
+      <EnvVarsTable
+        source={EnvVarSource.Workflows}
+        sourceId={workflowId}
+        hideAddButton={isMergedView}
+        renderJumpButton={isMergedView ? () => <CrossFileJumpButton kind="workflows" id={workflowId} /> : undefined}
+      />
+      {showDivider && <Divider />}
+    </>
+  );
+};
+
 const WorkflowsTab = () => {
   const workflowIds = useBitriseYmlStore((state) => Object.keys(state.yml.workflows ?? {}));
+  const isMergedView = useIsMergedConfigSelected();
 
   return (
     <TabContainer>
@@ -21,11 +58,11 @@ const WorkflowsTab = () => {
       />
       {workflowIds.map((workflowId, index) => (
         <Fragment key={workflowId}>
-          <Text as="h3" textStyle="heading/h3">
-            {workflowId}
-          </Text>
-          <EnvVarsTable source={EnvVarSource.Workflows} sourceId={workflowId} />
-          {workflowIds.length - 1 > index && <Divider />}
+          <WorkflowEnvVarsSection
+            workflowId={workflowId}
+            isMergedView={isMergedView}
+            showDivider={workflowIds.length - 1 > index}
+          />
         </Fragment>
       ))}
     </TabContainer>

--- a/source/javascripts/pages/EnvVarsPage/useProjectEnvVarFileGroups.ts
+++ b/source/javascripts/pages/EnvVarsPage/useProjectEnvVarFileGroups.ts
@@ -1,0 +1,35 @@
+import { EnvVar } from '@/core/models/EnvVar';
+import EnvVarService from '@/core/services/EnvVarService';
+import TreeService from '@/core/services/TreeService';
+import YmlUtils from '@/core/utils/YmlUtils';
+import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
+
+export type ProjectEnvVarFileGroup = { nodeId: string; path: string; envs: EnvVar[] };
+
+/**
+ * Project env vars (`app.envs`) grouped by the file that defines them, in tree pre-order — for the
+ * merged view's per-file sections. Reads each file's own `app.envs` directly (not the merged array),
+ * so files that contribute project env vars each get their own group.
+ */
+export function useProjectEnvVarFileGroups(): ProjectEnvVarFileGroup[] {
+  return useBitriseYmlStore((s) => {
+    if (!s.tree) {
+      return [];
+    }
+    const groups: ProjectEnvVarFileGroup[] = [];
+    TreeService.walk(s.tree, (node) => {
+      const doc = s.files[node.nodeId]?.ymlDocument;
+      if (!doc) {
+        return;
+      }
+      const json = YmlUtils.toJSON(doc) as { app?: { envs?: unknown[] } } | undefined;
+      const rawEnvs = json?.app?.envs;
+      if (!Array.isArray(rawEnvs) || rawEnvs.length === 0) {
+        return;
+      }
+      const envs = rawEnvs.map((env) => EnvVarService.fromYml(env as never, 'Project envs'));
+      groups.push({ nodeId: node.nodeId, path: s.files[node.nodeId]?.path ?? node.path, envs });
+    });
+    return groups;
+  });
+}

--- a/source/javascripts/pages/EnvVarsPage/useProjectEnvVarFileGroups.ts
+++ b/source/javascripts/pages/EnvVarsPage/useProjectEnvVarFileGroups.ts
@@ -6,6 +6,8 @@ import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
 
 export type ProjectEnvVarFileGroup = { nodeId: string; path: string; envs: EnvVar[] };
 
+export type WorkflowEnvVarFileGroup = { nodeId: string; path: string; workflowId: string; envs: EnvVar[] };
+
 /**
  * Project env vars (`app.envs`) grouped by the file that defines them, in tree pre-order — for the
  * merged view's per-file sections. Reads each file's own `app.envs` directly (not the merged array),
@@ -29,6 +31,57 @@ export function useProjectEnvVarFileGroups(): ProjectEnvVarFileGroup[] {
       }
       const envs = rawEnvs.map((env) => EnvVarService.fromYml(env as never, 'Project envs'));
       groups.push({ nodeId: node.nodeId, path: s.files[node.nodeId]?.path ?? node.path, envs });
+    });
+    return groups;
+  });
+}
+
+/**
+ * Workflow env vars grouped per (workflow, source file) — for the merged view's Workflows tab. Each
+ * group reads that file's *own* `workflows.<id>.envs` (not the merged list), so the jump arrow points
+ * to the exact file the vars live in, and workflows/files without env vars produce no (empty) group.
+ * Ordered workflow-major (active-doc workflow order), then by tree pre-order within each workflow.
+ */
+export function useWorkflowEnvVarFileGroups(): WorkflowEnvVarFileGroup[] {
+  return useBitriseYmlStore((s) => {
+    if (!s.tree) {
+      return [];
+    }
+
+    // Parse each file's own workflow→envs once.
+    const perFile = new Map<string, { path: string; byWorkflow: Record<string, EnvVar[]> }>();
+    TreeService.walk(s.tree, (node) => {
+      const doc = s.files[node.nodeId]?.ymlDocument;
+      if (!doc) {
+        return;
+      }
+      const json = YmlUtils.toJSON(doc) as { workflows?: Record<string, { envs?: unknown[] }> } | undefined;
+      const workflows = json?.workflows;
+      if (!workflows) {
+        return;
+      }
+      const byWorkflow: Record<string, EnvVar[]> = {};
+      Object.entries(workflows).forEach(([workflowId, workflow]) => {
+        const rawEnvs = workflow?.envs;
+        if (Array.isArray(rawEnvs) && rawEnvs.length > 0) {
+          byWorkflow[workflowId] = rawEnvs.map((env) => EnvVarService.fromYml(env as never, `Workflow: ${workflowId}`));
+        }
+      });
+      if (Object.keys(byWorkflow).length > 0) {
+        perFile.set(node.nodeId, { path: s.files[node.nodeId]?.path ?? node.path, byWorkflow });
+      }
+    });
+
+    const fileOrder = Array.from(perFile.keys());
+    const groups: WorkflowEnvVarFileGroup[] = [];
+    Object.keys(s.yml.workflows ?? {}).forEach((workflowId) => {
+      fileOrder.forEach((nodeId) => {
+        const file = perFile.get(nodeId);
+        const envs = file?.byWorkflow[workflowId];
+        if (file && envs) {
+          groups.push({ nodeId, path: file.path, workflowId, envs });
+        }
+      });
     });
     return groups;
   });

--- a/source/javascripts/pages/EnvVarsPage/useProjectEnvVarFileGroups.ts
+++ b/source/javascripts/pages/EnvVarsPage/useProjectEnvVarFileGroups.ts
@@ -28,8 +28,8 @@ export function useProjectEnvVarFileGroups(): ProjectEnvVarFileGroup[] {
       if (!doc) {
         return;
       }
-      const json = YmlUtils.toJSON(doc) as { app?: { envs?: unknown[] } } | undefined;
-      const rawEnvs = json?.app?.envs;
+      // Read just the `app.envs` subtree, not the whole document.
+      const rawEnvs = YmlUtils.getSeqIn(doc, ['app', 'envs'])?.toJSON() as unknown[] | undefined;
       if (!Array.isArray(rawEnvs) || rawEnvs.length === 0) {
         return;
       }
@@ -60,8 +60,10 @@ export function useWorkflowEnvVarFileGroups(): WorkflowEnvVarFileGroup[] {
       if (!doc) {
         return;
       }
-      const json = YmlUtils.toJSON(doc) as { workflows?: Record<string, { envs?: unknown[] }> } | undefined;
-      const workflows = json?.workflows;
+      // Read just the `workflows` subtree, not the whole document.
+      const workflows = YmlUtils.getMapIn(doc, ['workflows'])?.toJSON() as
+        | Record<string, { envs?: unknown[] }>
+        | undefined;
       if (!workflows) {
         return;
       }

--- a/source/javascripts/pages/EnvVarsPage/useProjectEnvVarFileGroups.ts
+++ b/source/javascripts/pages/EnvVarsPage/useProjectEnvVarFileGroups.ts
@@ -1,8 +1,11 @@
 import { EnvVar } from '@/core/models/EnvVar';
 import EnvVarService from '@/core/services/EnvVarService';
 import TreeService from '@/core/services/TreeService';
+import { MERGED_CONFIG_NODE_ID } from '@/core/stores/BitriseYmlStore';
 import YmlUtils from '@/core/utils/YmlUtils';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
+
+type FromYmlEnv = Parameters<typeof EnvVarService.fromYml>[0];
 
 export type ProjectEnvVarFileGroup = { nodeId: string; path: string; envs: EnvVar[] };
 
@@ -15,7 +18,8 @@ export type WorkflowEnvVarFileGroup = { nodeId: string; path: string; workflowId
  */
 export function useProjectEnvVarFileGroups(): ProjectEnvVarFileGroup[] {
   return useBitriseYmlStore((s) => {
-    if (!s.tree) {
+    // Per-file grouping is only shown on the merged-config tab; skip the tree walk + YAML parsing otherwise.
+    if (!s.tree || s.selectedNodeId !== MERGED_CONFIG_NODE_ID) {
       return [];
     }
     const groups: ProjectEnvVarFileGroup[] = [];
@@ -29,7 +33,7 @@ export function useProjectEnvVarFileGroups(): ProjectEnvVarFileGroup[] {
       if (!Array.isArray(rawEnvs) || rawEnvs.length === 0) {
         return;
       }
-      const envs = rawEnvs.map((env) => EnvVarService.fromYml(env as never, 'Project envs'));
+      const envs = rawEnvs.map((env) => EnvVarService.fromYml(env as FromYmlEnv, 'Project envs'));
       groups.push({ nodeId: node.nodeId, path: s.files[node.nodeId]?.path ?? node.path, envs });
     });
     return groups;
@@ -44,7 +48,8 @@ export function useProjectEnvVarFileGroups(): ProjectEnvVarFileGroup[] {
  */
 export function useWorkflowEnvVarFileGroups(): WorkflowEnvVarFileGroup[] {
   return useBitriseYmlStore((s) => {
-    if (!s.tree) {
+    // Per-file grouping is only shown on the merged-config tab; skip the tree walk + YAML parsing otherwise.
+    if (!s.tree || s.selectedNodeId !== MERGED_CONFIG_NODE_ID) {
       return [];
     }
 
@@ -64,7 +69,9 @@ export function useWorkflowEnvVarFileGroups(): WorkflowEnvVarFileGroup[] {
       Object.entries(workflows).forEach(([workflowId, workflow]) => {
         const rawEnvs = workflow?.envs;
         if (Array.isArray(rawEnvs) && rawEnvs.length > 0) {
-          byWorkflow[workflowId] = rawEnvs.map((env) => EnvVarService.fromYml(env as never, `Workflow: ${workflowId}`));
+          byWorkflow[workflowId] = rawEnvs.map((env) =>
+            EnvVarService.fromYml(env as FromYmlEnv, `Workflow: ${workflowId}`),
+          );
         }
       });
       if (Object.keys(byWorkflow).length > 0) {


### PR DESCRIPTION
Part of epic **BIVS-3664** — Jira **BIVS-3691**. Stacked on #1802 (triggers). Final screen in the stack.

On the merged (Effective config) tab — gated by the modular path:
- **Project tab**: group `app.envs` by source file (`useProjectEnvVarFileGroups` reads each file's own `app.envs` in tree order), one titled table per file with per-row arrows (kind `appEnvs`).
- **Workflows tab**: each workflow shows "Defined in {file}" provenance + per-row arrows (kind `workflows`).
- `SortableEnvVars` / `SortableEnvVarItem` gain optional `initialEnvs` + `renderJumpButton`; in read-only the arrow replaces the remove button. **Defaults preserve existing behaviour**, so the workflow/step-bundle drawer usages are unchanged.

Single module-file / non-modular tabs render the existing editable tables.

> Review after the parent PRs merge (base retargets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)