### PR TITLE
refactor + fixes: jump-button v2 migration, empty-doc setIn, file-tab validation dots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bitrise/bitkit": "^13.358.0",
-        "@bitrise/bitkit-v2": "0.3.266",
+        "@bitrise/bitkit-v2": "0.3.270",
         "@bitrise/languageserver": "git+https://github.com/bitrise-io/bitrise-yml-language-server.git#833b15995769404349b63986ea779b60fccce531",
         "@dagrejs/dagre": "^3.0.0",
         "@datadog/browser-rum": "^7.3.0",
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/@bitrise/bitkit-v2": {
-      "version": "0.3.266",
-      "resolved": "https://registry.npmjs.org/@bitrise/bitkit-v2/-/bitkit-v2-0.3.266.tgz",
-      "integrity": "sha512-5Fd2zDrUriPAAKPJOZBn2uJMovNzP3VVnX7MU8cpdq376lRSnJI/fJvhzbwtsyrSoo3nKfi8VftdFp7vOOu+1Q==",
+      "version": "0.3.270",
+      "resolved": "https://registry.npmjs.org/@bitrise/bitkit-v2/-/bitkit-v2-0.3.270.tgz",
+      "integrity": "sha512-qbxCzse68ftYv829BZfjEgRdmct/wWHSmVlaB5g6leFaOR/rZFmEl3abyc4KAKO+iwNV0ZgHKMUxZ97+51e8cw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@bitrise/bitkit": "^13.358.0",
-    "@bitrise/bitkit-v2": "0.3.266",
+    "@bitrise/bitkit-v2": "0.3.270",
     "@bitrise/languageserver": "git+https://github.com/bitrise-io/bitrise-yml-language-server.git#833b15995769404349b63986ea779b60fccce531",
     "@dagrejs/dagre": "^3.0.0",
     "@datadog/browser-rum": "^7.3.0",

--- a/source/javascripts/components/JumpToDefinitionLink/CrossFileJumpButton.tsx
+++ b/source/javascripts/components/JumpToDefinitionLink/CrossFileJumpButton.tsx
@@ -1,4 +1,4 @@
-import { ControlButton } from '@bitrise/bitkit';
+import { BitkitControlButton, IconArrowNortheast } from '@bitrise/bitkit-v2';
 import { Box } from '@chakra-ui/react/box';
 
 import { EntityKind } from '@/core/models/Tree';
@@ -17,14 +17,7 @@ const CrossFileJumpButton = ({ kind, id, onOpenChange }: Props) => (
       kind={kind}
       id={id}
       onOpenChange={onOpenChange}
-      trigger={
-        <ControlButton
-          size="xs"
-          iconName="ArrowNorthEast"
-          aria-label="Go to definition"
-          tooltipProps={{ 'aria-label': 'Go to definition' }}
-        />
-      }
+      trigger={<BitkitControlButton size="xs" icon={IconArrowNortheast} label="Go to definition" />}
     />
   </Box>
 );

--- a/source/javascripts/components/JumpToDefinitionLink/JumpToDefinitionLink.tsx
+++ b/source/javascripts/components/JumpToDefinitionLink/JumpToDefinitionLink.tsx
@@ -48,7 +48,7 @@ const JumpToDefinitionLink = ({ kind, id, children, trigger, onOpenChange }: Pro
       nodeIds={definitionNodeIds}
       onSelect={handleSelect}
       onOpenChange={onOpenChange}
-      trigger={trigger ?? <BitkitLinkButton>{children ?? ''}</BitkitLinkButton>}
+      trigger={trigger ?? <BitkitLinkButton>{children ?? 'Go to definition'}</BitkitLinkButton>}
     />
   );
 };

--- a/source/javascripts/components/JumpToDefinitionLink/JumpToDefinitionLink.tsx
+++ b/source/javascripts/components/JumpToDefinitionLink/JumpToDefinitionLink.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@bitrise/bitkit';
+import { BitkitLinkButton } from '@bitrise/bitkit-v2';
 import { ReactElement, ReactNode, useCallback, useMemo } from 'react';
 
 import { EntityKind } from '@/core/models/Tree';
@@ -47,13 +47,7 @@ const JumpToDefinitionLink = ({ kind, id, children, trigger, onOpenChange }: Pro
       nodeIds={definitionNodeIds}
       onSelect={handleSelect}
       onOpenChange={onOpenChange}
-      trigger={
-        trigger ?? (
-          <Link as="button" colorScheme="purple">
-            {children}
-          </Link>
-        )
-      }
+      trigger={trigger ?? <BitkitLinkButton>{children as string}</BitkitLinkButton>}
     />
   );
 };

--- a/source/javascripts/components/JumpToDefinitionLink/JumpToDefinitionLink.tsx
+++ b/source/javascripts/components/JumpToDefinitionLink/JumpToDefinitionLink.tsx
@@ -1,5 +1,5 @@
 import { BitkitLinkButton } from '@bitrise/bitkit-v2';
-import { ReactElement, ReactNode, useCallback, useMemo } from 'react';
+import { ReactElement, useCallback, useMemo } from 'react';
 
 import { EntityKind } from '@/core/models/Tree';
 import EntityIndexService from '@/core/services/EntityIndexService';
@@ -12,7 +12,8 @@ import FilePickerMenu from './FilePickerMenu';
 type Props = {
   kind: EntityKind;
   id: string;
-  children?: ReactNode;
+  /** Label for the default link trigger. Ignored when a custom `trigger` is provided. */
+  children?: string;
   trigger?: ReactElement<{ onClick?: () => void }>;
   onOpenChange?: (isOpen: boolean) => void;
 };
@@ -47,7 +48,7 @@ const JumpToDefinitionLink = ({ kind, id, children, trigger, onOpenChange }: Pro
       nodeIds={definitionNodeIds}
       onSelect={handleSelect}
       onOpenChange={onOpenChange}
-      trigger={trigger ?? <BitkitLinkButton>{children as string}</BitkitLinkButton>}
+      trigger={trigger ?? <BitkitLinkButton>{children ?? ''}</BitkitLinkButton>}
     />
   );
 };

--- a/source/javascripts/components/JumpToDefinitionLink/JumpToFileButton.tsx
+++ b/source/javascripts/components/JumpToDefinitionLink/JumpToFileButton.tsx
@@ -1,4 +1,4 @@
-import { ControlButton } from '@bitrise/bitkit';
+import { BitkitControlButton, IconArrowNortheast } from '@bitrise/bitkit-v2';
 
 import { openTab, recordActiveTabLocation } from '@/core/stores/BitriseYmlStore';
 import { useTree } from '@/hooks/useTree';
@@ -31,14 +31,7 @@ const JumpToFileButton = ({ nodeId }: Props) => {
         recordActiveTabLocation(window.parent.location.hash);
         openTab(id, { preview: false });
       }}
-      trigger={
-        <ControlButton
-          size="xs"
-          iconName="ArrowNorthEast"
-          aria-label="Go to definition"
-          tooltipProps={{ 'aria-label': 'Go to definition' }}
-        />
-      }
+      trigger={<BitkitControlButton size="xs" icon={IconArrowNortheast} label="Go to definition" />}
     />
   );
 };

--- a/source/javascripts/core/utils/MonacoUtils.ts
+++ b/source/javascripts/core/utils/MonacoUtils.ts
@@ -288,9 +288,25 @@ function onModelMarkerStatusChange(
   };
 }
 
+/** Derive the validation status from the current markers of a model URI. Returns 'valid' when the
+ * model doesn't exist or has no markers (e.g. a file not yet opened in the editor). */
+function getValidationStatusForUri(uri: string): ValidationStatus {
+  const markers = monaco.editor.getModelMarkers({ resource: monaco.Uri.parse(uri) });
+  if (markers.some((m) => m.severity === monaco.MarkerSeverity.Error)) return 'invalid';
+  if (markers.some((m) => m.severity === monaco.MarkerSeverity.Warning)) return 'warnings';
+  return 'valid';
+}
+
+/** Subscribe to any model's marker changes. Returns an IDisposable to unsubscribe. */
+function onMarkersChange(callback: () => void): monaco.IDisposable {
+  return monaco.editor.onDidChangeMarkers(() => callback());
+}
+
 export default {
   configureForYaml,
   configureBitriseLanguageServer,
   configureEnvVarsCompletionProvider,
   onModelMarkerStatusChange,
+  getValidationStatusForUri,
+  onMarkersChange,
 };

--- a/source/javascripts/core/utils/MonacoUtils.ts
+++ b/source/javascripts/core/utils/MonacoUtils.ts
@@ -297,9 +297,10 @@ function getValidationStatusForUri(uri: string): ValidationStatus {
   return 'valid';
 }
 
-/** Subscribe to any model's marker changes. Returns an IDisposable to unsubscribe. */
-function onMarkersChange(callback: () => void): monaco.IDisposable {
-  return monaco.editor.onDidChangeMarkers(() => callback());
+/** Subscribe to marker changes, forwarding the URIs whose markers changed so callers can filter.
+ * Returns an IDisposable to unsubscribe. */
+function onMarkersChange(callback: (changedUris: readonly monaco.Uri[]) => void): monaco.IDisposable {
+  return monaco.editor.onDidChangeMarkers(callback);
 }
 
 export default {

--- a/source/javascripts/core/utils/YmlUtils.spec.ts
+++ b/source/javascripts/core/utils/YmlUtils.spec.ts
@@ -511,6 +511,17 @@ describe('YmlUtils', () => {
       `);
     });
 
+    it('seeds a root collection when setting into an empty document', () => {
+      const root = YmlUtils.toDoc('');
+
+      YmlUtils.setIn(root, ['workflows', 'wf1'], {});
+
+      expect(YmlUtils.toYml(root)).toEqual(yaml`
+        workflows:
+          wf1: {}
+      `);
+    });
+
     it('should set a value in a YMLSeq at the specified path', () => {
       const root = YmlUtils.toDoc(yaml`
         workflows:

--- a/source/javascripts/core/utils/YmlUtils.spec.ts
+++ b/source/javascripts/core/utils/YmlUtils.spec.ts
@@ -522,6 +522,20 @@ describe('YmlUtils', () => {
       `);
     });
 
+    it('seeds a root collection when the document is a null scalar (saved-then-reloaded empty file)', () => {
+      // An empty module file serializes to the literal `null`, which reparses to a null Scalar.
+      const root = YmlUtils.toDoc('# modules/new.yml\n\nnull\n');
+
+      YmlUtils.setIn(root, ['workflows', 'wf1'], {});
+
+      expect(YmlUtils.toYml(root)).toEqual(yaml`
+        # modules/new.yml
+
+        workflows:
+          wf1: {}
+      `);
+    });
+
     it('should set a value in a YMLSeq at the specified path', () => {
       const root = YmlUtils.toDoc(yaml`
         workflows:

--- a/source/javascripts/core/utils/YmlUtils.ts
+++ b/source/javascripts/core/utils/YmlUtils.ts
@@ -239,8 +239,9 @@ function setIn(root: Root, path: Path, value: unknown, stringToTypedValue = true
   const isEmptyDocument =
     isDocument(root) && (root.contents == null || (isScalar(root.contents) && root.contents.value == null));
   if (isEmptyDocument) {
-    const firstSegmentAsIndex = Number(path[0]);
-    root.contents = root.createNode(Number.isInteger(firstSegmentAsIndex) && firstSegmentAsIndex >= 0 ? [] : {});
+    // A numeric path segment is a seq index; a string key (even a numeric-looking '0') is a map key.
+    const firstSegmentIsIndex = typeof path[0] === 'number' && Number.isInteger(path[0]) && path[0] >= 0;
+    root.contents = root.createNode(firstSegmentIsIndex ? [] : {});
   }
 
   let parentPath = [...path.slice(0, -1)];

--- a/source/javascripts/core/utils/YmlUtils.ts
+++ b/source/javascripts/core/utils/YmlUtils.ts
@@ -230,6 +230,15 @@ function setIn(root: Root, path: Path, value: unknown, stringToTypedValue = true
     throw new Error('Path cannot be empty when setting a value');
   }
 
+  // An empty document has `null` contents. Seed a root collection so a nested `setIn` doesn't throw
+  // "Expected a YAML collection as document contents" — e.g. adding the first workflow to a freshly
+  // created, empty module file. Use `createNode` (not a bare `new YAMLMap()`) so the collection is
+  // schema-bound and auto-creates intermediate nodes. The first path segment decides seq vs map.
+  if (isDocument(root) && root.contents == null) {
+    const firstSegmentAsIndex = Number(path[0]);
+    root.contents = root.createNode(Number.isInteger(firstSegmentAsIndex) && firstSegmentAsIndex >= 0 ? [] : {});
+  }
+
   let parentPath = [...path.slice(0, -1)];
   while (parentPath.length > 0 && isNil(root.getIn(parentPath))) {
     if (root.getIn(parentPath) === null) {

--- a/source/javascripts/core/utils/YmlUtils.ts
+++ b/source/javascripts/core/utils/YmlUtils.ts
@@ -230,11 +230,15 @@ function setIn(root: Root, path: Path, value: unknown, stringToTypedValue = true
     throw new Error('Path cannot be empty when setting a value');
   }
 
-  // An empty document has `null` contents. Seed a root collection so a nested `setIn` doesn't throw
-  // "Expected a YAML collection as document contents" — e.g. adding the first workflow to a freshly
-  // created, empty module file. Use `createNode` (not a bare `new YAMLMap()`) so the collection is
-  // schema-bound and auto-creates intermediate nodes. The first path segment decides seq vs map.
-  if (isDocument(root) && root.contents == null) {
+  // An empty document has no usable root collection, so a nested `setIn` throws "Expected a YAML
+  // collection as document contents" — e.g. adding the first workflow to an empty module file. This
+  // covers both shapes of "empty": freshly created (`contents` is `null`) and saved-then-reloaded
+  // (an empty doc serializes to the literal `null`, which reparses to a null-valued Scalar). Seed a
+  // root collection via `createNode` (not a bare `new YAMLMap()`) so it's schema-bound and
+  // auto-creates intermediate nodes. The first path segment decides seq vs map.
+  const isEmptyDocument =
+    isDocument(root) && (root.contents == null || (isScalar(root.contents) && root.contents.value == null));
+  if (isEmptyDocument) {
     const firstSegmentAsIndex = Number(path[0]);
     root.contents = root.createNode(Number.isInteger(firstSegmentAsIndex) && firstSegmentAsIndex >= 0 ? [] : {});
   }

--- a/source/javascripts/hooks/useFileTabValidationStatuses.spec.tsx
+++ b/source/javascripts/hooks/useFileTabValidationStatuses.spec.tsx
@@ -1,0 +1,73 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react';
+
+import MonacoUtils from '@/core/utils/MonacoUtils';
+
+import useFileTabValidationStatuses from './useFileTabValidationStatuses';
+
+jest.mock('@/core/utils/MonacoUtils', () => ({
+  __esModule: true,
+  default: {
+    getValidationStatusForUri: jest.fn(),
+    onMarkersChange: jest.fn(),
+  },
+}));
+
+const monaco = MonacoUtils as jest.Mocked<typeof MonacoUtils>;
+const uri = (nodeId: string) => `file:///modular/${nodeId}`;
+// Marker-change payload mimics Monaco's Uri[] (only `toString()` is used by the hook).
+const changed = (uris: string[]) => uris.map((u) => ({ toString: () => u }));
+
+describe('useFileTabValidationStatuses', () => {
+  let emitMarkerChange: (changedUris: unknown) => void = () => {};
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    monaco.onMarkersChange.mockImplementation((cb) => {
+      emitMarkerChange = cb as (changedUris: unknown) => void;
+      return { dispose: jest.fn() };
+    });
+    monaco.getValidationStatusForUri.mockReturnValue('valid');
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('computes a status per open tab on mount', () => {
+    monaco.getValidationStatusForUri.mockImplementation((u) => (u === uri('n1') ? 'invalid' : 'warnings'));
+
+    const { result } = renderHook(() => useFileTabValidationStatuses(['n1', 'n2']));
+
+    expect(result.current).toEqual({ n1: 'invalid', n2: 'warnings' });
+  });
+
+  it('recomputes when a marker changes for an open tab', () => {
+    const { result } = renderHook(() => useFileTabValidationStatuses(['n1']));
+    expect(result.current).toEqual({ n1: 'valid' });
+
+    monaco.getValidationStatusForUri.mockReturnValue('invalid');
+    act(() => {
+      emitMarkerChange(changed([uri('n1')]));
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(result.current).toEqual({ n1: 'invalid' });
+  });
+
+  it('ignores marker changes for models that are not open tabs', () => {
+    const { result } = renderHook(() => useFileTabValidationStatuses(['n1']));
+    monaco.getValidationStatusForUri.mockClear();
+
+    act(() => {
+      emitMarkerChange(changed(['file:///merged_config.yml']));
+      jest.advanceTimersByTime(250);
+    });
+
+    expect(monaco.getValidationStatusForUri).not.toHaveBeenCalled();
+    expect(result.current).toEqual({ n1: 'valid' });
+  });
+});

--- a/source/javascripts/hooks/useFileTabValidationStatuses.ts
+++ b/source/javascripts/hooks/useFileTabValidationStatuses.ts
@@ -18,6 +18,7 @@ export default function useFileTabValidationStatuses(nodeIds: string[]): Record<
 
   useEffect(() => {
     const ids = key ? key.split('\n') : [];
+    const tabUris = new Set(ids.map(fileModelUri));
     const recompute = () =>
       setStatuses(Object.fromEntries(ids.map((id) => [id, MonacoUtils.getValidationStatusForUri(fileModelUri(id))])));
 
@@ -25,7 +26,13 @@ export default function useFileTabValidationStatuses(nodeIds: string[]): Record<
     // Markers settle in two passes (monaco-yaml's schema layer + the slower Bitrise LS); debounce
     // the recompute so the dot doesn't flicker through a premature status.
     const debounced = debounce(recompute, 250);
-    const subscription = MonacoUtils.onMarkersChange(debounced);
+    // Only react to marker changes for the open file tabs — ignore the background/merged models and
+    // any other Monaco instances on the page.
+    const subscription = MonacoUtils.onMarkersChange((changedUris) => {
+      if (changedUris.some((uri) => tabUris.has(uri.toString()))) {
+        debounced();
+      }
+    });
     return () => {
       debounced.cancel();
       subscription.dispose();

--- a/source/javascripts/hooks/useFileTabValidationStatuses.ts
+++ b/source/javascripts/hooks/useFileTabValidationStatuses.ts
@@ -11,8 +11,8 @@ const fileModelUri = (nodeId: string) => `file:///modular/${nodeId}`;
  * model's markers and kept live via `onDidChangeMarkers`. Files without a loaded model (not yet
  * opened in the YAML editor) report `valid` — there are no markers to read.
  */
-export default function useFileTabValidationStatuses(nodeIds: string[]): Record<string, ValidationStatus> {
-  const [statuses, setStatuses] = useState<Record<string, ValidationStatus>>({});
+export default function useFileTabValidationStatuses(nodeIds: string[]): Partial<Record<string, ValidationStatus>> {
+  const [statuses, setStatuses] = useState<Partial<Record<string, ValidationStatus>>>({});
   // Stable primitive dep so the effect only re-subscribes when the set of open tabs changes.
   const key = nodeIds.join('\n');
 

--- a/source/javascripts/hooks/useFileTabValidationStatuses.ts
+++ b/source/javascripts/hooks/useFileTabValidationStatuses.ts
@@ -1,0 +1,36 @@
+import { debounce } from 'es-toolkit';
+import { useEffect, useState } from 'react';
+
+import MonacoUtils, { type ValidationStatus } from '@/core/utils/MonacoUtils';
+
+// Mirrors the model path ModularYmlEditor gives each module file's editor.
+const fileModelUri = (nodeId: string) => `file:///modular/${nodeId}`;
+
+/**
+ * Validation status (`valid` | `warnings` | `invalid`) per open file tab, derived from its Monaco
+ * model's markers and kept live via `onDidChangeMarkers`. Files without a loaded model (not yet
+ * opened in the YAML editor) report `valid` — there are no markers to read.
+ */
+export default function useFileTabValidationStatuses(nodeIds: string[]): Record<string, ValidationStatus> {
+  const [statuses, setStatuses] = useState<Record<string, ValidationStatus>>({});
+  // Stable primitive dep so the effect only re-subscribes when the set of open tabs changes.
+  const key = nodeIds.join('\n');
+
+  useEffect(() => {
+    const ids = key ? key.split('\n') : [];
+    const recompute = () =>
+      setStatuses(Object.fromEntries(ids.map((id) => [id, MonacoUtils.getValidationStatusForUri(fileModelUri(id))])));
+
+    recompute();
+    // Markers settle in two passes (monaco-yaml's schema layer + the slower Bitrise LS); debounce
+    // the recompute so the dot doesn't flicker through a premature status.
+    const debounced = debounce(recompute, 250);
+    const subscription = MonacoUtils.onMarkersChange(debounced);
+    return () => {
+      debounced.cancel();
+      subscription.dispose();
+    };
+  }, [key]);
+
+  return statuses;
+}

--- a/source/javascripts/pages/ContainersPage/components/ContainerUsageTable.tsx
+++ b/source/javascripts/pages/ContainersPage/components/ContainerUsageTable.tsx
@@ -1,4 +1,5 @@
-import { ControlButton, Table, Tbody, Td, Text, Th, Thead, Tr } from '@bitrise/bitkit';
+import { Table, Tbody, Td, Text, Th, Thead, Tr } from '@bitrise/bitkit';
+import { BitkitControlButton, IconArrowNortheast } from '@bitrise/bitkit-v2';
 
 import CrossFileJumpButton from '@/components/JumpToDefinitionLink/CrossFileJumpButton';
 import useNavigation from '@/hooks/useNavigation';
@@ -32,9 +33,10 @@ const ContainerUsageTable = ({ workflows }: Props) => {
               {isModular ? (
                 <CrossFileJumpButton kind="workflows" id={workflowId} />
               ) : (
-                <ControlButton
-                  aria-label="Go to Workflow"
-                  iconName="ArrowNorthEast"
+                <BitkitControlButton
+                  size="xs"
+                  icon={IconArrowNortheast}
+                  label="Go to Workflow"
                   onClick={() => replace('/workflows', { workflow_id: workflowId })}
                 />
               )}

--- a/source/javascripts/pages/StacksAndMachinesPage/tabs/DefaultTab.tsx
+++ b/source/javascripts/pages/StacksAndMachinesPage/tabs/DefaultTab.tsx
@@ -1,4 +1,5 @@
-import { Box, ControlButton, Text } from '@bitrise/bitkit';
+import { Box, Text } from '@bitrise/bitkit';
+import { BitkitControlButton, IconArrowNortheast } from '@bitrise/bitkit-v2';
 import { useMemo } from 'react';
 
 import FilePickerMenu from '@/components/JumpToDefinitionLink/FilePickerMenu';
@@ -57,14 +58,7 @@ const DefaultTab = () => {
               rootNode={tree}
               nodeIds={metaNodeIds}
               onSelect={(nodeId) => openTab(nodeId, { preview: false })}
-              trigger={
-                <ControlButton
-                  size="xs"
-                  iconName="ArrowNorthEast"
-                  aria-label="Go to definition"
-                  tooltipProps={{ 'aria-label': 'Go to definition' }}
-                />
-              }
+              trigger={<BitkitControlButton size="xs" icon={IconArrowNortheast} label="Go to definition" />}
             />
           )}
         </Box>

--- a/source/javascripts/pages/YmlPage/components/OpenFileTabs/OpenFileTabs.tsx
+++ b/source/javascripts/pages/YmlPage/components/OpenFileTabs/OpenFileTabs.tsx
@@ -3,17 +3,28 @@ import { useRef, useState } from 'react';
 
 import FileTreeViewer from '@/components/FileTreeViewer/FileTreeViewer';
 import { FileTabInfo, useFileTabs } from '@/hooks/useFileTabs';
+import useFileTabValidationStatuses from '@/hooks/useFileTabValidationStatuses';
 
 import DiscardFileTabDialog from './DiscardFileTabDialog';
 
 const OpenFileTabs = () => {
   const { fileTabs, activeTab, mergedConfigNodeId, selectTab, selectMergedConfig, closeTab, discardFile } =
     useFileTabs();
+  const validationStatuses = useFileTabValidationStatuses(fileTabs.map((tab) => tab.nodeId));
   const [discardNodeId, setDiscardNodeId] = useState<string | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const addButtonRef = useRef<HTMLButtonElement>(null);
 
   const discardTab = fileTabs.find((tab) => tab.nodeId === discardNodeId);
+
+  // Validation outranks the unsaved marker: a broken/warning file is more urgent to surface than a
+  // clean-but-unsaved one. Validation colours only apply to files with a loaded Monaco model.
+  const tabStatusColor = (tab: FileTabInfo) => {
+    const status = validationStatuses[tab.nodeId];
+    if (status === 'invalid') return 'red';
+    if (status === 'warnings') return 'yellow';
+    return tab.isDirty ? 'purple' : undefined;
+  };
 
   // Closing a tab with unsaved edits prompts first; a clean tab closes immediately.
   const handleClose = (tab: FileTabInfo) => {
@@ -45,7 +56,7 @@ const OpenFileTabs = () => {
             key={tab.nodeId}
             value={tab.nodeId}
             onClose={() => handleClose(tab)}
-            statusColor={tab.isDirty ? 'purple' : undefined}
+            statusColor={tabStatusColor(tab)}
             title={tab.editable ? undefined : `Read-only${tab.refLabel ? ` — included from ${tab.refLabel}` : ''}`}
           >
             {tab.name}


### PR DESCRIPTION
A few related workflow-editor changes batched into one PR (separate commits).

### 1. Migrate the jump-to-definition triggers to bitkit-v2 (+ fix a dead "Edit definition" link)
The jump area's triggers move from v1 (Chakra v2) to bitkit-v2:
- icon triggers → `BitkitControlButton` + `IconArrowNortheast` (`CrossFileJumpButton`, `JumpToFileButton`, `DefaultTab`, `ContainerUsageTable`); v2's `label` covers both the accessible name and the tooltip.
- the default text trigger ("Edit definition" / "Go to definition") → `BitkitLinkButton` (a real `<button>` with purple link styling). The old v1 `Link` didn't wire up as a Chakra-v3 `BitkitActionMenu` `asChild` trigger, so the link **did nothing** — most visibly on the pipeline config panels for cross-file workflows. Now the menu opens.

### 2. Fix: "Expected a YAML collection as document contents"
Adding the first entity (e.g. a workflow) to an **empty** module file threw — the document had no root collection. `YmlUtils.setIn` now seeds a schema-bound root collection (via `createNode`) when the document is empty. Covers both shapes of empty: freshly created (`null` contents) and saved-then-reloaded (serializes to the literal `null`, reparses to a null Scalar). Unit tests added.

### 3. Colour file tabs by validation status
The open-file tab dot now reflects each file's Monaco validation: **error → red**, **warning → yellow**, otherwise the existing **unsaved → purple** (validation outranks unsaved). Per-file status comes from the file's Monaco model markers (same source as the editor squiggles), kept live via `onDidChangeMarkers`; files without a loaded model report valid and fall back to the unsaved dot.

### 4. Bump `@bitrise/bitkit-v2` to `0.3.270`

### Verify
- `tsc`, ESLint clean; `YmlUtils.spec.ts` 251/251.