### PR TITLE
fix: keep the loading bitbot up until the config tree finishes loading

### DIFF
--- a/source/javascripts/layouts/ConfigLoading.context.tsx
+++ b/source/javascripts/layouts/ConfigLoading.context.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * True while the initial CI config is still loading — covering both bootstrap phases: the
+ * "does the repo have a config" settings check and the subsequent tree/legacy fetch. Provided by
+ * `InitialDataLoader` (which owns the queries) so the layout can show the loading state inside the
+ * content area while keeping the header + navigation visible.
+ */
+const ConfigLoadingContext = createContext(false);
+
+export const ConfigLoadingProvider = ConfigLoadingContext.Provider;
+
+export const useIsConfigLoading = () => useContext(ConfigLoadingContext);

--- a/source/javascripts/layouts/MainLayout.tsx
+++ b/source/javascripts/layouts/MainLayout.tsx
@@ -3,6 +3,7 @@ import { Redirect, Router, Switch } from 'wouter';
 
 import Header from '@/components/Header';
 import LazyRoute from '@/components/LazyRoute';
+import LoadingState from '@/components/LoadingState';
 import Navigation from '@/components/Navigation';
 import RuntimeUtils from '@/core/utils/RuntimeUtils';
 import useHashLocation from '@/hooks/useHashLocation';
@@ -10,6 +11,7 @@ import useHashSearch from '@/hooks/useHashSearch';
 import useMergedConfigSync from '@/hooks/useMergedConfigSync';
 import { useTree } from '@/hooks/useTree';
 import useYmlValidationStatus from '@/hooks/useYmlValidationStatus';
+import { useIsConfigLoading } from '@/layouts/ConfigLoading.context';
 import OpenFileTabs from '@/pages/YmlPage/components/OpenFileTabs/OpenFileTabs';
 import { paths, routes } from '@/routes';
 
@@ -39,6 +41,10 @@ const MainLayout = () => {
   // nav + content row); in CLI mode the tabs live inside the content column instead.
   const tabsUnderHeader = isModular && isWebsiteMode;
 
+  // The header + navigation stay visible during the initial config load; only the content area
+  // shows the loading state (settings check + tree/legacy fetch).
+  const isConfigLoading = useIsConfigLoading();
+
   useMergedConfigSync();
 
   return (
@@ -55,15 +61,19 @@ const MainLayout = () => {
         <Box display="flex" flexDirection="column" flex="1" minWidth={0} minHeight={0}>
           {isModular && !tabsUnderHeader && <OpenFileTabs />}
           <Box flex="1" overflowX="hidden" overflowY="auto">
-            <Router hook={useHashLocation} searchHook={useHashSearch}>
-              <InvalidYmlRedirect />
-              <Switch>
-                {routes.map(({ path, component }) => (
-                  <LazyRoute key={path} path={new RegExp(`^\\${path}`)} component={component} />
-                ))}
-                <Redirect to={paths.workflows} replace />
-              </Switch>
-            </Router>
+            {isConfigLoading ? (
+              <LoadingState />
+            ) : (
+              <Router hook={useHashLocation} searchHook={useHashSearch}>
+                <InvalidYmlRedirect />
+                <Switch>
+                  {routes.map(({ path, component }) => (
+                    <LazyRoute key={path} path={new RegExp(`^\\${path}`)} component={component} />
+                  ))}
+                  <Redirect to={paths.workflows} replace />
+                </Switch>
+              </Router>
+            )}
           </Box>
         </Box>
       </Box>

--- a/source/javascripts/main.tsx
+++ b/source/javascripts/main.tsx
@@ -11,6 +11,7 @@ import { ComponentProps, PropsWithChildren, StrictMode, useEffect, useRef } from
 import { createRoot } from 'react-dom/client';
 import { useEventListener } from 'usehooks-ts';
 
+import LoadingState from '@/components/LoadingState';
 import ModularYamlDevToggle from '@/components/ModularYamlDevToggle';
 import Client from '@/core/api/client';
 import { initializeBitriseYmlDocument, initializeModularConfig } from '@/core/stores/BitriseYmlStore';
@@ -238,6 +239,13 @@ const InitialDataLoader = ({ children }: PropsWithChildren) => {
         </Box>
       </Box>
     );
+  }
+
+  // Keep the loading state up until the config is fully loaded — covering both bootstrap phases:
+  // the "does the repo have a config" settings check (which gates the query) and the subsequent
+  // tree/legacy fetch. Without this the children would render against an empty store mid-load.
+  if (!data) {
+    return <LoadingState />;
   }
 
   return <>{children}</>;

--- a/source/javascripts/main.tsx
+++ b/source/javascripts/main.tsx
@@ -11,7 +11,6 @@ import { ComponentProps, PropsWithChildren, StrictMode, useEffect, useRef } from
 import { createRoot } from 'react-dom/client';
 import { useEventListener } from 'usehooks-ts';
 
-import LoadingState from '@/components/LoadingState';
 import ModularYamlDevToggle from '@/components/ModularYamlDevToggle';
 import Client from '@/core/api/client';
 import { initializeBitriseYmlDocument, initializeModularConfig } from '@/core/stores/BitriseYmlStore';
@@ -24,6 +23,7 @@ import useCloseAIDrawer from '@/hooks/useCloseAIDrawer';
 import useFeatureFlag from '@/hooks/useFeatureFlag';
 import useSearchParams from '@/hooks/useSearchParams';
 import useYmlLanguageServices from '@/hooks/useYmlLanguageServices';
+import { ConfigLoadingProvider } from '@/layouts/ConfigLoading.context';
 import MainLayout from '@/layouts/MainLayout';
 
 import bitriseLogo from '../images/bitrise-logo.svg';
@@ -241,14 +241,9 @@ const InitialDataLoader = ({ children }: PropsWithChildren) => {
     );
   }
 
-  // Keep the loading state up until the config is fully loaded — covering both bootstrap phases:
-  // the "does the repo have a config" settings check (which gates the query) and the subsequent
-  // tree/legacy fetch. Without this the children would render against an empty store mid-load.
-  if (!data) {
-    return <LoadingState />;
-  }
-
-  return <>{children}</>;
+  // Expose whether the config is still loading (settings check + tree/legacy fetch) so the layout
+  // can show the loading state in the content area while keeping the header + navigation visible.
+  return <ConfigLoadingProvider value={!data}>{children}</ConfigLoadingProvider>;
 };
 
 const App = () => {


### PR DESCRIPTION
### Problem
On bootstrap the loader runs in two phases:
1. the *"does the repo have a config"* settings check (`useCiConfigSettings`, which gates the config query), and
2. the **tree** fetch that returns the module structure + ymls (`useGetCiConfigTree`).

The progress bitbot showed during phase 1, but `InitialDataLoader` rendered its children as soon as the settings resolved — so during phase 2 (tree still loading) the app rendered against an **empty store** and the bitbot disappeared mid-load.

### Fix
Keep the loading bitbot up until the config has actually loaded, covering **both** phases (and branch switches, as agreed).

The header + navigation stay visible during the load — only the **content area** shows the bitbot:
- `InitialDataLoader` exposes the loading flag (`!data`) via a small `ConfigLoading` context instead of taking over the whole screen.
- `MainLayout` renders `<LoadingState />` inside the content box while the config loads, and the routes once it's ready.

### Verify
- `tsc`, ESLint clean; no import cycle.