### PR TITLE
fix: ghost card chevron, config-loading state, and Open module picker

### DIFF
--- a/source/javascripts/components/FileTreeViewer/FileTreeView.tsx
+++ b/source/javascripts/components/FileTreeViewer/FileTreeView.tsx
@@ -93,7 +93,18 @@ const GroupTree = ({
         nodeState.isBranch ? (
           <BitkitTreeView.Branch label={node.label} />
         ) : (
-          <BitkitTreeView.Leaf label={node.label} icon={IconFileYml} />
+          <BitkitTreeView.Leaf
+            label={node.label}
+            icon={IconFileYml}
+            // Clicking the already-selected file doesn't change the selection, so onSelectionChange
+            // never fires — handle that case here so selecting the active file still runs onSelect
+            // (which closes the picker). Other files are handled by onSelectionChange (single fire).
+            onClick={() => {
+              if (node.id === selectedNodeId) {
+                onSelect(node.id);
+              }
+            }}
+          />
         )
       }
     />

--- a/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
+++ b/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
@@ -214,10 +214,10 @@ const StepBundleCard = (props: StepBundleCardProps) => {
               onClick={handleClick}
               role={isButton ? 'button' : 'div'}
             >
-              {isCollapsable && (
+              {/* No expand/collapse for cross-file refs — their nested steps live in another file. */}
+              {isCollapsable && !isCrossFile && (
                 <ControlButton
                   size="xs"
-                  isDisabled={isCrossFile}
                   tabIndex={-1} // NOTE: Without this, the tooltip always appears when closing any drawers on the Workflows page.
                   className="nopan"
                   onClick={(e) => {

--- a/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
@@ -122,10 +122,11 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
   return (
     <Card minW={0} borderRadius="8" {...cardProps} variant={cardVariant}>
       <Box display="flex" alignItems="center" px="8" py="6" gap="4" className="group">
-        {isCollapsable && (
+        {/* No expand/collapse for cross-file refs — their nested content lives in another file
+            and isn't shown here, so the chevron is hidden rather than rendered disabled. */}
+        {isCollapsable && !isCrossFile && (
           <ControlButton
             size="xs"
-            isDisabled={isCrossFile}
             tabIndex={-1} // NOTE: Without this, the tooltip always appears when closing any drawers on the Workflows page.
             className="nopan"
             onClick={onToggle}

--- a/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
@@ -181,18 +181,21 @@ const ChainedWorkflowCard = ({ id, index, uniqueId, placement, isSortable, isDra
               />
             )}
 
-            <ControlButton
-              size="xs"
-              tabIndex={-1} // NOTE: Without this, the tooltip always appears when closing any drawers on the Workflows page.
-              className="nopan"
-              onClick={onToggle}
-              isDisabled={isDragging || isCrossFile}
-              iconName={isOpen ? 'ChevronUp' : 'ChevronDown'}
-              aria-label={!isDragging ? `${isOpen ? 'Collapse' : 'Expand'} Workflow details` : ''}
-              tooltipProps={{
-                'aria-label': `${isOpen ? 'Collapse' : 'Expand'} Workflow details`,
-              }}
-            />
+            {/* No expand/collapse for cross-file refs — their nested content isn't shown here. */}
+            {!isCrossFile && (
+              <ControlButton
+                size="xs"
+                tabIndex={-1} // NOTE: Without this, the tooltip always appears when closing any drawers on the Workflows page.
+                className="nopan"
+                onClick={onToggle}
+                isDisabled={isDragging}
+                iconName={isOpen ? 'ChevronUp' : 'ChevronDown'}
+                aria-label={!isDragging ? `${isOpen ? 'Collapse' : 'Expand'} Workflow details` : ''}
+                tooltipProps={{
+                  'aria-label': `${isOpen ? 'Collapse' : 'Expand'} Workflow details`,
+                }}
+              />
+            )}
 
             <Box display="flex" flexDir="column" alignItems="flex-start" justifyContent="center" flex="1" minW={0}>
               <Text textStyle="body/md/semibold" hasEllipsis>

--- a/source/javascripts/layouts/ConfigLoading.context.tsx
+++ b/source/javascripts/layouts/ConfigLoading.context.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * True while the initial CI config is still loading — covering both bootstrap phases: the
+ * "does the repo have a config" settings check and the subsequent tree/legacy fetch. Provided by
+ * `InitialDataLoader` (which owns the queries) so the layout can show the loading state inside the
+ * content area while keeping the header + navigation visible.
+ */
+const ConfigLoadingContext = createContext(false);
+
+export const ConfigLoadingProvider = ConfigLoadingContext.Provider;
+
+export const useIsConfigLoading = () => useContext(ConfigLoadingContext);

--- a/source/javascripts/layouts/MainLayout.tsx
+++ b/source/javascripts/layouts/MainLayout.tsx
@@ -3,6 +3,7 @@ import { Redirect, Router, Switch } from 'wouter';
 
 import Header from '@/components/Header';
 import LazyRoute from '@/components/LazyRoute';
+import LoadingState from '@/components/LoadingState';
 import Navigation from '@/components/Navigation';
 import RuntimeUtils from '@/core/utils/RuntimeUtils';
 import useHashLocation from '@/hooks/useHashLocation';
@@ -10,6 +11,7 @@ import useHashSearch from '@/hooks/useHashSearch';
 import useMergedConfigSync from '@/hooks/useMergedConfigSync';
 import { useTree } from '@/hooks/useTree';
 import useYmlValidationStatus from '@/hooks/useYmlValidationStatus';
+import { useIsConfigLoading } from '@/layouts/ConfigLoading.context';
 import OpenFileTabs from '@/pages/YmlPage/components/OpenFileTabs/OpenFileTabs';
 import { paths, routes } from '@/routes';
 
@@ -39,6 +41,10 @@ const MainLayout = () => {
   // nav + content row); in CLI mode the tabs live inside the content column instead.
   const tabsUnderHeader = isModular && isWebsiteMode;
 
+  // The header + navigation stay visible during the initial config load; only the content area
+  // shows the loading state (settings check + tree/legacy fetch).
+  const isConfigLoading = useIsConfigLoading();
+
   useMergedConfigSync();
 
   return (
@@ -55,15 +61,19 @@ const MainLayout = () => {
         <Box display="flex" flexDirection="column" flex="1" minWidth={0} minHeight={0}>
           {isModular && !tabsUnderHeader && <OpenFileTabs />}
           <Box flex="1" overflowX="hidden" overflowY="auto">
-            <Router hook={useHashLocation} searchHook={useHashSearch}>
-              <InvalidYmlRedirect />
-              <Switch>
-                {routes.map(({ path, component }) => (
-                  <LazyRoute key={path} path={new RegExp(`^\\${path}`)} component={component} />
-                ))}
-                <Redirect to={paths.workflows} replace />
-              </Switch>
-            </Router>
+            {isConfigLoading ? (
+              <LoadingState />
+            ) : (
+              <Router hook={useHashLocation} searchHook={useHashSearch}>
+                <InvalidYmlRedirect />
+                <Switch>
+                  {routes.map(({ path, component }) => (
+                    <LazyRoute key={path} path={new RegExp(`^\\${path}`)} component={component} />
+                  ))}
+                  <Redirect to={paths.workflows} replace />
+                </Switch>
+              </Router>
+            )}
           </Box>
         </Box>
       </Box>

--- a/source/javascripts/main.tsx
+++ b/source/javascripts/main.tsx
@@ -11,6 +11,7 @@ import { ComponentProps, PropsWithChildren, StrictMode, useEffect, useRef } from
 import { createRoot } from 'react-dom/client';
 import { useEventListener } from 'usehooks-ts';
 
+import LoadingState from '@/components/LoadingState';
 import ModularYamlDevToggle from '@/components/ModularYamlDevToggle';
 import Client from '@/core/api/client';
 import { initializeBitriseYmlDocument, initializeModularConfig } from '@/core/stores/BitriseYmlStore';
@@ -238,6 +239,13 @@ const InitialDataLoader = ({ children }: PropsWithChildren) => {
         </Box>
       </Box>
     );
+  }
+
+  // Keep the loading state up until the config is fully loaded — covering both bootstrap phases:
+  // the "does the repo have a config" settings check (which gates the query) and the subsequent
+  // tree/legacy fetch. Without this the children would render against an empty store mid-load.
+  if (!data) {
+    return <LoadingState />;
   }
 
   return <>{children}</>;

--- a/source/javascripts/main.tsx
+++ b/source/javascripts/main.tsx
@@ -11,7 +11,6 @@ import { ComponentProps, PropsWithChildren, StrictMode, useEffect, useRef } from
 import { createRoot } from 'react-dom/client';
 import { useEventListener } from 'usehooks-ts';
 
-import LoadingState from '@/components/LoadingState';
 import ModularYamlDevToggle from '@/components/ModularYamlDevToggle';
 import Client from '@/core/api/client';
 import { initializeBitriseYmlDocument, initializeModularConfig } from '@/core/stores/BitriseYmlStore';
@@ -24,6 +23,7 @@ import useCloseAIDrawer from '@/hooks/useCloseAIDrawer';
 import useFeatureFlag from '@/hooks/useFeatureFlag';
 import useSearchParams from '@/hooks/useSearchParams';
 import useYmlLanguageServices from '@/hooks/useYmlLanguageServices';
+import { ConfigLoadingProvider } from '@/layouts/ConfigLoading.context';
 import MainLayout from '@/layouts/MainLayout';
 
 import bitriseLogo from '../images/bitrise-logo.svg';
@@ -241,14 +241,9 @@ const InitialDataLoader = ({ children }: PropsWithChildren) => {
     );
   }
 
-  // Keep the loading state up until the config is fully loaded — covering both bootstrap phases:
-  // the "does the repo have a config" settings check (which gates the query) and the subsequent
-  // tree/legacy fetch. Without this the children would render against an empty store mid-load.
-  if (!data) {
-    return <LoadingState />;
-  }
-
-  return <>{children}</>;
+  // Expose whether the config is still loading (settings check + tree/legacy fetch) so the layout
+  // can show the loading state in the content area while keeping the header + navigation visible.
+  return <ConfigLoadingProvider value={!data}>{children}</ConfigLoadingProvider>;
 };
 
 const App = () => {


### PR DESCRIPTION
A few small, independent workflow-editor UX fixes, batched into one PR (consolidating what were #1818 / #1819 / #1820). Each is a separate commit; they touch disjoint files.

### 1. Hide the collapse chevron on ghost cards
A cross-file ("ghost") workflow / chained workflow / step bundle has no expandable content here (its nested items live in another file), so the collapse chevron was a dead, disabled control. Hide it entirely for cross-file refs. The merged read-only view is unchanged (content is shown there, so the chevron still works).
*WorkflowCard, ChainedWorkflowCard, StepBundleCard.*

### 2. Keep the loading bitbot up until the config tree finishes loading
Bootstrap runs in two phases — the "does the repo have a config" settings check, then the **tree** fetch (module structure + ymls). The bitbot showed in phase 1 but disappeared during phase 2, leaving an empty store on screen. Now the loading state stays up until the config has actually loaded (both phases + branch switches). The **header + navigation stay visible** — only the content area shows the bitbot, via a small `ConfigLoading` context exposed by `InitialDataLoader` and consumed by `MainLayout`.
*main.tsx, MainLayout.tsx, ConfigLoading.context.tsx (new).*

### 3. Close the Open module picker when selecting the already-active file
The file tree drove navigation off `BitkitTreeView`'s `onSelectionChange`, which only fires when the selection changes — so re-clicking the already-active file did nothing and the picker stayed open. Handled via the leaf's `onClick`, guarded to the selected node (other files still go through `onSelectionChange` exactly once).
*FileTreeView.tsx.*

### Verify
- `tsc`, ESLint clean.