### PR TITLE
refactor: hide the collapse chevron on ghost cards

### DIFF
--- a/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
+++ b/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
@@ -214,10 +214,10 @@ const StepBundleCard = (props: StepBundleCardProps) => {
               onClick={handleClick}
               role={isButton ? 'button' : 'div'}
             >
-              {isCollapsable && (
+              {/* No expand/collapse for cross-file refs — their nested steps live in another file. */}
+              {isCollapsable && !isCrossFile && (
                 <ControlButton
                   size="xs"
-                  isDisabled={isCrossFile}
                   tabIndex={-1} // NOTE: Without this, the tooltip always appears when closing any drawers on the Workflows page.
                   className="nopan"
                   onClick={(e) => {

--- a/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
@@ -122,10 +122,11 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
   return (
     <Card minW={0} borderRadius="8" {...cardProps} variant={cardVariant}>
       <Box display="flex" alignItems="center" px="8" py="6" gap="4" className="group">
-        {isCollapsable && (
+        {/* No expand/collapse for cross-file refs — their nested content lives in another file
+            and isn't shown here, so the chevron is hidden rather than rendered disabled. */}
+        {isCollapsable && !isCrossFile && (
           <ControlButton
             size="xs"
-            isDisabled={isCrossFile}
             tabIndex={-1} // NOTE: Without this, the tooltip always appears when closing any drawers on the Workflows page.
             className="nopan"
             onClick={onToggle}

--- a/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
@@ -181,18 +181,21 @@ const ChainedWorkflowCard = ({ id, index, uniqueId, placement, isSortable, isDra
               />
             )}
 
-            <ControlButton
-              size="xs"
-              tabIndex={-1} // NOTE: Without this, the tooltip always appears when closing any drawers on the Workflows page.
-              className="nopan"
-              onClick={onToggle}
-              isDisabled={isDragging || isCrossFile}
-              iconName={isOpen ? 'ChevronUp' : 'ChevronDown'}
-              aria-label={!isDragging ? `${isOpen ? 'Collapse' : 'Expand'} Workflow details` : ''}
-              tooltipProps={{
-                'aria-label': `${isOpen ? 'Collapse' : 'Expand'} Workflow details`,
-              }}
-            />
+            {/* No expand/collapse for cross-file refs — their nested content isn't shown here. */}
+            {!isCrossFile && (
+              <ControlButton
+                size="xs"
+                tabIndex={-1} // NOTE: Without this, the tooltip always appears when closing any drawers on the Workflows page.
+                className="nopan"
+                onClick={onToggle}
+                isDisabled={isDragging}
+                iconName={isOpen ? 'ChevronUp' : 'ChevronDown'}
+                aria-label={!isDragging ? `${isOpen ? 'Collapse' : 'Expand'} Workflow details` : ''}
+                tooltipProps={{
+                  'aria-label': `${isOpen ? 'Collapse' : 'Expand'} Workflow details`,
+                }}
+              />
+            )}
 
             <Box display="flex" flexDir="column" alignItems="flex-start" justifyContent="center" flex="1" minW={0}>
               <Text textStyle="body/md/semibold" hasEllipsis>


### PR DESCRIPTION
Follow-up to the ghost-card work (#1817). Continues tidying the ghost (cross-file) cards.

### Problem
A cross-file ("ghost") workflow / chained workflow / step bundle has no expandable content on this side — its nested steps/workflows live in another file and aren't rendered here (`{!isCrossFile && …}`). The collapse chevron was still shown, just **disabled** — a dead, greyed control that does nothing.

### Change
Hide the chevron entirely for cross-file refs (render-gate on `!isCrossFile`) instead of rendering it disabled. Affected: `WorkflowCard`, `ChainedWorkflowCard`, `StepBundleCard`.

The **merged read-only view** is unchanged: there the content *is* shown (entities resolve locally, so `isCrossFile` is false), so the chevron still renders and works.

Not touched: the `WorkflowConfigHeader` Properties/Triggers tabs that are disabled for cross-file — that's a separate, intentional behaviour.

### Verify
- `tsc`, ESLint clean.