### PR TITLE
refactor: ghost card appearance + action order

### DIFF
--- a/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
+++ b/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
@@ -52,7 +52,7 @@ const StepBundleCard = (props: StepBundleCardProps) => {
   const isMergedView = useIsMergedConfigSelected();
   // In the merged view every bundle resolves locally, but its definition still lives in a module — offer a jump.
   const showJumpButton = isCrossFile || (isMergedView && hasDefinition);
-  // Ghosts get the subtler `minElevated` card (border/minimal + small shadow) instead of the tint.
+  // Ghosts (cross-file refs or read-only view) get a lighter border/minimal instead of the tint.
   const isGhost = isCrossFile || isReadOnlyView;
   const { isSelected } = useSelection();
   const { onDeleteStep, onDeleteStepInStepBundle, onSelectStep } = useStepActions();

--- a/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
+++ b/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
@@ -52,6 +52,8 @@ const StepBundleCard = (props: StepBundleCardProps) => {
   const isMergedView = useIsMergedConfigSelected();
   // In the merged view every bundle resolves locally, but its definition still lives in a module — offer a jump.
   const showJumpButton = isCrossFile || (isMergedView && hasDefinition);
+  // Ghosts get the subtler `minElevated` card (border/minimal + small shadow) instead of the tint.
+  const isGhost = isCrossFile || isReadOnlyView;
   const { isSelected } = useSelection();
   const { onDeleteStep, onDeleteStepInStepBundle, onSelectStep } = useStepActions();
   const zoom = useReactFlowZoom();
@@ -130,7 +132,7 @@ const StepBundleCard = (props: StepBundleCardProps) => {
 
   const cardProps = useMemo(() => {
     const common: CardProps = {
-      variant: 'outline',
+      variant: isGhost ? 'minElevated' : 'outline',
       ...(isDragging ? { borderColor: 'border/hover', boxShadow: 'small' } : {}),
       ...(isCollapsable ? { borderRadius: '4' } : { borderRadius: '8' }),
     };
@@ -151,10 +153,9 @@ const StepBundleCard = (props: StepBundleCardProps) => {
 
     return {
       ...common,
-      ...(isCrossFile || isReadOnlyView ? { backgroundColor: 'background/secondary' } : {}),
       ...(isHighlighted ? { outline: '2px solid', outlineColor: 'border/selected' } : {}),
     };
-  }, [isCollapsable, isDragging, isHighlighted, isPlaceholder, isCrossFile, isReadOnlyView]);
+  }, [isCollapsable, isDragging, isHighlighted, isPlaceholder, isGhost]);
 
   const buttonGroup = useMemo(() => {
     // The menu's actions come from onDeleteStep OR onDeleteStepInStepBundle (the latter for

--- a/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
+++ b/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
@@ -132,7 +132,10 @@ const StepBundleCard = (props: StepBundleCardProps) => {
 
   const cardProps = useMemo(() => {
     const common: CardProps = {
-      variant: isGhost ? 'minElevated' : 'outline',
+      variant: 'outline',
+      // A step bundle is a step-level item inside a workflow, so the ghost look is just a lighter
+      // border/minimal — no shadow (unlike the node cards, which use minElevated).
+      ...(isGhost ? { borderColor: 'border/minimal' } : {}),
       ...(isDragging ? { borderColor: 'border/hover', boxShadow: 'small' } : {}),
       ...(isCollapsable ? { borderRadius: '4' } : { borderRadius: '8' }),
     };

--- a/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.stories.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.stories.tsx
@@ -1,5 +1,8 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 
+import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { initializeModularConfig } from '@/core/stores/BitriseYmlStore';
+
 import WorkflowCard from './WorkflowCard';
 
 export default {
@@ -37,5 +40,48 @@ export const Default: Story = {};
 export const Empty: Story = {
   args: {
     id: 'empty',
+  },
+};
+
+// A cross-file ("ghost") workflow: defined in another module, so it can't be edited here. The card
+// renders with the subtler `minElevated` look (border/minimal + small shadow, no background tint)
+// and a jump-to-definition button instead of the editable chrome.
+const GHOST_ROOT: TreeNode = {
+  nodeId: 'n_root',
+  path: 'bitrise.yml',
+  contents: 'format_version: "13"\n',
+  source: null,
+  commitSha: 'a1b2c3d4e5f6789012345678901234567890abcd',
+  editable: true,
+  includes: [
+    {
+      nodeId: 'n_mod',
+      path: 'modules/workflows.yml',
+      contents: 'workflows:\n  ghost-wf: {}\n',
+      source: { path: 'modules/workflows.yml', repository: null, branch: null, tag: null, commit: null },
+      commitSha: 'a1b2c3d4e5f6789012345678901234567890abcd',
+      editable: true,
+      includes: [],
+    },
+  ],
+};
+
+const GHOST_ENTITY_INDEX: EntityIndex = {
+  workflows: { 'ghost-wf': [{ nodeId: 'n_mod' }] },
+  pipelines: {},
+  stepBundles: {},
+};
+
+export const Ghost: Story = {
+  args: {
+    id: 'ghost-wf',
+  },
+  beforeEach: () => {
+    initializeModularConfig({
+      root: GHOST_ROOT,
+      entityIndex: GHOST_ENTITY_INDEX,
+      branch: 'main',
+      commitSha: GHOST_ROOT.commitSha,
+    });
   },
 };

--- a/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
@@ -79,6 +79,9 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
   const isReadOnlyView = useIsReadOnlyView();
   const isMergedView = useIsMergedConfigSelected();
   const showJumpButton = isCrossFile || (isMergedView && hasDefinition);
+  // Ghosts (cross-file refs, or everything in the read-only merged view) get a subtler card:
+  // the `minElevated` variant (border/minimal + small shadow) instead of the default elevated look.
+  const isGhost = isCrossFile || isReadOnlyView;
 
   const { isOpen, onOpen, onToggle } = useDisclosure({
     defaultIsOpen: !isCollapsable,
@@ -92,7 +95,6 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
   const cardProps = useMemo(
     () => ({
       ...containerProps,
-      ...(isCrossFile || isReadOnlyView ? { backgroundColor: 'background/secondary' } : {}),
       ...(isHighlighted
         ? {
             outline: '2px solid',
@@ -100,7 +102,7 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
           }
         : {}),
     }),
-    [containerProps, isHighlighted, isCrossFile, isReadOnlyView],
+    [containerProps, isHighlighted],
   );
 
   if (!workflow && !isCrossFile) {
@@ -115,7 +117,7 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
   }
 
   return (
-    <Card minW={0} borderRadius="8" variant="elevated" {...cardProps}>
+    <Card minW={0} borderRadius="8" variant={isGhost ? 'minElevated' : 'elevated'} {...cardProps}>
       <Box display="flex" alignItems="center" px="8" py="6" gap="4" className="group">
         {isCollapsable && (
           <ControlButton

--- a/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
@@ -104,6 +104,9 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
     }),
     [containerProps, isHighlighted],
   );
+  // Resolve the variant after spreading `cardProps` so a caller's `containerProps.variant`
+  // (e.g. WorkflowNode's 'outline') can't override the ghost styling — ghost always wins.
+  const cardVariant = isGhost ? 'minElevated' : (containerProps?.variant ?? 'elevated');
 
   if (!workflow && !isCrossFile) {
     return <WorkflowEmptyState onCreateWorkflow={() => onCreateWorkflow?.()} />;
@@ -117,7 +120,7 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
   }
 
   return (
-    <Card minW={0} borderRadius="8" variant={isGhost ? 'minElevated' : 'elevated'} {...cardProps}>
+    <Card minW={0} borderRadius="8" {...cardProps} variant={cardVariant}>
       <Box display="flex" alignItems="center" px="8" py="6" gap="4" className="group">
         {isCollapsable && (
           <ControlButton

--- a/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
@@ -156,6 +156,11 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
                 }}
               />
             )}
+            {/* Jump takes the leading "primary action" slot for ghosts (where Chain is hidden),
+                matching the design's referenced-WF actions: jump → settings → remove. */}
+            {showJumpButton && (
+              <CrossFileJumpButton kind="workflows" id={workflowId} onOpenChange={setIsJumpPopoverOpen} />
+            )}
             {onEditWorkflow && (
               <ControlButton
                 size="xs"
@@ -164,9 +169,6 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
                 tooltipProps={{ 'aria-label': 'Edit Workflow' }}
                 onClick={() => onEditWorkflow(id)}
               />
-            )}
-            {showJumpButton && (
-              <CrossFileJumpButton kind="workflows" id={workflowId} onOpenChange={setIsJumpPopoverOpen} />
             )}
             {onRemoveWorkflow && (
               <ControlButton

--- a/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
@@ -122,6 +122,8 @@ const ChainedWorkflowCard = ({ id, index, uniqueId, placement, isSortable, isDra
             }}
           />
         )}
+        {/* Jump leads the action group for ghosts (Chain is hidden there): jump → settings → remove. */}
+        {showJumpButton && <CrossFileJumpButton kind="workflows" id={id} onOpenChange={setIsJumpPopoverOpen} />}
         {onEditChainedWorkflow && (
           <ControlButton
             size="xs"
@@ -131,7 +133,6 @@ const ChainedWorkflowCard = ({ id, index, uniqueId, placement, isSortable, isDra
             onClick={() => onEditChainedWorkflow(id, parentWorkflowId)}
           />
         )}
-        {showJumpButton && <CrossFileJumpButton kind="workflows" id={id} onOpenChange={setIsJumpPopoverOpen} />}
         {onRemoveChainedWorkflow && (
           <ControlButton
             isDanger

--- a/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
@@ -36,6 +36,8 @@ const ChainedWorkflowCard = ({ id, index, uniqueId, placement, isSortable, isDra
   const isReadOnlyView = useIsReadOnlyView();
   const isMergedView = useIsMergedConfigSelected();
   const showJumpButton = isCrossFile || (isMergedView && hasDefinition);
+  // Ghosts get the subtler `minElevated` card (border/minimal + small shadow) instead of the tint.
+  const isGhost = isCrossFile || isReadOnlyView;
   const { isSelected } = useSelection();
   const dependants = useDependantWorkflows({ workflowId: id });
   const containerRef = useRef<HTMLDivElement>(null);
@@ -73,7 +75,7 @@ const ChainedWorkflowCard = ({ id, index, uniqueId, placement, isSortable, isDra
   const cardProps = useMemo(() => {
     const common: CardProps = {
       borderRadius: '4',
-      variant: 'outline',
+      variant: isGhost ? 'minElevated' : 'outline',
       ...(isDragging ? { borderColor: 'border/hover', boxShadow: 'small' } : {}),
     };
 
@@ -94,10 +96,9 @@ const ChainedWorkflowCard = ({ id, index, uniqueId, placement, isSortable, isDra
 
     return {
       ...common,
-      ...(isCrossFile || isReadOnlyView ? { backgroundColor: 'background/secondary' } : {}),
       ...(isHighlighted ? { outline: '2px solid', outlineColor: 'border/selected' } : {}),
     };
-  }, [isDragging, isHighlighted, isPlaceholder, isCrossFile, isReadOnlyView]);
+  }, [isDragging, isHighlighted, isPlaceholder, isGhost]);
 
   const buttonGroup = useMemo(() => {
     if (

--- a/source/javascripts/components/unified-editor/WorkflowCard/components/StepCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/components/StepCard.tsx
@@ -188,7 +188,8 @@ const StepCard = ({
       borderRadius: '4',
       variant: 'outline',
       className: 'group',
-      ...(isReadOnlyView ? { backgroundColor: 'background/secondary' } : {}),
+      // Ghost (read-only) steps: a lighter border/minimal, no shadow — per the design's ghost-step spec.
+      ...(isReadOnlyView ? { borderColor: 'border/minimal' } : {}),
       ...(isDragging ? { borderColor: 'border/hover', boxShadow: 'small' } : {}),
     };
 


### PR DESCRIPTION
Part of the design-driven refactor pass. Reworks how "ghost" entities (cross-file refs, and everything in the read-only merged view) look and which actions they show on the cards.

### Appearance — weaker, not stronger
Per the final ghost design (Figma "Ghost" node; dev annotation: *"ghost node change compared to current nodes: 1. border-minimal, 2. elevation-sm"*), the ghost differentiation is **weakened**: no more `background/secondary` tint — just a subtler border + shadow.

- **Node cards** (`WorkflowCard`, `ChainedWorkflowCard`): when ghost, use the existing v1 `Card` variant **`minElevated`** (`border/minimal` + `small` shadow, and v1's `small` = `0 2px 4px rgba(0,0,0,0.06)` is exactly the design's `elevation/sm`). No new tokens.
- **Step-level items** (`StepCard`, `StepBundleCard`): just a lighter `border/minimal` border, **no shadow** (per the ghost-step spec — a step bundle is a step inside a workflow, not a node).
- `background/secondary` is kept only on the drag **placeholder** branches (unrelated to ghosts).

### Action order
Per the design's referenced-WF actions, the ghost workflow cards lead with the **jump-to-definition** button: **jump → settings → remove** (the chain button is hidden for ghosts). Local workflows are unchanged: **chain → settings → remove**. The action *set* already matched; only the ghost ordering changed.

### Story
Adds a **Ghost** story to `WorkflowCard` (a cross-file workflow set up via a modular config) so the appearance + actions are reviewable in Storybook.

### Out of scope (deferred)
Ghost **interaction/behaviour** — whether a ghost node should expand to show read-only steps, the collapse-chevron state, and the ghost-step drag-handle / more-menu — is a separate follow-up.

### Verify
- `tsc`, ESLint clean. Reviewed the `Ghost` story in Storybook.