### PR TITLE
chore: drop the LaunchDarkly SDK from feature-flag resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "chakra-ui-2--react": "npm:@chakra-ui/react@2.10.9",
         "dequal": "^2.0.3",
         "es-toolkit": "^1.48.1",
-        "launchdarkly-js-client-sdk": "^3.9.3",
         "monaco-editor": "^0.53.0",
         "monaco-yaml": "^5.4.1",
         "node-diff3": "^3.2.1",
@@ -11033,6 +11032,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -19456,32 +19456,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/launchdarkly-js-client-sdk": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/launchdarkly-js-client-sdk/-/launchdarkly-js-client-sdk-3.9.3.tgz",
-      "integrity": "sha512-1q+TqfBEBQcaz77EHwPf5F0L1hc22iwoa/S+69O5DSyp7+Txg35SDrvIQJWDcpigYxg0WN9VswAiq3uFci1ZhA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "launchdarkly-js-sdk-common": "5.8.1"
-      }
-    },
-    "node_modules/launchdarkly-js-sdk-common": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/launchdarkly-js-sdk-common/-/launchdarkly-js-sdk-common-5.8.1.tgz",
-      "integrity": "sha512-q6sYOatAhkKJYIT+8eeJyFBy4HZxOjHLxg8028Q6j7/ZdaySbo451ntPnlyKBrvXw9YfyB+62pL9ZHME3U6trg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "base64-js": "^1.3.0",
-        "fast-deep-equal": "^2.0.1"
-      }
-    },
-    "node_modules/launchdarkly-js-sdk-common/node_modules/fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha512-bCK/2Z4zLidyB4ReuIsvALH6w31YfAQDmXMqMx6FyfHqvBxtjC0eRumeSu4Bs3XtXwpyIywtSTrVT99BxY1f9w==",
-      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "chakra-ui-2--react": "npm:@chakra-ui/react@2.10.9",
     "dequal": "^2.0.3",
     "es-toolkit": "^1.48.1",
-    "launchdarkly-js-client-sdk": "^3.9.3",
     "monaco-editor": "^0.53.0",
     "monaco-yaml": "^5.4.1",
     "node-diff3": "^3.2.1",

--- a/source/javascripts/hooks/useFeatureFlag.ts
+++ b/source/javascripts/hooks/useFeatureFlag.ts
@@ -10,8 +10,9 @@ const defaultValues = {
 
 type FeatureFlags = typeof defaultValues;
 
-// Feature flags are resolved by the parent (monolith) and injected into the top window's
-// `globalProps.featureFlags.account`; a local `ld.local.json` override wins in development.
+// Feature flags are resolved by the parent (monolith) and injected into the parent window's
+// `globalProps.featureFlags.account` (read via WindowUtils.instance() === window.parent); a
+// local `ld.local.json` override wins in development.
 const useFeatureFlag = <K extends keyof FeatureFlags>(key: K): FeatureFlags[K] => {
   const localValue = window.localFeatureFlags?.[key];
 

--- a/source/javascripts/hooks/useFeatureFlag.ts
+++ b/source/javascripts/hooks/useFeatureFlag.ts
@@ -1,5 +1,3 @@
-import { initialize, LDClient } from 'launchdarkly-js-client-sdk';
-
 import GlobalProps from '@/core/utils/GlobalProps';
 
 const defaultValues = {
@@ -12,23 +10,12 @@ const defaultValues = {
 
 type FeatureFlags = typeof defaultValues;
 
-let client: LDClient | undefined;
-
-if (GlobalProps.workspaceSlug() && !client) {
-  client = initialize(
-    window.parent.location.host === 'app.bitrise.io' ? '5e70774c8a726707851d2fff' : '5e70774c8a726707851d2ffe',
-    {
-      kind: 'user',
-      key: `org-${GlobalProps.workspaceSlug()}`,
-    },
-  );
-}
-
+// Feature flags are resolved by the parent (monolith) and injected into the top window's
+// `globalProps.featureFlags.account`; a local `ld.local.json` override wins in development.
 const useFeatureFlag = <K extends keyof FeatureFlags>(key: K): FeatureFlags[K] => {
   const localValue = window.localFeatureFlags?.[key];
-  const defaultValue = GlobalProps.accountFeatureFlags()?.[key] ?? defaultValues[key];
 
-  return (localValue ?? client?.variation(key, defaultValue) ?? defaultValue) as FeatureFlags[K];
+  return (localValue ?? GlobalProps.accountFeatureFlags()?.[key] ?? defaultValues[key]) as FeatureFlags[K];
 };
 
 export default useFeatureFlag;


### PR DESCRIPTION
## What

Removes the in-app LaunchDarkly client (and the `launchdarkly-js-client-sdk` dependency) from `useFeatureFlag`.

## Why

Feature flags are resolved by the parent (monolith) and injected into the top window's `globalProps.featureFlags.account` — which `useFeatureFlag` already reads via `GlobalProps.accountFeatureFlags()`. The in-app LD client was effectively redundant:

- **Non-reactive** — the hook never subscribed to LD updates, so a flag changing in LD wouldn't re-render anything.
- **Async init** — on first render `client.variation(key, default)` returns the default (i.e. the `globalProps`/hardcoded value) until LD bootstraps.
- **Duplicate source** — the monolith already resolves the account flags with its own LD and injects them.

## Change

```ts
// before: localFeatureFlags ?? client.variation(...) ?? globalProps.account ?? default
// after:  localFeatureFlags ?? globalProps.account ?? default
```

- `useFeatureFlag.ts`: drop the LD import + `initialize(...)` client + `client.variation(...)`.
- Remove `launchdarkly-js-client-sdk` from `package.json` + lockfile.

All 5 flags in `defaultValues` are in use, and the dev `ld.local.json` override path is unchanged.

## Note

This relies on the monolith injecting all 5 flags (`enable-branch-switching`, `enable-ci-config-expert-agent`, `enable-wfe-modular-yaml-editing`, `enable-wfe-step-bundles-when-to-run`, `enable-wfe-tool-versions`) into `globalProps.featureFlags.account`. A flag that isn't injected falls back to its hardcoded default (`false`) — same effective behavior as before, since the LD client was non-reactive and async.

## Testing
- `npm run lint` — clean
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)