### PR TITLE
chore: migrate all dialogs to new @bitrise/bitkit-v2 dialog API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bitrise/bitkit": "^13.358.0",
-        "@bitrise/bitkit-v2": "^0.3.273",
+        "@bitrise/bitkit-v2": "0.3.274-beta.1812",
         "@bitrise/languageserver": "git+https://github.com/bitrise-io/bitrise-yml-language-server.git#833b15995769404349b63986ea779b60fccce531",
         "@dagrejs/dagre": "^3.0.0",
         "@datadog/browser-rum": "^7.3.0",
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/@bitrise/bitkit-v2": {
-      "version": "0.3.273",
-      "resolved": "https://registry.npmjs.org/@bitrise/bitkit-v2/-/bitkit-v2-0.3.273.tgz",
-      "integrity": "sha512-YFtL5xdMYm1c+Ifw2cxbnS4ICbaqUZ6lCjWslUPzQ1dvvQ/XMc+K8pdoShG2p4Ccoerl5HbHPeAxAxIpnFEDdg==",
+      "version": "0.3.274-beta.1812",
+      "resolved": "https://registry.npmjs.org/@bitrise/bitkit-v2/-/bitkit-v2-0.3.274-beta.1812.tgz",
+      "integrity": "sha512-RBmCogSSIToryC2TPM9Rzz8qXu3U5seP7lBsn4IggLfdgmkTCL8fmOos4PTXMPpTcGbi99iOa2DZWr9Atw+VOQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bitrise/bitkit": "^13.358.0",
-        "@bitrise/bitkit-v2": "0.3.274-beta.1812",
+        "@bitrise/bitkit-v2": "0.3.274",
         "@bitrise/languageserver": "git+https://github.com/bitrise-io/bitrise-yml-language-server.git#833b15995769404349b63986ea779b60fccce531",
         "@dagrejs/dagre": "^3.0.0",
         "@datadog/browser-rum": "^7.3.0",
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/@bitrise/bitkit-v2": {
-      "version": "0.3.274-beta.1812",
-      "resolved": "https://registry.npmjs.org/@bitrise/bitkit-v2/-/bitkit-v2-0.3.274-beta.1812.tgz",
-      "integrity": "sha512-RBmCogSSIToryC2TPM9Rzz8qXu3U5seP7lBsn4IggLfdgmkTCL8fmOos4PTXMPpTcGbi99iOa2DZWr9Atw+VOQ==",
+      "version": "0.3.274",
+      "resolved": "https://registry.npmjs.org/@bitrise/bitkit-v2/-/bitkit-v2-0.3.274.tgz",
+      "integrity": "sha512-Q2D7f2T75G5sAARuP01rtxMlNF/okIHN0PDSWBEgGV2R97JabEQzVLVsN/HwLQhi055I8/Z5EwGGu8SrE7AsWw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@bitrise/bitkit": "^13.358.0",
-    "@bitrise/bitkit-v2": "0.3.273",
+    "@bitrise/bitkit-v2": "0.3.274-beta.1812",
     "@bitrise/languageserver": "git+https://github.com/bitrise-io/bitrise-yml-language-server.git#833b15995769404349b63986ea779b60fccce531",
     "@dagrejs/dagre": "^3.0.0",
     "@datadog/browser-rum": "^7.3.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@bitrise/bitkit": "^13.358.0",
-    "@bitrise/bitkit-v2": "0.3.274-beta.1812",
+    "@bitrise/bitkit-v2": "0.3.274",
     "@bitrise/languageserver": "git+https://github.com/bitrise-io/bitrise-yml-language-server.git#833b15995769404349b63986ea779b60fccce531",
     "@dagrejs/dagre": "^3.0.0",
     "@datadog/browser-rum": "^7.3.0",

--- a/source/javascripts/components/unified-editor/PushBranchDialog/PushBranchDialog.tsx
+++ b/source/javascripts/components/unified-editor/PushBranchDialog/PushBranchDialog.tsx
@@ -1,15 +1,12 @@
 import {
   BitkitAlert,
   BitkitButton,
-  BitkitDialog,
-  BitkitDialogRoot,
+  BitkitFormDialog,
   BitkitRadio,
   BitkitRadioGroup,
   BitkitTextArea,
   BitkitTextInput,
 } from '@bitrise/bitkit-v2';
-import { Dialog } from '@chakra-ui/react/dialog';
-import { Portal } from '@chakra-ui/react/portal';
 import { useEffect, useMemo } from 'react';
 import { Controller, useForm, useWatch } from 'react-hook-form';
 
@@ -68,93 +65,83 @@ const PushBranchDialog = ({ isOpen, onClose, isPushPending, pushError, onPush, o
   }, [isOpen, reset, defaultValues]);
 
   return (
-    <BitkitDialogRoot
+    <BitkitFormDialog
+      title="Push changes"
       open={isOpen}
       onOpenChange={({ open }) => {
         if (!open) onClose();
       }}
+      onSubmit={handleSubmit(onPush)}
+      footerButtons={
+        <>
+          <BitkitButton
+            variant="tertiary"
+            onClick={() => {
+              onClose();
+              onManualUpdate();
+            }}
+            marginInlineEnd="auto"
+            state={isPushPending ? 'disabled' : undefined}
+          >
+            Manual update
+          </BitkitButton>
+          <BitkitButton variant="secondary" onClick={onClose} state={isPushPending ? 'disabled' : undefined}>
+            Cancel
+          </BitkitButton>
+          <BitkitButton type="submit" state={isPushPending ? 'loading' : !formState.isValid ? 'disabled' : undefined}>
+            Push changes
+          </BitkitButton>
+        </>
+      }
     >
-      <Portal>
-        <Dialog.Backdrop />
-        <Dialog.Positioner>
-          <BitkitDialog.FormContent title="Push changes" onSubmit={handleSubmit(onPush)}>
-            <BitkitDialog.Body>
-              <BitkitRadioGroup
-                aria-label="Target branch"
-                layout="horizontal"
-                value={isCurrentBranch ? 'current' : 'new'}
-                onValueChange={({ value }) => {
-                  const newBranch = value === 'current' ? (configBranch ?? '') : '';
-                  reset(
-                    { branch: newBranch, message: formState.defaultValues?.message ?? defaultValues.message },
-                    { keepErrors: false },
-                  );
-                }}
-              >
-                <BitkitRadio value="current" labelText="Push to current branch" />
-                <BitkitRadio value="new" labelText="Create new branch" />
-              </BitkitRadioGroup>
-              <Controller
-                control={control}
-                name="branch"
-                rules={{
-                  required: 'Branch name is required',
-                  validate: !isCurrentBranch ? validateBranchName : undefined,
-                }}
-                render={({ field, fieldState }) => (
-                  <BitkitTextInput
-                    label="Target branch"
-                    placeholder="new-branch-name"
-                    helperText="Must follow git branch naming rules."
-                    state={isCurrentBranch ? 'readOnly' : undefined}
-                    errorText={fieldState.error?.message}
-                    inputProps={field}
-                  />
-                )}
-              />
-              <Controller
-                control={control}
-                name="message"
-                rules={{ required: 'Commit message is required' }}
-                render={({ field }) => (
-                  <BitkitTextArea
-                    label="Commit message"
-                    placeholder="e.g. Update bitrise.yml via Workflow Editor"
-                    helperText="Appears in your git commit history."
-                    textareaProps={field}
-                  />
-                )}
-              />
-              {pushError && <BitkitAlert variant="critical" messageText={pushError} />}
-            </BitkitDialog.Body>
-            <BitkitDialog.Footer>
-              <BitkitDialog.Buttons>
-                <BitkitButton
-                  variant="tertiary"
-                  onClick={() => {
-                    onClose();
-                    onManualUpdate();
-                  }}
-                  marginInlineEnd="auto"
-                  state={isPushPending ? 'disabled' : undefined}
-                >
-                  Manual update
-                </BitkitButton>
-                <BitkitButton variant="secondary" onClick={onClose} state={isPushPending ? 'disabled' : undefined}>
-                  Cancel
-                </BitkitButton>
-                <BitkitButton
-                  type="submit"
-                  state={isPushPending ? 'loading' : !formState.isValid ? 'disabled' : undefined}
-                >
-                  Push changes
-                </BitkitButton>
-              </BitkitDialog.Buttons>
-            </BitkitDialog.Footer>
-          </BitkitDialog.FormContent>
-        </Dialog.Positioner>
-      </Portal>
-    </BitkitDialogRoot>
+      <BitkitRadioGroup
+        aria-label="Target branch"
+        layout="horizontal"
+        value={isCurrentBranch ? 'current' : 'new'}
+        onValueChange={({ value }) => {
+          const newBranch = value === 'current' ? (configBranch ?? '') : '';
+          reset(
+            { branch: newBranch, message: formState.defaultValues?.message ?? defaultValues.message },
+            { keepErrors: false },
+          );
+        }}
+      >
+        <BitkitRadio value="current" labelText="Push to current branch" />
+        <BitkitRadio value="new" labelText="Create new branch" />
+      </BitkitRadioGroup>
+      <Controller
+        control={control}
+        name="branch"
+        rules={{
+          required: 'Branch name is required',
+          validate: !isCurrentBranch ? validateBranchName : undefined,
+        }}
+        render={({ field, fieldState }) => (
+          <BitkitTextInput
+            label="Target branch"
+            placeholder="new-branch-name"
+            helperText="Must follow git branch naming rules."
+            state={isCurrentBranch ? 'readOnly' : undefined}
+            errorText={fieldState.error?.message}
+            inputProps={field}
+          />
+        )}
+      />
+      <Controller
+        control={control}
+        name="message"
+        rules={{ required: 'Commit message is required' }}
+        render={({ field }) => (
+          <BitkitTextArea
+            label="Commit message"
+            placeholder="e.g. Update bitrise.yml via Workflow Editor"
+            helperText="Appears in your git commit history."
+            textareaProps={field}
+          />
+        )}
+      />
+      {pushError && <BitkitAlert variant="critical" messageText={pushError} />}
+    </BitkitFormDialog>
   );
 };
 

--- a/source/javascripts/components/unified-editor/SwitchBranchDialog/SwitchBranchDialog.tsx
+++ b/source/javascripts/components/unified-editor/SwitchBranchDialog/SwitchBranchDialog.tsx
@@ -1,6 +1,4 @@
-import { BitkitAlert, BitkitButton, BitkitDialog, BitkitDialogRoot, BitkitSelect } from '@bitrise/bitkit-v2';
-import { Dialog } from '@chakra-ui/react/dialog';
-import { Portal } from '@chakra-ui/react/portal';
+import { BitkitAlert, BitkitButton, BitkitFormDialog, BitkitSelect } from '@bitrise/bitkit-v2';
 import { Text } from '@chakra-ui/react/text';
 import { FormEvent, useEffect, useState } from 'react';
 import { useDebounceValue } from 'usehooks-ts';
@@ -69,55 +67,48 @@ const SwitchBranchDialog = ({ isOpen, onClose }: Props) => {
   };
 
   return (
-    <BitkitDialogRoot
+    <BitkitFormDialog
+      title="Switch branch"
       open={isOpen}
       onOpenChange={({ open }) => {
         if (!open) onClose();
       }}
+      onSubmit={handleSubmit}
+      footerButtons={
+        <>
+          <BitkitButton variant="secondary" onClick={onClose}>
+            Cancel
+          </BitkitButton>
+          <BitkitButton
+            type="submit"
+            state={isLoadingConfig ? 'loading' : isSubmitDisabled ? 'disabled' : undefined}
+            onClick={() => trackBranchSwitchAttempted(configBranch, targetBranch)}
+          >
+            Switch
+          </BitkitButton>
+        </>
+      }
     >
-      <Portal>
-        <Dialog.Backdrop />
-        <Dialog.Positioner>
-          <BitkitDialog.FormContent title="Switch branch" onSubmit={handleSubmit}>
-            <BitkitDialog.Body>
-              <Text>Load configuration from selected branch.</Text>
-              <BitkitSelect
-                label="Branch"
-                placeholder="Select branch"
-                items={filteredBranches || []}
-                isLoading={isLoading}
-                value={targetBranch}
-                onValueChange={setSelectedBranch}
-                searchValue={search}
-                onSearchChange={setSearch}
-              />
-              {getBranchesError && <BitkitAlert variant="critical" messageText="Failed to load branches." />}
-              {switchBranchError && (
-                <BitkitAlert
-                  variant="critical"
-                  titleText="Failed to load configuration"
-                  messageText={`Could not load bitrise.yml from ${targetBranch}. Check that the file exists on this branch and try again.`}
-                />
-              )}
-            </BitkitDialog.Body>
-            <BitkitDialog.Footer>
-              <BitkitDialog.Buttons>
-                <BitkitButton variant="secondary" onClick={onClose}>
-                  Cancel
-                </BitkitButton>
-                <BitkitButton
-                  type="submit"
-                  state={isLoadingConfig ? 'loading' : isSubmitDisabled ? 'disabled' : undefined}
-                  onClick={() => trackBranchSwitchAttempted(configBranch, targetBranch)}
-                >
-                  Switch
-                </BitkitButton>
-              </BitkitDialog.Buttons>
-            </BitkitDialog.Footer>
-          </BitkitDialog.FormContent>
-        </Dialog.Positioner>
-      </Portal>
-    </BitkitDialogRoot>
+      <Text>Load configuration from selected branch.</Text>
+      <BitkitSelect
+        label="Branch"
+        placeholder="Select branch"
+        items={filteredBranches || []}
+        isLoading={isLoading}
+        value={targetBranch}
+        onValueChange={setSelectedBranch}
+        searchValue={search}
+        onSearchChange={setSearch}
+      />
+      {getBranchesError && <BitkitAlert variant="critical" messageText="Failed to load branches." />}
+      {switchBranchError && (
+        <BitkitAlert
+          variant="critical"
+          titleText="Failed to load configuration"
+          messageText={`Could not load bitrise.yml from ${targetBranch}. Check that the file exists on this branch and try again.`}
+        />
+      )}
+    </BitkitFormDialog>
   );
 };
 

--- a/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
+++ b/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
@@ -12,7 +12,7 @@ import { Box } from '@chakra-ui/react/box';
 import { Card } from '@chakra-ui/react/card';
 import { Table } from '@chakra-ui/react/table';
 import { Text } from '@chakra-ui/react/text';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useCopyToClipboard } from 'usehooks-ts';
 
 import { trackCopyYmlClicked, trackDownloadYmlClicked } from '@/core/analytics/ConfigManagementAnalytics';
@@ -41,6 +41,12 @@ const UpdateConfigurationDialog = ({ isOpen, onClose }: Props) => {
   const [, copyToClipboard] = useCopyToClipboard();
   const { defaultBranch, gitRepoSlug } = PageProps.app() ?? {};
   const [isCopiedOrDownloaded, setIsCopiedOrDownloaded] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setIsCopiedOrDownloaded(false);
+    }
+  }, [isOpen]);
 
   const isModular = useBitriseYmlStore((s) => Boolean(s.tree));
   const changedModules = useBitriseYmlStore(

--- a/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
+++ b/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
@@ -37,7 +37,7 @@ type ChangedFileRow = {
 
 const moduleCountLabel = (count: number) => `${count} ${count === 1 ? 'module' : 'modules'} changed`;
 
-const DialogContent = ({ onClose }: Pick<Props, 'onClose'>) => {
+const UpdateConfigurationDialog = ({ isOpen, onClose }: Props) => {
   const [, copyToClipboard] = useCopyToClipboard();
   const { defaultBranch, gitRepoSlug } = PageProps.app() ?? {};
   const [isCopiedOrDownloaded, setIsCopiedOrDownloaded] = useState(false);
@@ -93,82 +93,70 @@ const DialogContent = ({ onClose }: Pick<Props, 'onClose'>) => {
   };
 
   return (
-    <>
-      <BitkitDialog.Body>
-        <Box display="flex" flexDirection="column" gap="24">
-          {isModular && (
-            <BitkitNoteCard
-              status="info"
-              title={moduleCountLabel(changedModules.length)}
-              message={changedModules.map((module) => module.path).join(', ')}
-            />
-          )}
-
-          <Text textStyle="body/lg/regular" color="text/body">
-            {isModular ? (
-              'You need to re-create the changes in the relevant configuration file on your Git repository.'
-            ) : (
-              <>
-                You need to update the content of the configuration YAML in the {gitRepoSlug} repository&apos;s{' '}
-                {defaultBranch} branch.
-              </>
-            )}
-          </Text>
-
-          <Box display="flex" flexDirection="column" gap="24">
-            <BitkitSectionHeading
-              label={isModular ? moduleCountLabel(changedModules.length) : 'Changed configuration'}
-            />
-            <Card.Root elevation={false} overflow="hidden">
-              <Table.Root variant="borderless" size="md">
-                <Table.Body>
-                  {rows.map((row) => (
-                    <Table.Row key={row.key}>
-                      <Table.Cell>{row.name}</Table.Cell>
-                      <Table.Cell display="flex" alignItems="center" justifyContent="flex-end" gap="8">
-                        <BitkitControlButton
-                          icon={IconDownload}
-                          label="Download changed version"
-                          onClick={() => handleDownload(row)}
-                        />
-                        <BitkitControlButton
-                          icon={IconCopy}
-                          label="Copy changed configuration"
-                          onClick={() => handleCopy(row)}
-                        />
-                      </Table.Cell>
-                    </Table.Row>
-                  ))}
-                </Table.Body>
-              </Table.Root>
-            </Card.Root>
-          </Box>
-        </Box>
-      </BitkitDialog.Body>
-      <BitkitDialog.Footer>
-        <BitkitDialog.Buttons>
-          <BitkitButton variant="secondary" onClick={onClose}>
-            Cancel
-          </BitkitButton>
-          <BitkitButton state={!isCopiedOrDownloaded ? 'disabled' : undefined} onClick={onClose}>
-            Done
-          </BitkitButton>
-        </BitkitDialog.Buttons>
-      </BitkitDialog.Footer>
-    </>
-  );
-};
-
-const UpdateConfigurationDialog = ({ isOpen, onClose }: Props) => {
-  return (
     <BitkitDialog
       title="Update configuration YAML"
       open={isOpen}
       onOpenChange={({ open }) => {
         if (!open) onClose();
       }}
+      footerButtons={
+        <>
+          <BitkitButton variant="secondary" onClick={onClose}>
+            Cancel
+          </BitkitButton>
+          <BitkitButton state={!isCopiedOrDownloaded ? 'disabled' : undefined} onClick={onClose}>
+            Done
+          </BitkitButton>
+        </>
+      }
     >
-      <DialogContent onClose={onClose} />
+      <Box display="flex" flexDirection="column" gap="24">
+        {isModular && (
+          <BitkitNoteCard
+            status="info"
+            title={moduleCountLabel(changedModules.length)}
+            message={changedModules.map((module) => module.path).join(', ')}
+          />
+        )}
+
+        <Text textStyle="body/lg/regular" color="text/body">
+          {isModular ? (
+            'You need to re-create the changes in the relevant configuration file on your Git repository.'
+          ) : (
+            <>
+              You need to update the content of the configuration YAML in the {gitRepoSlug} repository&apos;s{' '}
+              {defaultBranch} branch.
+            </>
+          )}
+        </Text>
+
+        <Box display="flex" flexDirection="column" gap="24">
+          <BitkitSectionHeading label={isModular ? moduleCountLabel(changedModules.length) : 'Changed configuration'} />
+          <Card.Root elevation={false} overflow="hidden">
+            <Table.Root variant="borderless" size="md">
+              <Table.Body>
+                {rows.map((row) => (
+                  <Table.Row key={row.key}>
+                    <Table.Cell>{row.name}</Table.Cell>
+                    <Table.Cell display="flex" alignItems="center" justifyContent="flex-end" gap="8">
+                      <BitkitControlButton
+                        icon={IconDownload}
+                        label="Download changed version"
+                        onClick={() => handleDownload(row)}
+                      />
+                      <BitkitControlButton
+                        icon={IconCopy}
+                        label="Copy changed configuration"
+                        onClick={() => handleCopy(row)}
+                      />
+                    </Table.Cell>
+                  </Table.Row>
+                ))}
+              </Table.Body>
+            </Table.Root>
+          </Card.Root>
+        </Box>
+      </Box>
     </BitkitDialog>
   );
 };

--- a/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
+++ b/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
@@ -268,7 +268,7 @@ const GitToBitriseSection = ({ isDisabled, lastModifiedFormatted, onChange, valu
   );
 };
 
-const DialogContent = ({ onClose }: Pick<ConfigurationYmlStorageDialogProps, 'onClose'>) => {
+const ConfigurationYmlSourceDialog = ({ isOpen, onClose }: ConfigurationYmlStorageDialogProps) => {
   const [ymlRootPath, setYmlRootPath] = useState('');
   const [selectedStorage, setSelectedStorage] = useState<CiConfigStorage>('bitrise');
   const [gitToBitriseStorage, setGitToBitriseStorage] = useState<NewCiConfigStorage>('git-ci-config');
@@ -433,41 +433,34 @@ const DialogContent = ({ onClose }: Pick<ConfigurationYmlStorageDialogProps, 'on
   };
 
   return (
-    <>
-      <BitkitDialog.Body>
-        <ConfigStorageGroup value={selectedStorage} isDisabled={isYmlSettingsLoading} onChange={setSelectedStorage} />
-
-        {showYmlRootPathSection && (
-          <GitYmlRootPathSection
-            value={ymlRootPath}
-            isDisabled={isYmlSettingsLoading}
-            defaultValue={ymlSettings?.ymlRootPath}
-            onChange={setYmlRootPath}
-          />
-        )}
-
-        {switchBitriseToGit && <BitriseToGitSection initialYmlRootPath={ymlSettings?.ymlRootPath} />}
-
-        {switchGitToBitrise && (
-          <GitToBitriseSection
-            value={gitToBitriseStorage}
-            isDisabled={isYmlSettingsLoading}
-            onChange={setGitToBitriseStorage}
-            lastModifiedFormatted={lastModifiedFormatted}
-          />
-        )}
-      </BitkitDialog.Body>
-      <BitkitDialog.Footer>
-        {asyncError && (
-          <YmlDialogErrorNotification error={asyncError} marginBlockEnd={showYmlRootPathWarning ? '24' : undefined} />
-        )}
-        {showYmlRootPathWarning && (
-          <BitkitAlert
-            variant="warning"
-            messageText="Ensure that Bitrise has access to all repositories where configuration files are stored."
-          />
-        )}
-        <BitkitDialog.Buttons>
+    <BitkitDialog
+      title="Configuration YAML storage"
+      scrollBehavior="inside"
+      showScrollGradient={false}
+      open={isOpen}
+      onOpenChange={({ open }) => {
+        if (!open) onClose();
+      }}
+      footerContent={
+        asyncError || showYmlRootPathWarning ? (
+          <>
+            {asyncError && (
+              <YmlDialogErrorNotification
+                error={asyncError}
+                marginBlockEnd={showYmlRootPathWarning ? '24' : undefined}
+              />
+            )}
+            {showYmlRootPathWarning && (
+              <BitkitAlert
+                variant="warning"
+                messageText="Ensure that Bitrise has access to all repositories where configuration files are stored."
+              />
+            )}
+          </>
+        ) : undefined
+      }
+      footerButtons={
+        <>
           <BitkitButton variant="secondary" onClick={onClose}>
             Cancel
           </BitkitButton>
@@ -479,24 +472,30 @@ const DialogContent = ({ onClose }: Pick<ConfigurationYmlStorageDialogProps, 'on
               Validate and save
             </BitkitButton>
           </BitkitTooltip>
-        </BitkitDialog.Buttons>
-      </BitkitDialog.Footer>
-    </>
-  );
-};
-
-const ConfigurationYmlSourceDialog = ({ isOpen, onClose }: ConfigurationYmlStorageDialogProps) => {
-  return (
-    <BitkitDialog
-      title="Configuration YAML storage"
-      scrollBehavior="inside"
-      showScrollGradient={false}
-      open={isOpen}
-      onOpenChange={({ open }) => {
-        if (!open) onClose();
-      }}
+        </>
+      }
     >
-      <DialogContent onClose={onClose} />
+      <ConfigStorageGroup value={selectedStorage} isDisabled={isYmlSettingsLoading} onChange={setSelectedStorage} />
+
+      {showYmlRootPathSection && (
+        <GitYmlRootPathSection
+          value={ymlRootPath}
+          isDisabled={isYmlSettingsLoading}
+          defaultValue={ymlSettings?.ymlRootPath}
+          onChange={setYmlRootPath}
+        />
+      )}
+
+      {switchBitriseToGit && <BitriseToGitSection initialYmlRootPath={ymlSettings?.ymlRootPath} />}
+
+      {switchGitToBitrise && (
+        <GitToBitriseSection
+          value={gitToBitriseStorage}
+          isDisabled={isYmlSettingsLoading}
+          onChange={setGitToBitriseStorage}
+          lastModifiedFormatted={lastModifiedFormatted}
+        />
+      )}
     </BitkitDialog>
   );
 };

--- a/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
+++ b/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
@@ -290,11 +290,13 @@ const ConfigurationYmlSourceDialog = ({ isOpen, onClose }: ConfigurationYmlStora
   );
 
   useEffect(() => {
-    if (ymlSettings) {
+    if (isOpen && ymlSettings) {
       setYmlRootPath(ymlSettings.ymlRootPath || '');
       setSelectedStorage(ymlSettings.usesRepositoryYml ? 'git' : 'bitrise');
+      setGitToBitriseStorage('git-ci-config');
+      setAsyncError(null);
     }
-  }, [ymlSettings]);
+  }, [isOpen, ymlSettings]);
 
   useEffect(() => {
     setAsyncError(null);

--- a/source/javascripts/pages/YmlPage/components/OpenFileTabs/DiscardFileTabDialog.tsx
+++ b/source/javascripts/pages/YmlPage/components/OpenFileTabs/DiscardFileTabDialog.tsx
@@ -15,22 +15,20 @@ const DiscardFileTabDialog = ({ isOpen, fileName, onKeepEditing, onDiscard }: Pr
     onOpenChange={({ open }) => {
       if (!open) onKeepEditing();
     }}
-  >
-    <BitkitDialog.Body>
-      <Text>
-        Closing this tab discards your edits to <Text as="strong">{fileName}</Text>.
-      </Text>
-    </BitkitDialog.Body>
-    <BitkitDialog.Footer>
-      <BitkitDialog.Buttons>
+    footerButtons={
+      <>
         <BitkitButton variant="secondary" onClick={onKeepEditing}>
           Keep editing
         </BitkitButton>
         <BitkitButton variant="danger-primary" onClick={onDiscard}>
           Discard and close
         </BitkitButton>
-      </BitkitDialog.Buttons>
-    </BitkitDialog.Footer>
+      </>
+    }
+  >
+    <Text>
+      Closing this tab discards your edits to <Text as="strong">{fileName}</Text>.
+    </Text>
   </BitkitDialog>
 );
 


### PR DESCRIPTION
## Summary

- Migrates all 5 dialog components to the new API introduced by the breaking change

## Changes

The new API removes the compound dialog pattern (`BitkitDialogRoot` + `BitkitDialog.FormContent/Body/Footer/Buttons`) and replaces it with self-contained components that accept `footerButtons` and `footerContent` as props.

| File | Change |
|------|--------|
| `SwitchBranchDialog.tsx` | `BitkitDialogRoot` + `BitkitDialog.FormContent` → `BitkitFormDialog` with `footerButtons` |
| `PushBranchDialog.tsx` | `BitkitDialogRoot` + `BitkitDialog.FormContent` → `BitkitFormDialog` with `footerButtons` |
| `DiscardFileTabDialog.tsx` | `BitkitDialog.Body/.Footer/.Buttons` → `footerButtons` prop |
| `UpdateConfigurationDialog.tsx` | Inner `DialogContent` inlined; `BitkitDialog.Body/.Footer/.Buttons` → `footerButtons` prop |
| `ConfigurationYmlStorageDialog.tsx` | Inner `DialogContent` inlined; `BitkitDialog.Body/.Footer/.Buttons` → `footerContent` + `footerButtons` props |

## Test plan

- [ ] Open the Switch Branch dialog — branches list, cancel, and switch all work
- [ ] Open the Push Changes dialog — radio group, branch name validation, commit message, and push work; "Manual update" link works
- [ ] Open a file tab and try to close it with unsaved changes — Discard dialog appears, "Keep editing" and "Discard and close" both work
- [ ] Open Update Configuration YAML dialog — download and copy enable the "Done" button
- [ ] Open Configuration YAML Storage dialog — storage toggle, path input, validate & save work; error and warning alerts appear in footer when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)