### PR TITLE
fix: close the Open module picker when selecting the already-active file

### DIFF
--- a/source/javascripts/components/FileTreeViewer/FileTreeView.tsx
+++ b/source/javascripts/components/FileTreeViewer/FileTreeView.tsx
@@ -93,7 +93,18 @@ const GroupTree = ({
         nodeState.isBranch ? (
           <BitkitTreeView.Branch label={node.label} />
         ) : (
-          <BitkitTreeView.Leaf label={node.label} icon={IconFileYml} />
+          <BitkitTreeView.Leaf
+            label={node.label}
+            icon={IconFileYml}
+            // Clicking the already-selected file doesn't change the selection, so onSelectionChange
+            // never fires — handle that case here so selecting the active file still runs onSelect
+            // (which closes the picker). Other files are handled by onSelectionChange (single fire).
+            onClick={() => {
+              if (node.id === selectedNodeId) {
+                onSelect(node.id);
+              }
+            }}
+          />
         )
       }
     />


### PR DESCRIPTION
### Problem
In the **Open module** picker, files that already have a tab are listed in the tree too. Clicking one navigates to its tab and closes the picker — **except** when you click the file that's *already the active tab*: nothing happens and the popover stays open.

### Cause
The tree drove navigation off `BitkitTreeView`'s `onSelectionChange`, which only fires when the selection actually **changes**. Re-clicking the already-selected file doesn't change the selection → no callback → no `onSelect` → the picker never closes.

### Fix
Handle that one case via the leaf's `onClick`, guarded to the currently-selected node:
```tsx
onClick={() => { if (node.id === selectedNodeId) onSelect(node.id); }}
```
Other files keep going through `onSelectionChange` (so it fires exactly once — no double navigation), and keyboard selection is unaffected.

### Verify
- `tsc`, ESLint clean.