### PR TITLE
refactor: tooltip info icon (not icon button) for read-only file-tree groups

### DIFF
--- a/source/javascripts/components/FileTreeViewer/FileTreeView.tsx
+++ b/source/javascripts/components/FileTreeViewer/FileTreeView.tsx
@@ -1,11 +1,5 @@
 import { Box, Text } from '@bitrise/bitkit';
-import {
-  BitkitIconButton,
-  BitkitTreeView,
-  createTreeCollection,
-  IconFileYml,
-  IconInfoCircle,
-} from '@bitrise/bitkit-v2';
+import { BitkitTooltip, BitkitTreeView, createTreeCollection, IconFileYml, IconInfoCircle } from '@bitrise/bitkit-v2';
 import { useMemo } from 'react';
 
 import { TreeNode } from '@/core/models/Tree';
@@ -122,12 +116,9 @@ const FileTreeView = ({ rootNode, filter, selectedNodeId, onSelect, isNodeDisabl
           <Box display="flex" alignItems="center" gap="4" py="6">
             <Text textStyle="body/md/semibold">{group.header}</Text>
             {group.isReadOnly && (
-              <BitkitIconButton
-                size="sm"
-                variant="tertiary"
-                label="Modules included from another repository or ref are read-only."
-                icon={IconInfoCircle}
-              />
+              <BitkitTooltip text="Modules included from another repository or ref are read-only.">
+                <IconInfoCircle size="16" color="icon/tertiary" />
+              </BitkitTooltip>
             )}
           </Box>
           <GroupTree


### PR DESCRIPTION
## What

In `FileTreeView`, the read-only group header showed an info icon via a `BitkitIconButton`. The button has no `onClick` — it existed only to carry the "…read-only" tooltip — so a button is the wrong semantics (and a stray tab stop).

Replace it with a `BitkitTooltip`-wrapped `IconInfoCircle` — a plain, non-interactive info indicator.

```tsx
// before
<BitkitIconButton size="sm" variant="tertiary" label="…read-only." icon={IconInfoCircle} />
// after
<BitkitTooltip text="…read-only."><IconInfoCircle size="16" color="icon/tertiary" /></BitkitTooltip>
```

## Testing
- `npm run lint` — clean
- `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)