### PR TITLE
Fix error notification in Configuration YAML dialog

### DIFF
--- a/source/javascripts/components/unified-editor/UpdateConfigurationDialog/YmlDialogErrorNotification.tsx
+++ b/source/javascripts/components/unified-editor/UpdateConfigurationDialog/YmlDialogErrorNotification.tsx
@@ -1,4 +1,4 @@
-import { Notification, NotificationProps, Text } from '@bitrise/bitkit';
+import { BitkitAlert, BitkitAlertProps } from '@bitrise/bitkit-v2';
 import { ReactNode } from 'react';
 
 import { ClientError } from '@/core/api/client';
@@ -11,19 +11,16 @@ const YmlDialogErrorNotification = (props: Props) => {
   const { error } = props;
   const message = error?.getResponseErrorMessage() || error?.message || 'Unknown error occurred';
 
-  let action: NotificationProps['action'];
+  let action: BitkitAlertProps['action'];
+  let title: ReactNode;
   let content: ReactNode = message;
 
   if (error?.status === 404) {
     content =
       "Couldn't find the bitrise.yml file in the app's repository. Please make sure that the file exists on the default branch and the app's Service Credential User has read rights on that.";
   } else if (message && message.includes('Split configuration requires an Enterprise plan')) {
-    content = (
-      <>
-        <Text fontWeight="bold">Split configuration requires an Enterprise plan</Text>
-        Contact our customer support if you'd like to try it out.
-      </>
-    );
+    title = 'Split configuration requires an Enterprise plan';
+    content = "Contact our customer support if you'd like to try it out.";
     action = {
       href: 'https://bitrise.io/contact',
       label: 'Contact us',
@@ -31,11 +28,7 @@ const YmlDialogErrorNotification = (props: Props) => {
     };
   }
 
-  return (
-    <Notification marginBlockStart="24" status="error" action={action}>
-      {content}
-    </Notification>
-  );
+  return <BitkitAlert marginBlockEnd="24" variant="critical" titleText={title} messageText={content} action={action} />;
 };
 
 export default YmlDialogErrorNotification;

--- a/source/javascripts/components/unified-editor/UpdateConfigurationDialog/YmlDialogErrorNotification.tsx
+++ b/source/javascripts/components/unified-editor/UpdateConfigurationDialog/YmlDialogErrorNotification.tsx
@@ -3,12 +3,12 @@ import { ReactNode } from 'react';
 
 import { ClientError } from '@/core/api/client';
 
-type Props = {
+type Props = Omit<BitkitAlertProps, 'variant' | 'titleText' | 'messageText' | 'action'> & {
   error: ClientError | undefined;
 };
 
 const YmlDialogErrorNotification = (props: Props) => {
-  const { error } = props;
+  const { error, ...rest } = props;
   const message = error?.getResponseErrorMessage() || error?.message || 'Unknown error occurred';
 
   let action: BitkitAlertProps['action'];
@@ -28,7 +28,7 @@ const YmlDialogErrorNotification = (props: Props) => {
     };
   }
 
-  return <BitkitAlert marginBlockEnd="24" variant="critical" titleText={title} messageText={content} action={action} />;
+  return <BitkitAlert variant="critical" titleText={title} messageText={content} action={action} {...rest} />;
 };
 
 export default YmlDialogErrorNotification;

--- a/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
+++ b/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
@@ -306,6 +306,7 @@ const DialogContent = ({ onClose }: Pick<ConfigurationYmlStorageDialogProps, 'on
       : 'You are already storing your configuration on bitrise.io';
 
   const showYmlRootPathSection = selectedStorage === 'git';
+  const showYmlRootPathWarning = showYmlRootPathSection && ymlSettings?.ymlRootPath !== null;
   const isYmlRootPathChanged = (ymlSettings?.ymlRootPath ?? '') !== ymlRootPath;
   const switchBitriseToGit = !ymlSettings?.usesRepositoryYml && selectedStorage === 'git';
   const switchGitToBitrise = ymlSettings?.usesRepositoryYml && selectedStorage === 'bitrise';
@@ -457,8 +458,10 @@ const DialogContent = ({ onClose }: Pick<ConfigurationYmlStorageDialogProps, 'on
         )}
       </BitkitDialog.Body>
       <BitkitDialog.Footer>
-        {asyncError && <YmlDialogErrorNotification error={asyncError} />}
-        {showYmlRootPathSection && ymlSettings?.ymlRootPath !== null && (
+        {asyncError && (
+          <YmlDialogErrorNotification error={asyncError} marginBlockEnd={showYmlRootPathWarning ? '24' : undefined} />
+        )}
+        {showYmlRootPathWarning && (
           <BitkitAlert
             variant="warning"
             messageText="Ensure that Bitrise has access to all repositories where configuration files are stored."

--- a/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
+++ b/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
@@ -455,9 +455,9 @@ const DialogContent = ({ onClose }: Pick<ConfigurationYmlStorageDialogProps, 'on
             lastModifiedFormatted={lastModifiedFormatted}
           />
         )}
-        {asyncError && <YmlDialogErrorNotification error={asyncError} />}
       </BitkitDialog.Body>
       <BitkitDialog.Footer>
+        {asyncError && <YmlDialogErrorNotification error={asyncError} />}
         {showYmlRootPathSection && ymlSettings?.ymlRootPath !== null && (
           <BitkitAlert
             variant="warning"


### PR DESCRIPTION
## Summary

Migrates the Configuration YAML dialog's error notification from the legacy `@bitrise/bitkit` `Notification` to the `@bitrise/bitkit-v2` `BitkitAlert`, and moves it into the dialog footer so it renders correctly.

## Changes

- **`YmlDialogErrorNotification`**: replaced legacy `Notification` with `BitkitAlert`
  - `status="error"` → `variant="critical"`
  - notification body → `messageText`; the bold "Split configuration requires an Enterprise plan" heading is now a proper `titleText` instead of a manual bold `<Text>`
  - the `action` (`href`/`label`/`target`) shape carries over unchanged
- **`ConfigurationYmlStorageDialog`**: moved the error notification out of `BitkitDialog.Body` into `BitkitDialog.Footer`

## Test plan

- [ ] Trigger a save/load error in the Configuration YAML dialog and confirm the `BitkitAlert` renders with the correct error message
- [ ] Verify the 404 case shows the "Couldn't find the bitrise.yml file…" message
- [ ] Verify the "Split configuration requires an Enterprise plan" case shows the title + "Contact us" action button linking to bitrise.io/contact
