### PR TITLE
Fix error notification in Configuration YAML dialog

### DIFF
--- a/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
+++ b/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
@@ -486,6 +486,8 @@ const ConfigurationYmlSourceDialog = ({ isOpen, onClose }: ConfigurationYmlStora
   return (
     <BitkitDialog
       title="Configuration YAML storage"
+      scrollBehavior="inside"
+      showScrollGradient={false}
       open={isOpen}
       onOpenChange={({ open }) => {
         if (!open) onClose();


### PR DESCRIPTION
## Summary

Migrates the Configuration YAML dialog's error notification from the legacy `@bitrise/bitkit` `Notification` to the `@bitrise/bitkit-v2` `BitkitAlert`, and fixes the dialog layout so the error notification no longer overflows.

## Changes

- **`YmlDialogErrorNotification`**: replaced legacy `Notification` with `BitkitAlert`
  - `status="error"` → `variant="critical"`
  - notification body → `messageText`; the bold "Split configuration requires an Enterprise plan" heading is now a proper `titleText` instead of a manual bold `<Text>`
  - the `action` (`href`/`label`/`target`) shape carries over unchanged
- **`ConfigurationYmlStorageDialog`**: moved the error notification out of `BitkitDialog.Body` into `BitkitDialog.Footer` so it renders correctly without overflowing the dialog body

## Test plan

- [ ] Trigger a save/load error in the Configuration YAML dialog and confirm the `BitkitAlert` renders with the correct error message
- [ ] Verify the 404 case shows the "Couldn't find the bitrise.yml file…" message
- [ ] Verify the "Split configuration requires an Enterprise plan" case shows the title + "Contact us" action button linking to bitrise.io/contact
- [ ] Confirm the notification no longer overflows the dialog
