### PR TITLE
fix: don't build the modular config tree for Bitrise-stored configs

### DIFF
--- a/source/javascripts/main.tsx
+++ b/source/javascripts/main.tsx
@@ -97,23 +97,33 @@ const InitialDataLoader = ({ children }: PropsWithChildren) => {
   const loadedBranch = useRef<string | undefined | null>(null);
   const hasChanges = useYmlHasChanges();
   const [searchParams] = useSearchParams();
-  const requestedBranch = RuntimeUtils.isWebsiteMode() ? searchParams.branch : undefined;
+  const isWebsiteMode = RuntimeUtils.isWebsiteMode();
+  const requestedBranch = isWebsiteMode ? searchParams.branch : undefined;
 
-  const { data: ymlSettings } = useCiConfigSettings();
+  const { data: ymlSettings, isPending: isYmlSettingsPending } = useCiConfigSettings();
   useYmlLanguageServices();
   useCloseAIDrawer();
 
-  // Modular flag: off → legacy single-file `GET /config`; on → tree-based config (a
-  // non-modular config is just a single-node tree).
-  const isModularEnabled = useFeatureFlag('enable-wfe-modular-yaml-editing');
+  // Modular editing only makes sense for repo-stored configs (where includes/modules can
+  // exist). A Bitrise-stored config can't have modules, so even with the flag on it must
+  // use the legacy single-file flow — otherwise we'd build a tree (and show file tabs) for
+  // a config that has none. CLI mode has no Bitrise storage, so the flag alone decides there.
+  const isModularFlagEnabled = useFeatureFlag('enable-wfe-modular-yaml-editing');
+  const canBeModular = !isWebsiteMode || ymlSettings?.usesRepositoryYml === true;
+  const isModularEnabled = isModularFlagEnabled && canBeModular;
+
+  // In website mode with the flag on, the storage type decides which endpoint to hit, so
+  // wait for the settings to resolve before fetching (don't fire the tree query then switch
+  // to legacy once it turns out to be Bitrise-stored). Flag off or CLI → decide immediately.
+  const isStorageKnown = !(isModularFlagEnabled && isWebsiteMode) || !isYmlSettingsPending;
 
   const legacyConfig = useGetCiConfig(
     { projectSlug: PageProps.appSlug(), skipValidation: true, branch: requestedBranch },
-    { enabled: !isModularEnabled },
+    { enabled: isStorageKnown && !isModularEnabled },
   );
   const treeConfig = useGetCiConfigTree(
     { projectSlug: PageProps.appSlug(), branch: requestedBranch },
-    { enabled: isModularEnabled },
+    { enabled: isStorageKnown && isModularEnabled },
   );
 
   const { data, error, refetch } = isModularEnabled ? treeConfig : legacyConfig;


### PR DESCRIPTION
## Bug

With the modular-YAML feature enabled (`enable-wfe-modular-yaml-editing`, incl. the dev override), a config **stored on Bitrise** still showed the modular file tabs ("Merged Config", "bitrise.yml", "+") — even though a Bitrise-stored config can't have includes/modules, so the tabs are meaningless there.

## Root cause

In `main.tsx` the modular path was gated **only on the feature flag**:

```ts
const isModularEnabled = useFeatureFlag('enable-wfe-modular-yaml-editing');
```

When on, it always fetched the tree config and called `initializeModularConfig`, which builds a `tree` (root `bitrise.yml` node + Merged Config) **regardless of storage**. Everything downstream (file tabs, `MainLayout`, etc.) keys off `store.tree`, so the tabs appeared for Bitrise-stored configs too. It's not a new file being created — it's an in-memory tree that shouldn't exist for non-repo configs.

## Fix

Gate the modular path on repo storage as well — in website mode it now also requires `usesRepositoryYml`:

```ts
const canBeModular = !isWebsiteMode || ymlSettings?.usesRepositoryYml === true;
const isModularEnabled = isModularFlagEnabled && canBeModular;
```

So a Bitrise-stored config falls back to the **legacy single-file flow** (no tree, no tabs) — i.e. it behaves as if modular editing weren't enabled, which is the intended behavior.

Because storage type (`usesRepositoryYml`) loads asynchronously, when the flag is on in website mode we wait for the settings to resolve before choosing the config endpoint, so we don't fire the tree query and then switch to legacy once it turns out to be Bitrise-stored. **Flag-off and CLI paths are unchanged** and fetch immediately as before; unknown/errored settings default to legacy.

## Testing
- `npm run lint` — clean
- `tsc --noEmit` — clean
- No unit/smoke tests cover this init path; the fix is best verified manually: flag on + Bitrise-stored → no tabs (legacy); flag on + repo-stored → tabs as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)