### PR TITLE
fix: hide empty-state create actions on read-only views

### DIFF
--- a/source/javascripts/components/SortableEnvVars/SortableEnvVars.tsx
+++ b/source/javascripts/components/SortableEnvVars/SortableEnvVars.tsx
@@ -79,9 +79,10 @@ const SortableEnvVars = ({
         <DragOverlay>{activeItem && <SortableEnvVarItem env={activeItem} isDragging />}</DragOverlay>
       </DndContext>
 
-      {!hideAddButton && (
+      {/* Read-only views (merged config, cross-repo/ref files) can't add — show no action. */}
+      {!hideAddButton && !isReadOnlyView && (
         <Box px="16" py="12">
-          <Button size="md" variant="tertiary" leftIconName="Plus" isDisabled={isReadOnlyView} onClick={onAdd}>
+          <Button size="md" variant="tertiary" leftIconName="Plus" onClick={onAdd}>
             Add new
           </Button>
         </Box>

--- a/source/javascripts/components/unified-editor/WorkflowEmptyState.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowEmptyState.tsx
@@ -26,30 +26,27 @@ const WorkflowEmptyState = ({ onCreateWorkflow }: Props) => {
       title="Your Workflow will appear here"
       description="It looks like you haven't set up any Workflows. Create your first Workflow to automate your CI/CD pipeline."
     >
-      <ButtonGroup spacing="0" gap="24">
-        {isAIButtonVisible && (
-          <Tooltip label={tooltipLabel} isDisabled={!tooltipLabel}>
-            <Button
-              isDisabled={isAIButtonDisabled || isReadOnlyView}
-              leftIconName="SparkleFilled"
-              size="md"
-              variant="ai-primary"
-              onClick={onAIButtonClick}
-            >
-              Create Workflow with AI
-            </Button>
-          </Tooltip>
-        )}
-        <Button
-          leftIconName="Plus"
-          size="md"
-          isDisabled={isReadOnlyView}
-          onClick={onCreateWorkflow}
-          variant="secondary"
-        >
-          Create Workflow manually
-        </Button>
-      </ButtonGroup>
+      {/* Read-only views (merged config, cross-repo/ref files) can't create — show no actions. */}
+      {!isReadOnlyView && (
+        <ButtonGroup spacing="0" gap="24">
+          {isAIButtonVisible && (
+            <Tooltip label={tooltipLabel} isDisabled={!tooltipLabel}>
+              <Button
+                isDisabled={isAIButtonDisabled}
+                leftIconName="SparkleFilled"
+                size="md"
+                variant="ai-primary"
+                onClick={onAIButtonClick}
+              >
+                Create Workflow with AI
+              </Button>
+            </Tooltip>
+          )}
+          <Button leftIconName="Plus" size="md" onClick={onCreateWorkflow} variant="secondary">
+            Create Workflow manually
+          </Button>
+        </ButtonGroup>
+      )}
     </EmptyState>
   );
 };

--- a/source/javascripts/pages/PipelinesPage/components/EmptyStates/CreateFirstGraphPipelineEmptyState.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/EmptyStates/CreateFirstGraphPipelineEmptyState.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, ButtonGroup, Card, Icon, Image, Link, List, ListItem, Text, Tooltip } from '@bitrise/bitkit';
 
 import useAIButton from '@/hooks/useAIButton';
+import { useIsReadOnlyView } from '@/hooks/useTree';
 
 import graphPipelineImage from '../../assets/graph-pipeline.png';
 
@@ -9,6 +10,7 @@ type Props = {
 };
 
 const CreateFirstGraphPipelineEmptyState = ({ onCreate }: Props) => {
+  const isReadOnlyView = useIsReadOnlyView();
   const {
     isVisible: isAIButtonVisible,
     tooltipLabel,
@@ -75,18 +77,23 @@ const CreateFirstGraphPipelineEmptyState = ({ onCreate }: Props) => {
             <ListItem>Edit Workflows directly in the Pipeline</ListItem>
           </List>
 
-          <Box display={['none', 'flex']} gap="24" alignItems="center">
-            {actions}
-          </Box>
+          {/* Read-only views (merged config, cross-repo/ref files) can't create — show no actions. */}
+          {!isReadOnlyView && (
+            <Box display={['none', 'flex']} gap="24" alignItems="center">
+              {actions}
+            </Box>
+          )}
         </Box>
 
         <Box p="8" maxW="436" display="flex" borderRadius="8" bg="background/secondary" alignItems="center">
           <Image src={graphPipelineImage} alt="Graph Pipeline" />
         </Box>
 
-        <Box display={['flex', 'none']} flexDir="column" gap="24" alignItems="center">
-          {actions}
-        </Box>
+        {!isReadOnlyView && (
+          <Box display={['flex', 'none']} flexDir="column" gap="24" alignItems="center">
+            {actions}
+          </Box>
+        )}
       </Card>
     </Box>
   );

--- a/source/javascripts/pages/StepBundlesPage/StepBundlesPage.tsx
+++ b/source/javascripts/pages/StepBundlesPage/StepBundlesPage.tsx
@@ -63,16 +63,18 @@ const StepBundlesPage = () => {
       description="With Step bundles, you can create reusable chunks of configuration. You can also create Step bundles in your Workflows."
       height="100%"
     >
-      <Button
-        size="md"
-        leftIconName="Plus"
-        isDisabled={isReadOnlyView}
-        onClick={openDialog({
-          type: StepBundlesPageDialogType.CREATE_STEP_BUNDLE,
-        })}
-      >
-        Create Step bundle
-      </Button>
+      {/* Read-only views (merged config, cross-repo/ref files) can't create — show no action. */}
+      {!isReadOnlyView && (
+        <Button
+          size="md"
+          leftIconName="Plus"
+          onClick={openDialog({
+            type: StepBundlesPageDialogType.CREATE_STEP_BUNDLE,
+          })}
+        >
+          Create Step bundle
+        </Button>
+      )}
     </EmptyState>
   );
   return (


### PR DESCRIPTION
On read-only views — the merged config ("Effective config") tab and cross-repo/ref files — the empty-state **create/add actions can't do anything**. Most were shown **disabled**; the Pipelines one stayed **active but did nothing**. Per the design these are simply **removed** on read-only, leaving the informational empty state.

Design refs: Workflows / Pipelines / Step bundles empty states on the merged tab (Figma `14060-164821`, `14060-165391`, `14060-165882`).

### Changes
- **`WorkflowEmptyState`** — hide the Create / Create-with-AI button group.
- **`CreateFirstGraphPipelineEmptyState`** — it had no read-only awareness (hence the active-but-dead Create button); now hides its actions block.
- **`StepBundlesPage`** empty state — hide the "Create Step bundle" button.
- **`SortableEnvVars`** — hide the "Add new" button (the merged grouped env-var view already passed `hideAddButton`; this covers the read-only single-file case).

Informational content (icon, title, description, and the Pipelines "Get started" card with its bullets + image) stays.

> Note: for Pipelines I removed the whole actions row, which also drops the "Read the docs" link on read-only — matching the design (informational card only). Easy to keep the link if preferred.

### Verify
- `tsc`, ESLint clean.