### PR TITLE
chore: add .mcp.json (Bitkit Storybook + Chakra UI MCP servers)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "bitkit-storybook-mcp": {
+      "type": "http",
+      "url": "https://storybook.services.bitrise.dev/projects/bitkit-v2/production/mcp"
+    },
+    "chakra-ui": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@chakra-ui/react-mcp@2.1.1"],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## What

Checks in the project-level `.mcp.json` so every teammate (and Claude Code) gets the same MCP servers configured automatically when working in this repo.

| Server | Transport | Purpose |
|--------|-----------|---------|
| `bitkit-storybook-mcp` | HTTP | Authoritative `@bitrise/bitkit-v2` component/token docs (props, variants, tokens, examples). |
| `chakra-ui` | stdio (`npx`) | Chakra UI v3 docs/props for the underlying primitives. |

## Why

`bitkit-v2/AGENTS.md` mandates using the Bitkit Storybook MCP before generating Bitkit code — hallucinated props/tokens are the #1 failure mode. Checking the config in removes the per-developer setup step.

Note: the `bitkit-storybook-mcp` URL is deliberately an MCP endpoint that needs **no** Google auth (unlike the browser Storybook), so it works headless and in CI-adjacent contexts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)