### PR TITLE
Fix Configuration YAML storage dialog overflow

### DIFF
--- a/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
+++ b/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
@@ -486,6 +486,8 @@ const ConfigurationYmlSourceDialog = ({ isOpen, onClose }: ConfigurationYmlStora
   return (
     <BitkitDialog
       title="Configuration YAML storage"
+      scrollBehavior="inside"
+      showScrollGradient={false}
       open={isOpen}
       onOpenChange={({ open }) => {
         if (!open) onClose();


### PR DESCRIPTION
## Summary

The **Configuration YAML storage** dialog could grow taller than the viewport, overflowing the screen so the footer buttons (Cancel / Validate and save) were cut off with no way to scroll to them.

## Changes

- Set `scrollBehavior="inside"` on the `BitkitDialog` so the dialog is height-capped to the viewport — the header and footer stay pinned and only the body scrolls.
- Set `showScrollGradient={false}` to remove the fade gradient at the bottom of the scroll area.

## Test plan

- Open the Configuration YAML storage dialog and select **Git repository** so the full task list renders.
- On a short viewport, confirm the dialog stays within the screen, the body scrolls, and the footer buttons remain visible and clickable.
- Confirm no fade gradient appears at the bottom of the scroll area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)