### PR TITLE
Misc UI fixes 2: diff dialog, provenance, read-only pipeline, Update-config redesign

### DIFF
--- a/source/javascripts/components/CrossFileProvenanceText.tsx
+++ b/source/javascripts/components/CrossFileProvenanceText.tsx
@@ -1,21 +1,46 @@
 import { Text } from '@bitrise/bitkit';
+import { Fragment } from 'react';
 
 type Props = {
-  definingPath?: string;
+  definingPaths?: string[];
   sourceLabel?: string;
   pathTextStyle?: string;
 };
 
-export const crossFileProvenanceLabel = (definingPath?: string) => `Defined in ${definingPath || 'another file'}`;
+const MULTIPLE_LABEL = 'multiple modules';
 
-const CrossFileProvenanceText = ({ definingPath, sourceLabel, pathTextStyle = 'body/sm/semibold' }: Props) => (
-  <>
-    Defined in{' '}
-    <Text as="span" textStyle={pathTextStyle}>
-      {definingPath ?? 'another file'}
-    </Text>
-    {sourceLabel ? ` • ${sourceLabel}` : ''}
-  </>
-);
+// One or two defining files are listed by path; three or more collapse to "multiple modules".
+// Falls back to "another file" when no path is known.
+export const crossFileProvenanceLabel = (definingPaths: string[] = []) => {
+  if (definingPaths.length > 2) {
+    return `Defined in ${MULTIPLE_LABEL}`;
+  }
+  if (definingPaths.length === 0) {
+    return 'Defined in another file';
+  }
+  return `Defined in ${definingPaths.join(', ')}`;
+};
+
+const CrossFileProvenanceText = ({ definingPaths = [], sourceLabel, pathTextStyle = 'body/sm/semibold' }: Props) => {
+  const isMultiple = definingPaths.length > 2;
+  const paths = isMultiple ? [MULTIPLE_LABEL] : definingPaths.length ? definingPaths : ['another file'];
+  // The cross-repo source badge only makes sense for a single, concrete file.
+  const showSource = sourceLabel && !isMultiple && paths.length === 1;
+
+  return (
+    <>
+      Defined in{' '}
+      {paths.map((path, index) => (
+        <Fragment key={path}>
+          {index > 0 ? ', ' : ''}
+          <Text as="span" textStyle={pathTextStyle}>
+            {path}
+          </Text>
+        </Fragment>
+      ))}
+      {showSource ? ` • ${sourceLabel}` : ''}
+    </>
+  );
+};
 
 export default CrossFileProvenanceText;

--- a/source/javascripts/components/CrossFileProvenanceText.tsx
+++ b/source/javascripts/components/CrossFileProvenanceText.tsx
@@ -1,5 +1,4 @@
 import { Text } from '@bitrise/bitkit';
-import { Fragment } from 'react';
 
 type Props = {
   definingPaths?: string[];
@@ -24,20 +23,16 @@ export const crossFileProvenanceLabel = (definingPaths: string[] = []) => {
 const CrossFileProvenanceText = ({ definingPaths = [], sourceLabel, pathTextStyle = 'body/sm/semibold' }: Props) => {
   const isMultiple = definingPaths.length > 2;
   const paths = isMultiple ? [MULTIPLE_LABEL] : definingPaths.length ? definingPaths : ['another file'];
-  // The cross-repo source badge only makes sense for a single, concrete file.
-  const showSource = sourceLabel && !isMultiple && paths.length === 1;
+  // The cross-repo source badge only makes sense for a single, concrete defining file (not the
+  // "another file" fallback, nor the "multiple modules" summary).
+  const showSource = Boolean(sourceLabel) && definingPaths.length === 1;
 
   return (
     <>
       Defined in{' '}
-      {paths.map((path, index) => (
-        <Fragment key={path}>
-          {index > 0 ? ', ' : ''}
-          <Text as="span" textStyle={pathTextStyle}>
-            {path}
-          </Text>
-        </Fragment>
-      ))}
+      <Text as="span" textStyle={pathTextStyle}>
+        {paths.join(', ')}
+      </Text>
       {showSource ? ` • ${sourceLabel}` : ''}
     </>
   );

--- a/source/javascripts/components/DiffEditor/DiffEditorDialog.tsx
+++ b/source/javascripts/components/DiffEditor/DiffEditorDialog.tsx
@@ -124,15 +124,15 @@ export const DiffEditorDialogContent = ({ onClose, nodeId, tabs, isReadOnly }: C
         <Icon name="Cross" />
       </ModalCloseButton>
       <DialogBody flex="1" display="flex" flexDirection="column" gap="16" minHeight="0">
+        <Notification status="info">
+          {isMerged
+            ? 'The merged configuration built from your saved files (left) vs. your current unsaved changes (right). This view is read-only.'
+            : isReadOnly
+              ? 'This file is read-only — changes here cannot be saved.'
+              : 'You can edit the right side of the diff view, and your changes will be saved'}
+        </Notification>
         {tabs}
         <Box flex="1" display="flex" flexDirection="column" gap="16" minWidth="0">
-          <Notification status="info">
-            {isMerged
-              ? 'The merged configuration built from your saved files (left) vs. your current unsaved changes (right). This view is read-only.'
-              : isReadOnly
-                ? 'This file is read-only — changes here cannot be saved.'
-                : 'You can edit the right side of the diff view, and your changes will be saved'}
-          </Notification>
           <DiffEditor
             key={nodeId ?? 'legacy'}
             originalText={originalText}

--- a/source/javascripts/components/DiffEditor/GlobalDiffEditorDialog.tsx
+++ b/source/javascripts/components/DiffEditor/GlobalDiffEditorDialog.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import TreeService from '@/core/services/TreeService';
 import { isFileDirty, MERGED_CONFIG_NODE_ID } from '@/core/stores/BitriseYmlStore';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
+import useMergedConfigSync from '@/hooks/useMergedConfigSync';
 
 import { DiffEditorDialogContent, DiffEditorDialogShell } from './DiffEditorDialog';
 
@@ -25,6 +26,10 @@ const GlobalDiffEditorDialogBody = ({ onClose }: { onClose: VoidFunction }) => {
   // If the selected file tab vanished (saved/discarded elsewhere), fall back to the merged tab.
   const effectiveTab = selectedTab === MERGED_CONFIG_NODE_ID || selectedFile ? selectedTab : MERGED_CONFIG_NODE_ID;
   const isMerged = effectiveTab === MERGED_CONFIG_NODE_ID;
+
+  // The merge is a backend round-trip; trigger it (like the main Merged tab does) so the dialog's
+  // Merged tab shows the live merged config even before saving.
+  useMergedConfigSync({ active: isMerged });
 
   return (
     <DiffEditorDialogContent

--- a/source/javascripts/components/unified-editor/ChainWorkflowDrawer/components/ChainableWorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/ChainWorkflowDrawer/components/ChainableWorkflowCard.tsx
@@ -37,7 +37,7 @@ const ChainableWorkflowCard = ({ chainableWorkflowId, parentWorkflowId, onChainW
         </Text>
         <Text textStyle="body/sm/regular" color="text/secondary">
           {crossFile.isCrossFile ? (
-            <CrossFileProvenanceText definingPath={crossFile.definingPath} sourceLabel={crossFile.sourceLabel} />
+            <CrossFileProvenanceText definingPaths={crossFile.definingPaths} sourceLabel={crossFile.sourceLabel} />
           ) : (
             WorkflowService.getUsedByText(dependants)
           )}

--- a/source/javascripts/components/unified-editor/StepBundleConfig/StepBundleConfigHeader.tsx
+++ b/source/javascripts/components/unified-editor/StepBundleConfig/StepBundleConfigHeader.tsx
@@ -26,7 +26,7 @@ const StepBundleConfigHeader = ({ variant }: HeaderProps) => {
   const { replace } = useNavigation();
 
   const isMergedView = useIsMergedConfigSelected();
-  const { isCrossFile, hasDefinition, definingPath } = useCrossFileEntity('stepBundles', stepBundleId);
+  const { isCrossFile, hasDefinition, definingPaths } = useCrossFileEntity('stepBundles', stepBundleId);
   const shouldJumpToDefinition = isCrossFile || (isMergedView && hasDefinition);
   const editDefinitionLink = shouldJumpToDefinition ? (
     <JumpToDefinitionLink kind="stepBundles" id={stepBundleId} />
@@ -40,7 +40,7 @@ const StepBundleConfigHeader = ({ variant }: HeaderProps) => {
   let subtitle: ReactNode = usedIn;
   if (variant === 'drawer') {
     const middle = isCrossFile ? (
-      <CrossFileProvenanceText definingPath={definingPath} pathTextStyle="body/md/semibold" />
+      <CrossFileProvenanceText definingPaths={definingPaths} pathTextStyle="body/md/semibold" />
     ) : (
       usedIn
     );

--- a/source/javascripts/components/unified-editor/StepSelectorDrawer/components/SelectableStepBundleCard.tsx
+++ b/source/javascripts/components/unified-editor/StepSelectorDrawer/components/SelectableStepBundleCard.tsx
@@ -43,7 +43,7 @@ const SelectableStepBundleCard = (props: SelectableStepBundleCardProps) => {
           </Text>
           <Text textStyle="body/md/regular" color="text/secondary">
             {crossFile.isCrossFile ? (
-              <CrossFileProvenanceText definingPath={crossFile.definingPath} sourceLabel={crossFile.sourceLabel} />
+              <CrossFileProvenanceText definingPaths={crossFile.definingPaths} sourceLabel={crossFile.sourceLabel} />
             ) : (
               usedInWorkflowsText
             )}

--- a/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
+++ b/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
@@ -47,7 +47,7 @@ const StepBundleCard = (props: StepBundleCardProps) => {
 
   // Cross-file: bundle definition lives in another module — a subtle tint signals it.
   const bundleId = StepBundleService.cvsToId(cvs);
-  const { isCrossFile, hasDefinition, definingPath } = useCrossFileEntity('stepBundles', bundleId);
+  const { isCrossFile, hasDefinition, definingPaths } = useCrossFileEntity('stepBundles', bundleId);
   const isReadOnlyView = useIsReadOnlyView();
   const isMergedView = useIsMergedConfigSelected();
   // In the merged view every bundle resolves locally, but its definition still lives in a module — offer a jump.
@@ -237,7 +237,7 @@ const StepBundleCard = (props: StepBundleCardProps) => {
                 </Text>
                 <Box display="flex" alignItems="center" gap="4">
                   <Text textStyle="body/sm/regular" color="text/secondary" hasEllipsis>
-                    {isCrossFile ? crossFileProvenanceLabel(definingPath) : usedInWorkflowsText}
+                    {isCrossFile ? crossFileProvenanceLabel(definingPaths) : usedInWorkflowsText}
                   </Text>
                   {referenceIds.length > 0 && (
                     <>

--- a/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.stories.tsx
+++ b/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.stories.tsx
@@ -1,6 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { delay, http, HttpResponse } from 'msw';
 
+import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { bitriseYmlStore, initializeModularConfig, updateFileDocument } from '@/core/stores/BitriseYmlStore';
+import YmlUtils from '@/core/utils/YmlUtils';
 import { getCiConfig } from '@/pages/YmlPage/components/ConfigurationYmlStorage.mswMocks';
 
 import UpdateConfigurationDialog from './UpdateConfigurationDialog';
@@ -14,6 +17,33 @@ const formatYml = () => {
   });
 };
 
+const SHA = 'a1b2c3d4e5f6789012345678901234567890abcd';
+
+const moduleLeaf = (nodeId: string, path: string): TreeNode => ({
+  nodeId,
+  path,
+  contents: `# ${path}\n`,
+  source: { path, repository: null, branch: null, tag: null, commit: null },
+  commitSha: SHA,
+  editable: true,
+  includes: [],
+});
+
+const MODULAR_ROOT: TreeNode = {
+  nodeId: 'n_root',
+  path: 'bitrise.yml',
+  contents: 'format_version: "13"\n',
+  source: null,
+  commitSha: SHA,
+  editable: true,
+  includes: [
+    moduleLeaf('n_pipelines', 'ci_config/pipelines/pipelines.yml'),
+    moduleLeaf('n_workflows', 'ci_config/workflows/workflows.yml'),
+  ],
+};
+
+const ENTITY_INDEX: EntityIndex = { workflows: {}, pipelines: {}, stepBundles: {} };
+
 export default {
   component: UpdateConfigurationDialog,
   args: {
@@ -22,6 +52,10 @@ export default {
   argTypes: {
     onClose: { type: 'function' },
   },
+  // Stories share the module-level store; start each one from a single (non-modular) config.
+  beforeEach: () => {
+    bitriseYmlStore.setState({ tree: undefined, files: {} });
+  },
   parameters: {
     msw: {
       handlers: [formatYml(), getCiConfig()],
@@ -29,9 +63,11 @@ export default {
   },
 } as Meta<typeof UpdateConfigurationDialog>;
 
-export const Default: StoryObj = {};
+type Story = StoryObj<typeof UpdateConfigurationDialog>;
 
-export const Failed: StoryObj = {
+export const Default: Story = {};
+
+export const Failed: Story = {
   parameters: {
     msw: {
       handlers: [
@@ -41,5 +77,20 @@ export const Failed: StoryObj = {
         ),
       ],
     },
+  },
+};
+
+export const Modular: Story = {
+  beforeEach: () => {
+    initializeModularConfig({ root: MODULAR_ROOT, entityIndex: ENTITY_INDEX, branch: 'main', commitSha: SHA });
+    // Make both module files dirty so they show up as changed modules.
+    updateFileDocument('n_pipelines', ({ doc }) => {
+      YmlUtils.setIn(doc, ['pipelines', 'pl-1'], {});
+      return doc;
+    });
+    updateFileDocument('n_workflows', ({ doc }) => {
+      YmlUtils.setIn(doc, ['workflows', 'wf-1'], {});
+      return doc;
+    });
   },
 };

--- a/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
+++ b/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
@@ -1,28 +1,69 @@
-import { BitkitButton, BitkitDialog, createBitkitToast, IconCopy, IconDownload } from '@bitrise/bitkit-v2';
+import {
+  BitkitButton,
+  BitkitControlButton,
+  BitkitDialog,
+  BitkitNoteCard,
+  BitkitSectionHeading,
+  createBitkitToast,
+  IconCopy,
+  IconDownload,
+} from '@bitrise/bitkit-v2';
 import { Box } from '@chakra-ui/react/box';
 import { Text } from '@chakra-ui/react/text';
 import { useState } from 'react';
 import { useCopyToClipboard } from 'usehooks-ts';
 
 import { trackCopyYmlClicked, trackDownloadYmlClicked } from '@/core/analytics/ConfigManagementAnalytics';
-import { getYmlString } from '@/core/stores/BitriseYmlStore';
+import TreeService from '@/core/services/TreeService';
+import { getFileYmlString, getYmlString, isFileDirty } from '@/core/stores/BitriseYmlStore';
 import { download } from '@/core/utils/CommonUtils';
 import PageProps from '@/core/utils/PageProps';
+import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
+import { useShallow } from '@/hooks/useShallow';
 
 type Props = {
   isOpen: boolean;
   onClose: () => void;
 };
 
+type ChangedFileRow = {
+  key: string;
+  name: string;
+  getContent: () => string;
+};
+
+const moduleCountLabel = (count: number) => `${count} ${count === 1 ? 'module' : 'modules'} changed`;
+
 const DialogContent = ({ onClose }: Pick<Props, 'onClose'>) => {
   const [, copyToClipboard] = useCopyToClipboard();
   const { defaultBranch, gitRepoSlug } = PageProps.app() ?? {};
   const [isCopiedOrDownloded, setIsCopiedOrDownloaded] = useState(false);
 
-  const handleCopyToClipboard = () => {
-    trackCopyYmlClicked('git', 'update_configuration_yml_modal');
+  const isModular = useBitriseYmlStore((s) => Boolean(s.tree));
+  const changedModules = useBitriseYmlStore(
+    useShallow((s) =>
+      !s.tree
+        ? []
+        : Object.values(s.files)
+            .filter((slice) => isFileDirty(slice))
+            .map((slice) => ({ nodeId: slice.nodeId, path: slice.path, name: TreeService.fileName(slice.path) })),
+    ),
+  );
 
-    copyToClipboard(getYmlString()).then((isCopied) => {
+  // Single config → one synthetic "bitrise.yml" row (the whole config); modular → one row per changed module file.
+  const rows: ChangedFileRow[] = isModular
+    ? changedModules.map(({ nodeId, name }) => ({ key: nodeId, name, getContent: () => getFileYmlString(nodeId) }))
+    : [{ key: 'bitrise.yml', name: 'bitrise.yml', getContent: getYmlString }];
+
+  const handleDownload = (row: ChangedFileRow) => {
+    trackDownloadYmlClicked('git', 'update_configuration_yml_modal');
+    download(row.getContent(), row.name, 'application/yaml;charset=utf-8');
+    setIsCopiedOrDownloaded(true);
+  };
+
+  const handleCopy = (row: ChangedFileRow) => {
+    trackCopyYmlClicked('git', 'update_configuration_yml_modal');
+    copyToClipboard(row.getContent()).then((isCopied) => {
       if (isCopied) {
         createBitkitToast({
           titleText: 'Copied to clipboard',
@@ -41,54 +82,57 @@ const DialogContent = ({ onClose }: Pick<Props, 'onClose'>) => {
     });
   };
 
-  const handleDownloadClick = () => {
-    trackDownloadYmlClicked('git', 'update_configuration_yml_modal');
-
-    download(getYmlString(), 'bitrise.yml', 'application/yaml;charset=utf-8');
-
-    setIsCopiedOrDownloaded(true);
-  };
-
   return (
     <>
       <BitkitDialog.Body>
-        <Text>
-          If you would like to apply these changes to your configuration, depending on your setup, you need to do the
-          following:
-        </Text>
-        <Box display="flex" flexDirection="column">
-          <Text textStyle="heading/h4" marginBlockEnd="4">
-            Using a single configuration file
+        <Box display="flex" flexDirection="column" gap="24">
+          {isModular && (
+            <BitkitNoteCard
+              status="info"
+              title={moduleCountLabel(changedModules.length)}
+              message={changedModules.map((module) => module.path).join(', ')}
+            />
+          )}
+
+          <Text textStyle="body/lg/regular" color="text/body">
+            {isModular
+              ? 'You need to re-create the changes in the relevant configuration file on your Git repository.'
+              : `You need to update the content of the configuration YAML in the ${gitRepoSlug} repository's ${defaultBranch} branch.`}
           </Text>
-          <Text marginBlockEnd="16">
-            Update the content of the configuration YAML in the {gitRepoSlug} repository&apos;s {defaultBranch} branch.
-          </Text>
-          <Box display="flex" flexDirection="column" gap="8">
-            <BitkitButton
-              size="sm"
-              variant="tertiary"
-              width="fit-content"
-              icon={IconDownload}
-              onClick={handleDownloadClick}
-            >
-              Download changed version
-            </BitkitButton>
-            <BitkitButton
-              size="sm"
-              variant="tertiary"
-              width="fit-content"
-              icon={IconCopy}
-              onClick={handleCopyToClipboard}
-            >
-              Copy changed configuration
-            </BitkitButton>
+
+          <Box display="flex" flexDirection="column" gap="24">
+            <BitkitSectionHeading
+              label={isModular ? moduleCountLabel(changedModules.length) : 'Changed configuration'}
+            />
+            <Box border="1px solid" borderColor="border/regular" borderRadius="8" overflow="hidden">
+              {rows.map((row, index) => (
+                <Box
+                  key={row.key}
+                  display="flex"
+                  alignItems="center"
+                  gap="8"
+                  height="56"
+                  paddingInline="24"
+                  borderBlockEnd={index < rows.length - 1 ? '1px solid' : undefined}
+                  borderColor="border/minimal"
+                >
+                  <Text flex="1" minWidth="0" truncate textStyle="body/md/regular" color="text/body">
+                    {row.name}
+                  </Text>
+                  <BitkitControlButton
+                    icon={IconDownload}
+                    label="Download changed version"
+                    onClick={() => handleDownload(row)}
+                  />
+                  <BitkitControlButton
+                    icon={IconCopy}
+                    label="Copy changed configuration"
+                    onClick={() => handleCopy(row)}
+                  />
+                </Box>
+              ))}
+            </Box>
           </Box>
-        </Box>
-        <Box display="flex" flexDirection="column">
-          <Text textStyle="heading/h4" marginBlockEnd="4">
-            Using multiple configuration files
-          </Text>
-          <Text>You need to re-create the changes in the relevant configuration file on your Git repository.</Text>
         </Box>
       </BitkitDialog.Body>
       <BitkitDialog.Footer>

--- a/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
+++ b/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
@@ -105,9 +105,14 @@ const DialogContent = ({ onClose }: Pick<Props, 'onClose'>) => {
           )}
 
           <Text textStyle="body/lg/regular" color="text/body">
-            {isModular
-              ? 'You need to re-create the changes in the relevant configuration file on your Git repository.'
-              : `You need to update the content of the configuration YAML in the ${gitRepoSlug} repository's ${defaultBranch} branch.`}
+            {isModular ? (
+              'You need to re-create the changes in the relevant configuration file on your Git repository.'
+            ) : (
+              <>
+                You need to update the content of the configuration YAML in the {gitRepoSlug} repository&apos;s{' '}
+                {defaultBranch} branch.
+              </>
+            )}
           </Text>
 
           <Box display="flex" flexDirection="column" gap="24">

--- a/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
+++ b/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
@@ -115,24 +115,22 @@ const DialogContent = ({ onClose }: Pick<Props, 'onClose'>) => {
               label={isModular ? moduleCountLabel(changedModules.length) : 'Changed configuration'}
             />
             <Card.Root elevation={false} overflow="hidden">
-              <Table.Root variant="borderless">
+              <Table.Root variant="borderless" size="md">
                 <Table.Body>
                   {rows.map((row) => (
                     <Table.Row key={row.key}>
                       <Table.Cell>{row.name}</Table.Cell>
-                      <Table.Cell>
-                        <Box display="flex" gap="8" justifyContent="flex-end">
-                          <BitkitControlButton
-                            icon={IconDownload}
-                            label="Download changed version"
-                            onClick={() => handleDownload(row)}
-                          />
-                          <BitkitControlButton
-                            icon={IconCopy}
-                            label="Copy changed configuration"
-                            onClick={() => handleCopy(row)}
-                          />
-                        </Box>
+                      <Table.Cell display="flex" alignItems="center" justifyContent="flex-end" gap="8">
+                        <BitkitControlButton
+                          icon={IconDownload}
+                          label="Download changed version"
+                          onClick={() => handleDownload(row)}
+                        />
+                        <BitkitControlButton
+                          icon={IconCopy}
+                          label="Copy changed configuration"
+                          onClick={() => handleCopy(row)}
+                        />
                       </Table.Cell>
                     </Table.Row>
                   ))}

--- a/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
+++ b/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
@@ -9,6 +9,8 @@ import {
   IconDownload,
 } from '@bitrise/bitkit-v2';
 import { Box } from '@chakra-ui/react/box';
+import { Card } from '@chakra-ui/react/card';
+import { Table } from '@chakra-ui/react/table';
 import { Text } from '@chakra-ui/react/text';
 import { useState } from 'react';
 import { useCopyToClipboard } from 'usehooks-ts';
@@ -104,34 +106,31 @@ const DialogContent = ({ onClose }: Pick<Props, 'onClose'>) => {
             <BitkitSectionHeading
               label={isModular ? moduleCountLabel(changedModules.length) : 'Changed configuration'}
             />
-            <Box border="1px solid" borderColor="border/regular" borderRadius="8" overflow="hidden">
-              {rows.map((row, index) => (
-                <Box
-                  key={row.key}
-                  display="flex"
-                  alignItems="center"
-                  gap="8"
-                  height="56"
-                  paddingInline="24"
-                  borderBlockEnd={index < rows.length - 1 ? '1px solid' : undefined}
-                  borderColor="border/minimal"
-                >
-                  <Text flex="1" minWidth="0" truncate textStyle="body/md/regular" color="text/body">
-                    {row.name}
-                  </Text>
-                  <BitkitControlButton
-                    icon={IconDownload}
-                    label="Download changed version"
-                    onClick={() => handleDownload(row)}
-                  />
-                  <BitkitControlButton
-                    icon={IconCopy}
-                    label="Copy changed configuration"
-                    onClick={() => handleCopy(row)}
-                  />
-                </Box>
-              ))}
-            </Box>
+            <Card.Root elevation={false} overflow="hidden">
+              <Table.Root variant="borderless">
+                <Table.Body>
+                  {rows.map((row) => (
+                    <Table.Row key={row.key}>
+                      <Table.Cell>{row.name}</Table.Cell>
+                      <Table.Cell>
+                        <Box display="flex" gap="8" justifyContent="flex-end">
+                          <BitkitControlButton
+                            icon={IconDownload}
+                            label="Download changed version"
+                            onClick={() => handleDownload(row)}
+                          />
+                          <BitkitControlButton
+                            icon={IconCopy}
+                            label="Copy changed configuration"
+                            onClick={() => handleCopy(row)}
+                          />
+                        </Box>
+                      </Table.Cell>
+                    </Table.Row>
+                  ))}
+                </Table.Body>
+              </Table.Root>
+            </Card.Root>
           </Box>
         </Box>
       </BitkitDialog.Body>

--- a/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
+++ b/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
@@ -37,7 +37,7 @@ const moduleCountLabel = (count: number) => `${count} ${count === 1 ? 'module' :
 const DialogContent = ({ onClose }: Pick<Props, 'onClose'>) => {
   const [, copyToClipboard] = useCopyToClipboard();
   const { defaultBranch, gitRepoSlug } = PageProps.app() ?? {};
-  const [isCopiedOrDownloded, setIsCopiedOrDownloaded] = useState(false);
+  const [isCopiedOrDownloaded, setIsCopiedOrDownloaded] = useState(false);
 
   const isModular = useBitriseYmlStore((s) => Boolean(s.tree));
   const changedModules = useBitriseYmlStore(
@@ -140,7 +140,7 @@ const DialogContent = ({ onClose }: Pick<Props, 'onClose'>) => {
           <BitkitButton variant="secondary" onClick={onClose}>
             Cancel
           </BitkitButton>
-          <BitkitButton state={!isCopiedOrDownloded ? 'disabled' : undefined} onClick={onClose}>
+          <BitkitButton state={!isCopiedOrDownloaded ? 'disabled' : undefined} onClick={onClose}>
             Done
           </BitkitButton>
         </BitkitDialog.Buttons>

--- a/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
+++ b/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
@@ -31,6 +31,7 @@ type Props = {
 type ChangedFileRow = {
   key: string;
   name: string;
+  downloadName: string;
   getContent: () => string;
 };
 
@@ -54,12 +55,19 @@ const DialogContent = ({ onClose }: Pick<Props, 'onClose'>) => {
 
   // Single config → one synthetic "bitrise.yml" row (the whole config); modular → one row per changed module file.
   const rows: ChangedFileRow[] = isModular
-    ? changedModules.map(({ nodeId, name }) => ({ key: nodeId, name, getContent: () => getFileYmlString(nodeId) }))
-    : [{ key: 'bitrise.yml', name: 'bitrise.yml', getContent: getYmlString }];
+    ? changedModules.map(({ nodeId, path, name }) => ({
+        key: nodeId,
+        name,
+        // Full path (slashes → dashes) as the download filename so same-named modules in different
+        // folders don't collide; the basename stays the displayed label (full paths are in the note above).
+        downloadName: path.replace(/\//g, '-'),
+        getContent: () => getFileYmlString(nodeId),
+      }))
+    : [{ key: 'bitrise.yml', name: 'bitrise.yml', downloadName: 'bitrise.yml', getContent: getYmlString }];
 
   const handleDownload = (row: ChangedFileRow) => {
     trackDownloadYmlClicked('git', 'update_configuration_yml_modal');
-    download(row.getContent(), row.name, 'application/yaml;charset=utf-8');
+    download(row.getContent(), row.downloadName, 'application/yaml;charset=utf-8');
     setIsCopiedOrDownloaded(true);
   };
 

--- a/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
@@ -75,7 +75,7 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
   const workflow = useWorkflow(workflowId, (s) => (s ? { title: s?.userValues?.title } : undefined));
   const stackName = useWorkflowStackName(workflowId);
 
-  const { isCrossFile, hasDefinition, definingPath } = useCrossFileEntity('workflows', workflowId);
+  const { isCrossFile, hasDefinition, definingPaths } = useCrossFileEntity('workflows', workflowId);
   const isReadOnlyView = useIsReadOnlyView();
   const isMergedView = useIsMergedConfigSelected();
   const showJumpButton = isCrossFile || (isMergedView && hasDefinition);
@@ -116,7 +116,7 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
   if (uses) {
     subtitle = `Uses ${uses}`;
   } else if (isCrossFile) {
-    subtitle = crossFileProvenanceLabel(definingPath);
+    subtitle = crossFileProvenanceLabel(definingPaths);
   }
 
   return (

--- a/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
@@ -32,7 +32,7 @@ type Props = {
 const ChainedWorkflowCard = ({ id, index, uniqueId, placement, isSortable, isDragging, parentWorkflowId }: Props) => {
   const zoom = useReactFlowZoom();
   const workflow = useWorkflow(id, (s) => (s?.id ? { title: s.userValues.title } : undefined));
-  const { isCrossFile, hasDefinition, definingPath } = useCrossFileEntity('workflows', id);
+  const { isCrossFile, hasDefinition, definingPaths } = useCrossFileEntity('workflows', id);
   const isReadOnlyView = useIsReadOnlyView();
   const isMergedView = useIsMergedConfigSelected();
   const showJumpButton = isCrossFile || (isMergedView && hasDefinition);
@@ -204,7 +204,7 @@ const ChainedWorkflowCard = ({ id, index, uniqueId, placement, isSortable, isDra
               <Text textStyle="body/sm/regular" color="text/secondary" hasEllipsis>
                 {placement}
                 {' • '}
-                {isCrossFile ? crossFileProvenanceLabel(definingPath) : WorkflowService.getUsedByText(dependants)}
+                {isCrossFile ? crossFileProvenanceLabel(definingPaths) : WorkflowService.getUsedByText(dependants)}
               </Text>
             </Box>
 

--- a/source/javascripts/components/unified-editor/WorkflowConfig/components/WorkflowConfigHeader.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowConfig/components/WorkflowConfigHeader.tsx
@@ -22,7 +22,7 @@ const WorkflowConfigHeader = ({ variant, context, parentWorkflowId }: Props) => 
 
   const dependants = useDependantWorkflows({ workflowId: id });
 
-  const { isCrossFile, hasDefinition, definingPath } = useCrossFileEntity('workflows', id);
+  const { isCrossFile, hasDefinition, definingPaths } = useCrossFileEntity('workflows', id);
   const isMergedView = useIsMergedConfigSelected();
   const showDefinitionLink = isCrossFile || (isMergedView && hasDefinition);
 
@@ -60,7 +60,7 @@ const WorkflowConfigHeader = ({ variant, context, parentWorkflowId }: Props) => 
             <Text textStyle="body/sm/regular" color="text/secondary">
               {isCrossFile && (
                 <>
-                  <CrossFileProvenanceText definingPath={definingPath} />
+                  <CrossFileProvenanceText definingPaths={definingPaths} />
                   {' • '}
                 </>
               )}

--- a/source/javascripts/hooks/useMergedConfigSync.spec.tsx
+++ b/source/javascripts/hooks/useMergedConfigSync.spec.tsx
@@ -8,6 +8,8 @@ import { TreeNode } from '@/core/models/Tree';
 import {
   bitriseYmlStore,
   initializeModularConfig,
+  MERGED_CONFIG_NODE_ID,
+  openTab,
   selectMergedConfig,
   updateFileDocument,
 } from '@/core/stores/BitriseYmlStore';
@@ -109,5 +111,26 @@ describe('useMergedConfigSync', () => {
     });
     await waitFor(() => expect(bitriseYmlStore.getState().mergedYml).toBe('merged: FRESH'));
     expect(bitriseYmlStore.getState().mergedYmlStale).toBe(false);
+  });
+
+  it('merges when `active` is forced on, even off the merged tab (e.g. the diff dialog)', async () => {
+    const merge = jest.spyOn(BitriseYmlApi, 'getMergedConfig').mockResolvedValue({ mergedYml: 'merged: forced' });
+    openTab('child-a'); // selection is a file tab, not the merged config
+    expect(bitriseYmlStore.getState().selectedNodeId).not.toBe(MERGED_CONFIG_NODE_ID);
+
+    renderHook(() => useMergedConfigSync({ active: true }));
+
+    await waitFor(() => expect(bitriseYmlStore.getState().mergedYml).toBe('merged: forced'));
+    expect(merge).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not merge when `active` is false, even on the merged tab', () => {
+    const merge = jest.spyOn(BitriseYmlApi, 'getMergedConfig').mockResolvedValue({ mergedYml: 'merged: nope' });
+    expect(bitriseYmlStore.getState().selectedNodeId).toBe(MERGED_CONFIG_NODE_ID);
+
+    renderHook(() => useMergedConfigSync({ active: false }));
+
+    expect(merge).not.toHaveBeenCalled();
+    expect(bitriseYmlStore.getState().mergedYml).toBeUndefined();
   });
 });

--- a/source/javascripts/hooks/useMergedConfigSync.ts
+++ b/source/javascripts/hooks/useMergedConfigSync.ts
@@ -29,6 +29,9 @@ export default function useMergedConfigSync({ active }: { active?: boolean } = {
     }
 
     isFetchingRef.current = true;
+    // Set on cleanup (the merged view was left, or staleness resolved) so an in-flight loop stops
+    // instead of re-merging in the background until the tree stabilizes.
+    let aborted = false;
 
     // Reads live store state each pass (not closed-over deps), so an edit that lands while a fetch is
     // in flight — which re-sets mergedYmlStale to true without toggling it, so the effect never
@@ -36,7 +39,7 @@ export default function useMergedConfigSync({ active }: { active?: boolean } = {
     // current one) and a fresh merge runs for the post-edit tree.
     const runMerge = () => {
       const state = bitriseYmlStore.getState();
-      if (!state.mergedYmlStale) {
+      if (aborted || !state.mergedYmlStale) {
         isFetchingRef.current = false;
         return;
       }
@@ -50,6 +53,10 @@ export default function useMergedConfigSync({ active }: { active?: boolean } = {
       const requestedTree = JSON.stringify(tree);
       BitriseYmlApi.getMergedConfig({ projectSlug: PageProps.appSlug(), tree, branch: state.configBranch })
         .then((result) => {
+          if (aborted) {
+            isFetchingRef.current = false;
+            return;
+          }
           // Apply only if the tree we merged is still current; otherwise an edit landed
           // mid-flight and the result is stale — re-merge the fresh tree instead.
           if (JSON.stringify(getModularConfigTree()) === requestedTree) {
@@ -66,5 +73,9 @@ export default function useMergedConfigSync({ active }: { active?: boolean } = {
     };
 
     runMerge();
+
+    return () => {
+      aborted = true;
+    };
   }, [isActive, isStale]);
 }

--- a/source/javascripts/hooks/useMergedConfigSync.ts
+++ b/source/javascripts/hooks/useMergedConfigSync.ts
@@ -11,33 +11,32 @@ import {
 import PageProps from '@/core/utils/PageProps';
 
 /**
- * Re-merges the live tree whenever the Merged tab is active and stale. Mounted
- * once in `MainLayout` so the merge is available on the entity pages too.
+ * Re-merges the live tree (backend round-trip) whenever the merged view is active and stale, and
+ * stores the result as `mergedYml`. Mounted once in `MainLayout` for the main Merged tab; the diff
+ * dialog's Merged tab passes `active` so it gets the same live merge regardless of the main selection.
  */
-export default function useMergedConfigSync() {
+export default function useMergedConfigSync({ active }: { active?: boolean } = {}) {
   const selectedNodeId = useStore(bitriseYmlStore, (s) => s.selectedNodeId);
   const isStale = useStore(bitriseYmlStore, (s) => s.mergedYmlStale);
-  const isMerged = selectedNodeId === MERGED_CONFIG_NODE_ID;
+  const isActive = active ?? selectedNodeId === MERGED_CONFIG_NODE_ID;
 
   // Ref (not state) so the fetch doesn't re-enter and we avoid a setState in the effect.
   const isFetchingRef = useRef(false);
 
   useEffect(() => {
-    if (!isMerged || !isStale || isFetchingRef.current) {
+    if (!isActive || !isStale || isFetchingRef.current) {
       return;
     }
 
     isFetchingRef.current = true;
 
-    // Reads live store state each pass (not closed-over deps), so an edit that lands
-    // while a fetch is in flight — which re-sets mergedYmlStale to true without
-    // toggling it, so the effect never re-runs — is still picked up: the in-flight
-    // result is discarded and a fresh merge runs for the post-edit tree. This also
-    // covers the tab-switch race (merged→file→edit→merged before the first fetch
-    // resolves), where the persistent ref would otherwise block any re-trigger.
+    // Reads live store state each pass (not closed-over deps), so an edit that lands while a fetch is
+    // in flight — which re-sets mergedYmlStale to true without toggling it, so the effect never
+    // re-runs — is still picked up: the in-flight result is discarded (its tree no longer matches the
+    // current one) and a fresh merge runs for the post-edit tree.
     const runMerge = () => {
       const state = bitriseYmlStore.getState();
-      if (state.selectedNodeId !== MERGED_CONFIG_NODE_ID || !state.mergedYmlStale) {
+      if (!state.mergedYmlStale) {
         isFetchingRef.current = false;
         return;
       }
@@ -67,5 +66,5 @@ export default function useMergedConfigSync() {
     };
 
     runMerge();
-  }, [isMerged, isStale]);
+  }, [isActive, isStale]);
 }

--- a/source/javascripts/hooks/useTree.ts
+++ b/source/javascripts/hooks/useTree.ts
@@ -84,7 +84,10 @@ export type CrossFileEntityInfo = {
   /** Defined in some file (local or cross-file) — i.e. present in the entity index. */
   hasDefinition: boolean;
   isCrossFile: boolean;
+  /** Path of the top-most (highest-precedence) defining file. */
   definingPath?: string;
+  /** Paths of every file that defines the entity, in precedence order. */
+  definingPaths?: string[];
   sourceLabel?: string;
 };
 
@@ -95,17 +98,22 @@ export function useCrossFileEntity(kind: EntityKind, id: string): CrossFileEntit
       kind === 'appEnvs'
         ? Boolean(s.yml.app?.envs?.some((env) => env && id !== 'opts' && id in env))
         : Boolean(s.yml[SECTION_BY_KIND[kind]]?.[id]);
-    const nodeId = EntityIndexService.definingNodeId(s.entityIndex, kind, id);
+    const definitions = EntityIndexService.definitionsOf(s.entityIndex, kind, id);
+    const nodeId = definitions[0]?.nodeId;
     const hasDefinition = Boolean(nodeId);
     if (isLocal || !nodeId) {
       return { isLocal, hasDefinition, isCrossFile: false };
     }
     const file = s.files[nodeId];
+    const definingPaths = definitions
+      .map((definition) => s.files[definition.nodeId]?.path)
+      .filter((path): path is string => Boolean(path));
     return {
       isLocal,
       hasDefinition,
       isCrossFile: true,
       definingPath: file?.path,
+      definingPaths,
       sourceLabel: TreeService.sourceLabel(file?.source ?? null) ?? undefined,
     };
   });

--- a/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/Handles.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/PipelineCanvas/GraphPipelineCanvas/components/Handles.tsx
@@ -4,6 +4,8 @@ import { Icon, IconProps } from 'chakra-ui-2--react';
 import { CSSProperties, useRef } from 'react';
 import { useHover } from 'usehooks-ts';
 
+import { useIsReadOnlyView } from '@/hooks/useTree';
+
 import usePipelineSelector from '../../../../hooks/usePipelineSelector';
 import { PipelinesPageDialogType, usePipelinesPageStore } from '../../../../PipelinesPage.store';
 import { PLACEHOLDER_NODE_ID, WORKFLOW_NODE_HEIGHT } from '../GraphPipelineCanvas.const';
@@ -136,10 +138,13 @@ export const RightHandle = (props: BoxProps) => {
   const ref = useRef(null);
   const edges = useEdges();
   const hover = useHover(ref);
+  const isReadOnly = useIsReadOnlyView();
   const fromHandle = useConnection((s) => s.fromHandle);
 
   const isDragging = fromHandle?.position === Position.Right && fromHandle?.nodeId === id;
-  const isInButtonState = isDragging || (hover && !fromHandle);
+  // Read-only (merged / cross-file) views have no "add workflow" affordance: no + button, and the
+  // plain handle below is non-interactive (pointer-events: none), so no new connections either.
+  const isInButtonState = !isReadOnly && (isDragging || (hover && !fromHandle));
   const isSelected = edges.some(({ source, selected }) => source === id && selected);
   const isHighlighted = edges.some(({ source, data }) => source === id && data?.highlighted);
 

--- a/source/javascripts/pages/PipelinesPage/components/WorkflowSelectorDrawer/components/SelectableWorkflowCard.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/WorkflowSelectorDrawer/components/SelectableWorkflowCard.tsx
@@ -49,7 +49,7 @@ const SelectableWorkflowCard = ({ id, onClick }: Props) => {
             {/* A cross-file workflow's pipeline-usage + stack live in its defining
                 module, not this file — show provenance instead of stale counts. */}
             {crossFile.isCrossFile ? (
-              <CrossFileProvenanceText definingPath={crossFile.definingPath} sourceLabel={crossFile.sourceLabel} />
+              <CrossFileProvenanceText definingPaths={crossFile.definingPaths} sourceLabel={crossFile.sourceLabel} />
             ) : (
               <>
                 {usedInPipelinesText}


### PR DESCRIPTION
A second batch of modular-YAML editor UI fixes + the Update configuration YAML dialog redesign. Reviewable commit-by-commit.

## Changes

1. **Diff dialog — notification above the tabs.** The info/read-only notification in the "Show diff" window moved from inside the editor column to the top of the dialog body, above the file tab bar.

2. **Provenance label lists every defining file.** The "Defined in …" cross-file label (workflow cards, chained cards, config headers, selector drawers — all via `useCrossFileEntity` + `CrossFileProvenanceText`) used to show only the top-most defining file. It now lists every file that defines the entity: one or two files are named, three or more collapse to **"Defined in multiple modules"**. `useCrossFileEntity` gains `definingPaths` (all paths in precedence order, from `EntityIndexService.definitionsOf`).

3. **Read-only pipelines — no "add workflow" affordance.** In merged / cross-file (read-only) views, hovering a pipeline workflow node still showed the `+` button and spawned the dashed "Workflow" placeholder (and let you open the workflow selector / drag a new connection). The RightHandle button state is now gated on `!useIsReadOnlyView()`, so there's no `+`, no placeholder, and the plain handle stays non-interactive.

4. **Diff dialog — live merged config before saving.** The merge is a backend round-trip (`useMergedConfigSync` sends the module tree and stores the returned `mergedYml`), but it only ran while the main Merged tab was selected. The diff dialog's own Merged tab now triggers the same merge (the hook takes an `active` flag), so the merged view shows the live config even before saving.

5. **Update configuration YAML dialog — redesign (single + modular).** Replaces the static text sections + standalone buttons with the new design:
   - A **"Changed configuration"** section with a **borderless table inside a padding-less Card**, one row per changed file, each with per-file **Download** and **Copy** actions (`BitkitControlButton`).
   - **Single config:** one `bitrise.yml` row (the whole config) + the repo/branch instruction.
   - **Modular:** an info **NoteCard** ("N module(s) changed" + the full module paths), the re-create instruction, and one row per changed module — Download/Copy act on that module's own content (`getFileYmlString`), with unique download filenames (full path) so same-named modules don't collide.
   - Adds a **Modular** Storybook story alongside the existing single-config ones.

## Verification

- `tsc --noEmit`: 0 errors
- `eslint`: 0 errors
- `jest`: 1350/1350 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)