### PR TITLE
Add per-file conflict resolution for modular YML push [BIVS-3703]

### DIFF
--- a/source/javascripts/components/ConfigMergeDialog/ModularConfigMergeDialog.tsx
+++ b/source/javascripts/components/ConfigMergeDialog/ModularConfigMergeDialog.tsx
@@ -1,0 +1,328 @@
+import { Box, Button, ButtonGroup, DialogBody, DialogFooter, Icon, Notification, Text, Tooltip } from '@bitrise/bitkit';
+import { BitkitTabs } from '@bitrise/bitkit-v2';
+import { DiffEditor, MonacoDiffEditor } from '@monaco-editor/react';
+import { ModalCloseButton, ModalHeader } from 'chakra-ui-2--react';
+import type { editor } from 'monaco-editor';
+import { useMemo, useRef, useState } from 'react';
+import { useEventListener } from 'usehooks-ts';
+
+import { PushBranchConflict } from '@/core/api/BranchesApi';
+import TreeService from '@/core/services/TreeService';
+import { getFileSlice, updateFileDocumentByString } from '@/core/stores/BitriseYmlStore';
+import MonacoUtils from '@/core/utils/MonacoUtils';
+import YmlUtils from '@/core/utils/YmlUtils';
+import usePushBranch from '@/hooks/usePushBranch';
+
+import { DiffEditorDialogShell } from '../DiffEditor/DiffEditorDialog';
+import { diffEditorOptions, mergeYamls, readOnlyDiffEditorOptions } from './mergeYamls';
+
+type Props = {
+  isOpen: boolean;
+  onClose: VoidFunction;
+  branch: string;
+  message: string;
+  conflict: PushBranchConflict;
+};
+
+/** Per-file 3-way merge state derived once from the conflict + the local file slice. */
+type FileMerge = {
+  nodeId: string;
+  path: string;
+  name: string;
+  yourYml: string;
+  baseYml: string;
+  remoteYml: string;
+  mergedYml: string;
+  decorations: editor.IModelDeltaDecoration[];
+};
+
+function buildFileMerges(conflict: PushBranchConflict): FileMerge[] {
+  // The BE may list the same file more than once; dedupe by node_id so each
+  // conflicting file gets exactly one tab (tab value/selection keys off node_id).
+  const seen = new Set<string>();
+  const uniqueFiles = conflict.conflicts.filter((file) => {
+    if (seen.has(file.nodeId)) {
+      return false;
+    }
+    seen.add(file.nodeId);
+    return true;
+  });
+
+  return uniqueFiles.map((file) => {
+    const slice = getFileSlice(file.nodeId);
+    const yourYml = slice ? YmlUtils.toYml(slice.ymlDocument) : '';
+    const baseYml = slice ? YmlUtils.toYml(slice.savedYmlDocument) : '';
+    const { mergedYml, decorations } = mergeYamls(yourYml, baseYml, file.remoteYml);
+
+    return {
+      nodeId: file.nodeId,
+      path: file.path,
+      name: TreeService.fileName(file.path),
+      yourYml,
+      baseYml,
+      remoteYml: file.remoteYml,
+      mergedYml,
+      decorations,
+    };
+  });
+}
+
+const ModularConfigMergeDialogBody = ({
+  onClose,
+  branch,
+  message,
+  initialConflict,
+}: {
+  onClose: VoidFunction;
+  branch: string;
+  message: string;
+  initialConflict: PushBranchConflict;
+}) => {
+  // Held in state so a nested conflict (someone pushed again while resolving) can
+  // replace the whole set and re-seed the per-file merges from the new remote.
+  const [conflict, setConflict] = useState(initialConflict);
+  const fileMerges = useMemo(() => buildFileMerges(conflict), [conflict]);
+
+  const [selectedTab, setSelectedTab] = useState(fileMerges[0]?.nodeId ?? '');
+  const effectiveTab = fileMerges.some((f) => f.nodeId === selectedTab) ? selectedTab : (fileMerges[0]?.nodeId ?? '');
+  const activeMerge = fileMerges.find((f) => f.nodeId === effectiveTab);
+
+  // Resolved text + validity per file, keyed by node_id. Seeded from each file's
+  // auto-merge so unvisited tabs still contribute their merged result on apply.
+  const [resolved, setResolved] = useState<Record<string, string>>(() =>
+    Object.fromEntries(fileMerges.map((f) => [f.nodeId, f.mergedYml])),
+  );
+  const [validity, setValidity] = useState<Record<string, 'valid' | 'invalid' | 'warnings'>>(() =>
+    Object.fromEntries(fileMerges.map((f) => [f.nodeId, 'valid' as const])),
+  );
+  // Files the user has edited — skip re-decorating them when their tab remounts.
+  const touched = useRef<Set<string>>(new Set());
+  const [clientError, setClientError] = useState<string>();
+
+  const seedFromConflict = (next: PushBranchConflict) => {
+    const merges = buildFileMerges(next);
+    setConflict(next);
+    setResolved(Object.fromEntries(merges.map((f) => [f.nodeId, f.mergedYml])));
+    setValidity(Object.fromEntries(merges.map((f) => [f.nodeId, 'valid' as const])));
+    touched.current = new Set();
+    setSelectedTab(merges[0]?.nodeId ?? '');
+  };
+
+  const { isPushPending, pushBranch } = usePushBranch({
+    onSuccess: onClose,
+    onMergeConflict: (_branch, nextConflict) => {
+      if (nextConflict) {
+        setClientError('There are changes outside your current editing session. Review and resolve them again.');
+        seedFromConflict(nextConflict);
+      } else {
+        setClientError('Failed to push the resolved changes. Please try again.');
+      }
+    },
+  });
+
+  const onResultEditorMount = (mountedNodeId: string, decorations: editor.IModelDeltaDecoration[]) => {
+    return (diff: MonacoDiffEditor) => {
+      const modified = diff.getModifiedEditor();
+
+      modified.onDidChangeModelContent((e) => {
+        touched.current.add(mountedNodeId);
+        setResolved((prev) => ({ ...prev, [mountedNodeId]: modified.getValue() }));
+
+        const removable = e.changes.reduce<Set<string>>((acc, c) => {
+          for (let i = c.range.startLineNumber; i <= c.range.endLineNumber; i += 1) {
+            modified.getLineDecorations(i)?.forEach((d) => {
+              if (d.options.blockClassName === 'conflict') {
+                acc.add(d.id);
+              }
+            });
+          }
+          return acc;
+        }, new Set<string>());
+        modified.removeDecorations(Array.from(removable));
+      });
+
+      if (!touched.current.has(mountedNodeId)) {
+        diff.createDecorationsCollection(decorations);
+      }
+
+      const model = modified.getModel();
+      if (model) {
+        MonacoUtils.onModelMarkerStatusChange(model, (status) =>
+          setValidity((prev) => ({ ...prev, [mountedNodeId]: status })),
+        );
+      }
+    };
+  };
+
+  const isInvalid = Object.values(validity).some((s) => s === 'invalid');
+
+  const handleApply = () => {
+    setClientError(undefined);
+    // Write each resolved file back into its slice, then re-push the whole tree
+    // based on the branch HEAD we reconciled against (the SHA from the 409).
+    conflict.conflicts.forEach((file) => {
+      const text = resolved[file.nodeId];
+      if (text !== undefined) {
+        updateFileDocumentByString(file.nodeId, text);
+      }
+    });
+    pushBranch({ branch, message, baseCommitSha: conflict.commitSha });
+  };
+
+  useEventListener(
+    'keydown',
+    (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!isInvalid && !isPushPending) {
+          handleApply();
+        }
+      }
+    },
+    undefined,
+    { capture: true },
+  );
+
+  return (
+    <>
+      <ModalHeader display="flex" gap="16" alignItems="center">
+        <Text as="h1" textStyle="comp/dialog/title">
+          Review changes
+        </Text>
+      </ModalHeader>
+      <ModalCloseButton size="large">
+        <Icon name="Cross" />
+      </ModalCloseButton>
+      <DialogBody flex="1" display="flex" flexDirection="column" gap="16" minHeight="0">
+        <Text>
+          There are changes outside your current editing session. Review the differences for each of the modules and
+          resolve any conflicts to proceed.
+        </Text>
+
+        <BitkitTabs.Root value={effectiveTab} onValueChange={({ value }) => setSelectedTab(value)}>
+          <BitkitTabs.List>
+            {fileMerges.map((file) => (
+              <BitkitTabs.Trigger key={file.nodeId} value={file.nodeId}>
+                {file.name}
+              </BitkitTabs.Trigger>
+            ))}
+          </BitkitTabs.List>
+        </BitkitTabs.Root>
+
+        {activeMerge && (
+          <Box display="flex" flex="1" gap="4" minHeight="0">
+            <Box display="flex" flexDirection="column" flex="1" gap="4">
+              <Text textStyle="body/md/semibold">Your changes</Text>
+              <Box flex="1" borderRadius="8" overflow="hidden" bg="rgb(30,30,30)" opacity="0.9">
+                <DiffEditor
+                  key={`${activeMerge.nodeId}-yours`}
+                  theme="vs-dark"
+                  language="yaml"
+                  original={activeMerge.baseYml}
+                  modified={activeMerge.yourYml}
+                  options={readOnlyDiffEditorOptions}
+                  keepCurrentModifiedModel
+                  keepCurrentOriginalModel
+                />
+              </Box>
+            </Box>
+
+            <Box alignSelf="center">
+              <Icon name="ArrowRight" color="icon/tertiary" size="24" />
+            </Box>
+
+            <Box display="flex" flexDirection="column" flex="1" gap="4">
+              <Text textStyle="body/md/semibold">Results</Text>
+              <Box flex="1" borderRadius="8" overflow="hidden" bg="rgb(30,30,30)">
+                <DiffEditor
+                  key={`${activeMerge.nodeId}-results`}
+                  theme="vs-dark"
+                  language="yaml"
+                  original={activeMerge.baseYml}
+                  modified={resolved[activeMerge.nodeId] ?? activeMerge.mergedYml}
+                  options={diffEditorOptions}
+                  keepCurrentModifiedModel
+                  keepCurrentOriginalModel
+                  onMount={onResultEditorMount(activeMerge.nodeId, activeMerge.decorations)}
+                />
+              </Box>
+            </Box>
+
+            <Box alignSelf="center">
+              <Icon name="ArrowLeft" color="icon/tertiary" size="24" />
+            </Box>
+
+            <Box display="flex" flexDirection="column" flex="1" gap="4">
+              <Text textStyle="body/md/semibold">Remote changes</Text>
+              <Box flex="1" borderRadius="8" overflow="hidden" bg="rgb(30,30,30)" opacity="0.9">
+                <DiffEditor
+                  key={`${activeMerge.nodeId}-remote`}
+                  theme="vs-dark"
+                  language="yaml"
+                  original={activeMerge.baseYml}
+                  modified={activeMerge.remoteYml}
+                  options={readOnlyDiffEditorOptions}
+                  keepCurrentModifiedModel
+                  keepCurrentOriginalModel
+                />
+              </Box>
+            </Box>
+          </Box>
+        )}
+
+        <Notification status="info">
+          <Text textStyle="comp/notification/title">Merge conflict auto-resolution</Text>
+          <Text>
+            In case of a conflict, remote changes will take priority over your local changes. To retain your changes,
+            edit the results before applying.
+          </Text>
+        </Notification>
+        {clientError && (
+          <Notification status="error">
+            <Text textStyle="comp/notification/title">Error pushing changes</Text>
+            <Text>{clientError}</Text>
+          </Notification>
+        )}
+      </DialogBody>
+      <DialogFooter>
+        <ButtonGroup spacing={16}>
+          <Button variant="secondary" isDisabled={isPushPending} onClick={onClose}>
+            Cancel
+          </Button>
+          <Tooltip
+            placement="top-end"
+            isDisabled={!isInvalid}
+            label="YAML is invalid, please fix it before applying changes"
+          >
+            <Button variant="primary" isLoading={isPushPending} isDisabled={isInvalid} onClick={handleApply}>
+              Apply changes
+            </Button>
+          </Tooltip>
+        </ButtonGroup>
+      </DialogFooter>
+    </>
+  );
+};
+
+const ModularConfigMergeDialog = ({ isOpen, onClose, branch, message, conflict }: Props) => {
+  return (
+    <DiffEditorDialogShell isOpen={isOpen} onClose={onClose}>
+      {/* Re-mount the body per branch-HEAD so a fresh conflict set re-seeds cleanly. */}
+      <ModularConfigMergeDialogBody
+        key={conflict.commitSha}
+        onClose={onClose}
+        branch={branch}
+        message={message}
+        initialConflict={conflict}
+      />
+      <style>{`
+        .monaco-diff-editor .conflict {
+          border: 1px solid rgba(255, 0, 0, 1);
+        }
+      `}</style>
+    </DiffEditorDialogShell>
+  );
+};
+
+export default ModularConfigMergeDialog;

--- a/source/javascripts/components/ConfigMergeDialog/ModularConfigMergeDialog.tsx
+++ b/source/javascripts/components/ConfigMergeDialog/ModularConfigMergeDialog.tsx
@@ -2,7 +2,7 @@ import { Box, Button, ButtonGroup, DialogBody, DialogFooter, Icon, Notification,
 import { BitkitTabs } from '@bitrise/bitkit-v2';
 import { DiffEditor, MonacoDiffEditor } from '@monaco-editor/react';
 import { ModalCloseButton, ModalHeader } from 'chakra-ui-2--react';
-import type { editor } from 'monaco-editor';
+import type { editor, IDisposable } from 'monaco-editor';
 import { useMemo, useRef, useState } from 'react';
 import { useEventListener } from 'usehooks-ts';
 
@@ -35,6 +35,16 @@ type FileMerge = {
   mergedYml: string;
   decorations: editor.IModelDeltaDecoration[];
 };
+
+/** A file's auto-merged result is valid YAML iff parsing it yields no errors. */
+function isMergedYmlValid(mergedYml: string): boolean {
+  return YmlUtils.toDoc(mergedYml).errors.length === 0;
+}
+
+/** Seed per-file validity from the up-front parse so unvisited tabs still gate Apply. */
+function seedValidity(fileMerges: FileMerge[]): Record<string, 'valid' | 'invalid' | 'warnings'> {
+  return Object.fromEntries(fileMerges.map((f) => [f.nodeId, isMergedYmlValid(f.mergedYml) ? 'valid' : 'invalid']));
+}
 
 function buildFileMerges(conflict: PushBranchConflict): FileMerge[] {
   // The BE may list the same file more than once; dedupe by node_id so each
@@ -93,7 +103,7 @@ const ModularConfigMergeDialogBody = ({
     Object.fromEntries(fileMerges.map((f) => [f.nodeId, f.mergedYml])),
   );
   const [validity, setValidity] = useState<Record<string, 'valid' | 'invalid' | 'warnings'>>(() =>
-    Object.fromEntries(fileMerges.map((f) => [f.nodeId, 'valid' as const])),
+    seedValidity(fileMerges),
   );
   // Files the user has edited — skip re-decorating them when their tab remounts.
   const touched = useRef<Set<string>>(new Set());
@@ -103,7 +113,7 @@ const ModularConfigMergeDialogBody = ({
     const merges = buildFileMerges(next);
     setConflict(next);
     setResolved(Object.fromEntries(merges.map((f) => [f.nodeId, f.mergedYml])));
-    setValidity(Object.fromEntries(merges.map((f) => [f.nodeId, 'valid' as const])));
+    setValidity(seedValidity(merges));
     touched.current = new Set();
     setSelectedTab(merges[0]?.nodeId ?? '');
   };
@@ -123,34 +133,49 @@ const ModularConfigMergeDialogBody = ({
   const onResultEditorMount = (mountedNodeId: string, decorations: editor.IModelDeltaDecoration[]) => {
     return (diff: MonacoDiffEditor) => {
       const modified = diff.getModifiedEditor();
+      // Tab switches remount this editor (its key includes the node_id), so every
+      // listener registered here must be disposed on unmount — otherwise the global
+      // marker listener (onModelMarkerStatusChange) leaks one per visit and keeps
+      // firing setValidity for stale models. Collected here, disposed on dispose.
+      const disposables: IDisposable[] = [];
 
-      modified.onDidChangeModelContent((e) => {
-        touched.current.add(mountedNodeId);
-        setResolved((prev) => ({ ...prev, [mountedNodeId]: modified.getValue() }));
+      disposables.push(
+        modified.onDidChangeModelContent((e) => {
+          touched.current.add(mountedNodeId);
+          setResolved((prev) => ({ ...prev, [mountedNodeId]: modified.getValue() }));
 
-        const removable = e.changes.reduce<Set<string>>((acc, c) => {
-          for (let i = c.range.startLineNumber; i <= c.range.endLineNumber; i += 1) {
-            modified.getLineDecorations(i)?.forEach((d) => {
-              if (d.options.blockClassName === 'conflict') {
-                acc.add(d.id);
-              }
-            });
-          }
-          return acc;
-        }, new Set<string>());
-        modified.removeDecorations(Array.from(removable));
-      });
+          const removable = e.changes.reduce<Set<string>>((acc, c) => {
+            for (let i = c.range.startLineNumber; i <= c.range.endLineNumber; i += 1) {
+              modified.getLineDecorations(i)?.forEach((d) => {
+                if (d.options.blockClassName === 'conflict') {
+                  acc.add(d.id);
+                }
+              });
+            }
+            return acc;
+          }, new Set<string>());
+          modified.removeDecorations(Array.from(removable));
+        }),
+      );
 
+      // Conflict markers are positioned for the pristine auto-merge; once the file
+      // is edited those line positions no longer map to the displayed text, so we
+      // only (re)apply them while it is untouched — which also restores them when
+      // an unedited tab is revisited.
       if (!touched.current.has(mountedNodeId)) {
         diff.createDecorationsCollection(decorations);
       }
 
       const model = modified.getModel();
       if (model) {
-        MonacoUtils.onModelMarkerStatusChange(model, (status) =>
-          setValidity((prev) => ({ ...prev, [mountedNodeId]: status })),
+        disposables.push(
+          MonacoUtils.onModelMarkerStatusChange(model, (status) =>
+            setValidity((prev) => ({ ...prev, [mountedNodeId]: status })),
+          ),
         );
       }
+
+      diff.onDidDispose(() => disposables.forEach((d) => d.dispose()));
     };
   };
 

--- a/source/javascripts/components/ConfigMergeDialog/mergeYamls.spec.ts
+++ b/source/javascripts/components/ConfigMergeDialog/mergeYamls.spec.ts
@@ -1,0 +1,35 @@
+import { mergeYamls } from './mergeYamls';
+
+describe('mergeYamls', () => {
+  it('cleanly merges non-overlapping changes from both sides', () => {
+    const base = 'a: 1\nb: 2\n';
+    const yours = 'a: 1\nb: 2\nc: 3\n'; // added c
+    const remote = 'a: 0\nb: 2\n'; // changed a
+
+    const { mergedYml, decorations } = mergeYamls(yours, base, remote);
+
+    expect(mergedYml).toBe('a: 0\nb: 2\nc: 3\n');
+    expect(decorations).toHaveLength(0);
+  });
+
+  it('resolves an overlapping change to the remote side and reports a conflict decoration', () => {
+    const base = 'title: base\n';
+    const yours = 'title: yours\n';
+    const remote = 'title: remote\n';
+
+    const { mergedYml, decorations } = mergeYamls(yours, base, remote);
+
+    expect(mergedYml).toContain('title: remote');
+    expect(mergedYml).not.toContain('title: yours');
+    expect(decorations.length).toBeGreaterThan(0);
+    expect(decorations[0].options.blockClassName).toBe('conflict');
+  });
+
+  it('returns the input unchanged when nothing differs', () => {
+    const yaml = 'a: 1\nb: 2\n';
+    const { mergedYml, decorations } = mergeYamls(yaml, yaml, yaml);
+
+    expect(mergedYml).toBe('a: 1\nb: 2\n');
+    expect(decorations).toHaveLength(0);
+  });
+});

--- a/source/javascripts/components/ConfigMergeDialog/mergeYamls.spec.ts
+++ b/source/javascripts/components/ConfigMergeDialog/mergeYamls.spec.ts
@@ -25,6 +25,22 @@ describe('mergeYamls', () => {
     expect(decorations[0].options.blockClassName).toBe('conflict');
   });
 
+  it('positions each conflict decoration by merged-output line, not input index', () => {
+    // Two separate overlapping changes with an unchanged line between them, so the
+    // merge emits: conflict(line 1), ok(line 2), conflict(line 3). The second
+    // conflict must be marked at output line 3 — the old bIndex-based code put it
+    // elsewhere.
+    const base = 'a\nKEEP\nd\n';
+    const yours = 'aY\nKEEP\ndY\n';
+    const remote = 'aR\nKEEP\ndR\n';
+
+    const { mergedYml, decorations } = mergeYamls(yours, base, remote);
+
+    expect(mergedYml).toBe('aR\nKEEP\ndR\n');
+    const startLines = decorations.map((d) => d.range.startLineNumber).sort((x, y) => x - y);
+    expect(startLines).toEqual([1, 3]);
+  });
+
   it('returns the input unchanged when nothing differs', () => {
     const yaml = 'a: 1\nb: 2\n';
     const { mergedYml, decorations } = mergeYamls(yaml, yaml, yaml);

--- a/source/javascripts/components/ConfigMergeDialog/mergeYamls.ts
+++ b/source/javascripts/components/ConfigMergeDialog/mergeYamls.ts
@@ -20,40 +20,40 @@ export function mergeYamls(yourYaml: string, baseYaml: string, remoteYaml: strin
   }).forEach((region) => {
     if (region.ok) {
       rows.push(...region.ok);
-    } else if (region.conflict) {
-      rows.push(...region.conflict.b);
+      return;
+    }
 
-      const remoteChangeIsADeletion = region.conflict.b.length === 0;
+    if (!region.conflict) {
+      return;
+    }
 
-      if (remoteChangeIsADeletion) {
-        decorations.push({
-          options: {
-            isWholeLine: false,
-            blockClassName: 'conflict',
-          },
-          range: {
-            startLineNumber: region.conflict.oIndex + 1,
-            startColumn: 1,
-            endLineNumber: region.conflict.oIndex + 1,
-            endColumn: 1,
-          },
-        });
-      }
+    // Decorations must be positioned by the running line count of the MERGED
+    // OUTPUT, not by diff3's `bIndex`/`oIndex` — those are offsets into the
+    // remote/base inputs and don't map onto the concatenated merged result, so
+    // with more than one conflict region they land on the wrong line.
+    const conflictStartLine = rows.length + 1; // 1-based line where conflict.b begins
+    rows.push(...region.conflict.b);
 
-      if (!remoteChangeIsADeletion) {
-        decorations.push({
-          options: {
-            isWholeLine: true,
-            blockClassName: 'conflict',
-          },
-          range: {
-            startLineNumber: region.conflict.bIndex + 1,
-            startColumn: 1,
-            endLineNumber: region.conflict.bIndex + region.conflict.b.length,
-            endColumn: 1,
-          },
-        });
-      }
+    const remoteChangeIsADeletion = region.conflict.b.length === 0;
+
+    if (remoteChangeIsADeletion) {
+      // The remote removed lines you had — there are no output lines to mark, so
+      // flag the boundary (the line now sitting in the gap, clamped to line 1).
+      const boundaryLine = Math.max(conflictStartLine - 1, 1);
+      decorations.push({
+        options: { isWholeLine: false, blockClassName: 'conflict' },
+        range: { startLineNumber: boundaryLine, startColumn: 1, endLineNumber: boundaryLine, endColumn: 1 },
+      });
+    } else {
+      decorations.push({
+        options: { isWholeLine: true, blockClassName: 'conflict' },
+        range: {
+          startLineNumber: conflictStartLine,
+          startColumn: 1,
+          endLineNumber: conflictStartLine + region.conflict.b.length - 1,
+          endColumn: 1,
+        },
+      });
     }
   });
 

--- a/source/javascripts/components/ConfigMergeDialog/mergeYamls.ts
+++ b/source/javascripts/components/ConfigMergeDialog/mergeYamls.ts
@@ -1,0 +1,86 @@
+import { DiffEditorProps } from '@monaco-editor/react';
+import type { editor } from 'monaco-editor';
+import { diff3Merge } from 'node-diff3';
+
+/**
+ * 3-way merge of a single YAML file: `yours` (local edits) and `remoteYaml` (the
+ * branch HEAD) reconciled against their common `baseYaml`. Conflicting regions are
+ * auto-resolved to the remote side and reported as decorations so the UI can mark
+ * them red — the user edits the merged result to recover their own changes.
+ *
+ * Shared by the modular per-file conflict dialog. (The legacy single-file dialog
+ * keeps its own copy until the modular-editing flag graduates and it is removed.)
+ */
+export function mergeYamls(yourYaml: string, baseYaml: string, remoteYaml: string) {
+  const rows: string[] = [];
+  const decorations: editor.IModelDeltaDecoration[] = [];
+
+  diff3Merge<string>(yourYaml, baseYaml, remoteYaml, {
+    stringSeparator: '\n',
+  }).forEach((region) => {
+    if (region.ok) {
+      rows.push(...region.ok);
+    } else if (region.conflict) {
+      rows.push(...region.conflict.b);
+
+      const remoteChangeIsADeletion = region.conflict.b.length === 0;
+
+      if (remoteChangeIsADeletion) {
+        decorations.push({
+          options: {
+            isWholeLine: false,
+            blockClassName: 'conflict',
+          },
+          range: {
+            startLineNumber: region.conflict.oIndex + 1,
+            startColumn: 1,
+            endLineNumber: region.conflict.oIndex + 1,
+            endColumn: 1,
+          },
+        });
+      }
+
+      if (!remoteChangeIsADeletion) {
+        decorations.push({
+          options: {
+            isWholeLine: true,
+            blockClassName: 'conflict',
+          },
+          range: {
+            startLineNumber: region.conflict.bIndex + 1,
+            startColumn: 1,
+            endLineNumber: region.conflict.bIndex + region.conflict.b.length,
+            endColumn: 1,
+          },
+        });
+      }
+    }
+  });
+
+  return {
+    decorations,
+    mergedYml: rows.join('\n'),
+  };
+}
+
+export const diffEditorOptions: DiffEditorProps['options'] = {
+  diffWordWrap: 'off',
+  automaticLayout: true,
+  roundedSelection: false,
+  renderSideBySide: false,
+  renderGutterMenu: false,
+  renderWhitespace: 'all',
+  ignoreTrimWhitespace: false,
+  padding: {
+    top: 16,
+    bottom: 16,
+  },
+  hideUnchangedRegions: {
+    enabled: true,
+  },
+};
+
+export const readOnlyDiffEditorOptions: DiffEditorProps['options'] = {
+  ...diffEditorOptions,
+  readOnly: true,
+};

--- a/source/javascripts/components/Header.tsx
+++ b/source/javascripts/components/Header.tsx
@@ -18,6 +18,7 @@ import {
   trackSaveButtonClicked,
 } from '@/core/analytics/ConfigManagementAnalytics';
 import { segmentTrack } from '@/core/analytics/SegmentBaseTracking';
+import { PushBranchConflict } from '@/core/api/BranchesApi';
 import { ClientError } from '@/core/api/client';
 import {
   bitriseYmlStore,
@@ -47,6 +48,7 @@ import { useWorkflowsPageStore } from '@/pages/WorkflowsPage/WorkflowsPage.store
 import { paths } from '@/routes';
 
 import ConfigMergeDialog from './ConfigMergeDialog/ConfigMergeDialog';
+import ModularConfigMergeDialog from './ConfigMergeDialog/ModularConfigMergeDialog';
 import DiffEditorDialog from './DiffEditor/DiffEditorDialog';
 import GlobalDiffEditorDialog from './DiffEditor/GlobalDiffEditorDialog';
 import ConfigSettingsMenu from './unified-editor/ConfigSettingsMenu/ConfigSettingsMenu';
@@ -122,6 +124,14 @@ const Header = () => {
   const enableBranchSwitching = useFeatureFlag('enable-branch-switching');
 
   const [mergeDialogContext, setMergeDialogContext] = useState({ targetBranch: '', isNewTargetBranch: false });
+  // Modular (per-file) conflict resolution: the parsed 409 plus the branch/message
+  // to re-push with after the user resolves each conflicting file.
+  const [modularConflict, setModularConflict] = useState<{
+    branch: string;
+    message: string;
+    conflict: PushBranchConflict;
+  }>();
+  const lastPushPayload = useRef<PushBranchPayload>();
 
   const {
     isOpen: isDiffViewerOpen,
@@ -139,6 +149,11 @@ const Header = () => {
   });
 
   const { isOpen: isMergeDialogOpen, onOpen: openMergeDialog, onClose: closeMergeDialog } = useDisclosure();
+  const {
+    isOpen: isModularMergeDialogOpen,
+    onOpen: openModularMergeDialog,
+    onClose: closeModularMergeDialog,
+  } = useDisclosure();
 
   const {
     isOpen: isUpdateConfigDialogOpen,
@@ -176,11 +191,20 @@ const Header = () => {
     onSuccess: () => {
       closePushBranchDialog();
     },
-    onMergeConflict: (branch) => {
+    onMergeConflict: (branch, conflict) => {
       const configBranch = bitriseYmlStore.getState().configBranch;
-      setMergeDialogContext({ targetBranch: branch, isNewTargetBranch: branch !== configBranch });
       trackConfigMergePopupShown(currentPage, branch, branch !== configBranch);
       closePushBranchDialog();
+
+      // Modular push: resolve every conflicting file in the per-file dialog.
+      // Single-file push: fall back to the legacy whole-config merge dialog.
+      if (conflict) {
+        setModularConflict({ branch, message: lastPushPayload.current?.message ?? '', conflict });
+        openModularMergeDialog();
+        return;
+      }
+
+      setMergeDialogContext({ targetBranch: branch, isNewTargetBranch: branch !== configBranch });
       openMergeDialog();
     },
   });
@@ -188,6 +212,8 @@ const Header = () => {
   const handlePush = useCallback(
     (values: PushBranchPayload) => {
       clearPushError();
+      // Remember the message so a modular conflict can re-push with it after resolution.
+      lastPushPayload.current = values;
       pushBranch(values);
     },
     [clearPushError, pushBranch],
@@ -380,6 +406,15 @@ const Header = () => {
         targetBranch={mergeDialogContext.targetBranch}
         isNewTargetBranch={mergeDialogContext.isNewTargetBranch}
       />
+      {modularConflict && (
+        <ModularConfigMergeDialog
+          isOpen={isModularMergeDialogOpen}
+          onClose={closeModularMergeDialog}
+          branch={modularConflict.branch}
+          message={modularConflict.message}
+          conflict={modularConflict.conflict}
+        />
+      )}
       <UpdateConfigurationDialog isOpen={isUpdateConfigDialogOpen} onClose={closeUpdateConfigDialog} />
       <PushBranchDialog
         isOpen={isPushBranchDialogOpen}

--- a/source/javascripts/core/api/BranchesApi.spec.ts
+++ b/source/javascripts/core/api/BranchesApi.spec.ts
@@ -1,0 +1,55 @@
+import BranchesApi from './BranchesApi';
+import { ClientError } from './client';
+
+function clientError(status: number, data?: Record<string, unknown>) {
+  return new ClientError(new Error('boom'), new Response(null, { status }), data);
+}
+
+describe('BranchesApi.parsePushConflict', () => {
+  it('parses a modular 409 body into a per-file conflict, mapping snake_case to camelCase', () => {
+    const error = clientError(409, {
+      status: 'conflict',
+      commit_sha: 'head999',
+      remote_yml: 'workflows: {}\n',
+      conflicts: [
+        { node_id: 'n_root', path: 'bitrise.yml', remote_yml: "format_version: '14'\n" },
+        { node_id: 'n_wf', path: 'workflows/deploy.yml', remote_yml: 'workflows: {}\n' },
+      ],
+    });
+
+    expect(BranchesApi.parsePushConflict(error)).toEqual({
+      commitSha: 'head999',
+      conflicts: [
+        { nodeId: 'n_root', path: 'bitrise.yml', remoteYml: "format_version: '14'\n" },
+        { nodeId: 'n_wf', path: 'workflows/deploy.yml', remoteYml: 'workflows: {}\n' },
+      ],
+    });
+  });
+
+  it('returns undefined for a single-file (legacy) 409 that has no `conflicts` array', () => {
+    const error = clientError(409, { status: 'conflict', commit_sha: 'head999', remote_yml: 'workflows: {}\n' });
+    expect(BranchesApi.parsePushConflict(error)).toBeUndefined();
+  });
+
+  it('returns undefined for an empty conflicts list', () => {
+    const error = clientError(409, { status: 'conflict', commit_sha: 'head999', conflicts: [] });
+    expect(BranchesApi.parsePushConflict(error)).toBeUndefined();
+  });
+
+  it('returns undefined for a non-409 error', () => {
+    expect(BranchesApi.parsePushConflict(clientError(403, { conflicts: [{ node_id: 'x' }] }))).toBeUndefined();
+  });
+
+  it('returns undefined for a non-ClientError value', () => {
+    expect(BranchesApi.parsePushConflict(new Error('plain'))).toBeUndefined();
+    expect(BranchesApi.parsePushConflict(undefined)).toBeUndefined();
+  });
+
+  it('defaults missing per-file fields to empty strings', () => {
+    const error = clientError(409, { conflicts: [{ path: 'a.yml' }] });
+    expect(BranchesApi.parsePushConflict(error)).toEqual({
+      commitSha: '',
+      conflicts: [{ nodeId: '', path: 'a.yml', remoteYml: '' }],
+    });
+  });
+});

--- a/source/javascripts/core/api/BranchesApi.ts
+++ b/source/javascripts/core/api/BranchesApi.ts
@@ -1,7 +1,7 @@
 import { TreeNode } from '@/core/models/Tree';
 
 import BitriseYmlApi from './BitriseYmlApi';
-import Client from './client';
+import Client, { ClientError } from './client';
 
 type GetBranchesOptions = {
   appSlug: string;
@@ -32,6 +32,50 @@ export type PushBranchResult = {
   pr_url?: string;
 };
 
+/** One module file that changed on the branch since load (modular push 409). */
+export type PushBranchConflictFile = {
+  nodeId: string;
+  path: string;
+  remoteYml: string;
+};
+
+/** Parsed body of a modular push 409 — the new branch HEAD plus every conflicting file. */
+export type PushBranchConflict = {
+  commitSha: string;
+  conflicts: PushBranchConflictFile[];
+};
+
+type WirePushConflictFile = {
+  node_id?: string;
+  path?: string;
+  remote_yml?: string;
+};
+
+/**
+ * Extract the per-file conflict list from a 409 ClientError. Returns `undefined`
+ * for a single-file (legacy) conflict, which carries `remote_yml`/`commit_sha`
+ * but no `conflicts` array — the caller falls back to the legacy merge dialog.
+ */
+function parsePushConflict(error: unknown): PushBranchConflict | undefined {
+  if (!(error instanceof ClientError) || error.status !== 409) {
+    return undefined;
+  }
+
+  const data = error.data as { commit_sha?: string; conflicts?: WirePushConflictFile[] } | undefined;
+  if (!data?.conflicts?.length) {
+    return undefined;
+  }
+
+  return {
+    commitSha: data.commit_sha ?? '',
+    conflicts: data.conflicts.map((c) => ({
+      nodeId: c.node_id ?? '',
+      path: c.path ?? '',
+      remoteYml: c.remote_yml ?? '',
+    })),
+  };
+}
+
 async function getBranches({ appSlug, signal, limit, q }: GetBranchesOptions): Promise<GetBranchesResult> {
   const params = new URLSearchParams();
   if (limit !== undefined) {
@@ -58,4 +102,4 @@ async function pushBranch({ appSlug, branch, sourceBranch, commitSha, bitriseYml
   });
 }
 
-export default { getBranches, pushBranch };
+export default { getBranches, pushBranch, parsePushConflict };

--- a/source/javascripts/hooks/usePushBranch.spec.tsx
+++ b/source/javascripts/hooks/usePushBranch.spec.tsx
@@ -7,6 +7,7 @@ import React, { ReactNode } from 'react';
 
 import BitriseYmlApi from '@/core/api/BitriseYmlApi';
 import BranchesApi from '@/core/api/BranchesApi';
+import { ClientError } from '@/core/api/client';
 import { bitriseYmlStore, initializeBitriseYmlDocument } from '@/core/stores/BitriseYmlStore';
 import PageProps from '@/core/utils/PageProps';
 
@@ -78,6 +79,68 @@ describe('usePushBranch', () => {
     });
     expect(getCiConfigSpy).toHaveBeenCalledWith({ projectSlug: 'app-1', branch: 'feature' });
     expect(storeAtOnSuccess).toEqual({ version: '2', configCommitSha: 'new-sha' });
+  });
+
+  it('on a modular 409 calls onMergeConflict with the parsed per-file conflict', async () => {
+    const conflictError = new ClientError(new Error('conflict'), { status: 409 } as unknown as Response, {
+      status: 'conflict',
+      commit_sha: 'head-sha',
+      conflicts: [{ node_id: 'n_wf', path: 'workflows/deploy.yml', remote_yml: 'workflows: {}\n' }],
+    });
+    jest.spyOn(BranchesApi, 'pushBranch').mockRejectedValue(conflictError);
+
+    const onMergeConflict = jest.fn();
+    const onSuccess = jest.fn();
+    const { result } = renderHook(() => usePushBranch({ onSuccess, onMergeConflict }), { wrapper });
+
+    act(() => {
+      result.current.pushBranch({ branch: 'feature', message: 'push it' });
+    });
+
+    await waitFor(() => expect(onMergeConflict).toHaveBeenCalledTimes(1));
+    expect(onMergeConflict).toHaveBeenCalledWith('feature', {
+      commitSha: 'head-sha',
+      conflicts: [{ nodeId: 'n_wf', path: 'workflows/deploy.yml', remoteYml: 'workflows: {}\n' }],
+    });
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('on a single-file 409 calls onMergeConflict with undefined (legacy fallback)', async () => {
+    const conflictError = new ClientError(new Error('conflict'), { status: 409 } as unknown as Response, {
+      status: 'conflict',
+      commit_sha: 'head-sha',
+      remote_yml: 'format_version: "14"\n',
+    });
+    jest.spyOn(BranchesApi, 'pushBranch').mockRejectedValue(conflictError);
+
+    const onMergeConflict = jest.fn();
+    const { result } = renderHook(() => usePushBranch({ onMergeConflict }), { wrapper });
+
+    act(() => {
+      result.current.pushBranch({ branch: 'feature', message: 'push it' });
+    });
+
+    await waitFor(() => expect(onMergeConflict).toHaveBeenCalledTimes(1));
+    expect(onMergeConflict).toHaveBeenCalledWith('feature', undefined);
+  });
+
+  it('forwards baseCommitSha as the conflict-token commit SHA when re-pushing after resolution', async () => {
+    const pushSpy = jest.spyOn(BranchesApi, 'pushBranch').mockResolvedValue(undefined as never);
+    jest.spyOn(BitriseYmlApi, 'getCiConfig').mockResolvedValue({
+      ymlString: yaml`format_version: "17"`,
+      version: '2',
+      branch: 'feature',
+      commitSha: 'new-sha',
+    });
+
+    const { result } = renderHook(() => usePushBranch(), { wrapper });
+
+    act(() => {
+      result.current.pushBranch({ branch: 'feature', message: 'resolved', baseCommitSha: 'reconciled-sha' });
+    });
+
+    await waitFor(() => expect(pushSpy).toHaveBeenCalledTimes(1));
+    expect(pushSpy).toHaveBeenCalledWith(expect.objectContaining({ commitSha: 'reconciled-sha' }));
   });
 
   it('does not push and does not call onSuccess when the config is not loaded', async () => {

--- a/source/javascripts/hooks/usePushBranch.ts
+++ b/source/javascripts/hooks/usePushBranch.ts
@@ -9,7 +9,7 @@ import {
   trackPushConfigChangesSucceeded,
 } from '@/core/analytics/ConfigManagementAnalytics';
 import BitriseYmlApi from '@/core/api/BitriseYmlApi';
-import BranchesApi from '@/core/api/BranchesApi';
+import BranchesApi, { PushBranchConflict } from '@/core/api/BranchesApi';
 import { ClientError } from '@/core/api/client';
 import {
   applyModularSaveResult,
@@ -24,12 +24,24 @@ import { CI_CONFIG_TREE_QUERY_KEY } from '@/hooks/useCiConfigTree';
 export type PushBranchPayload = {
   branch: string;
   message: string;
+  /**
+   * Override for the conflict-token commit SHA sent to the BE. Used when re-pushing
+   * after a modular conflict was resolved: we reconciled against the new branch HEAD
+   * (returned in the 409), so the re-push must be based on that SHA, not the now-stale
+   * `configCommitSha` the config was originally loaded at. Omitted for normal pushes.
+   */
+  baseCommitSha?: string;
 };
 
 type UsePushBranchOptions = {
   /** Called after a successful push + store refresh (e.g. to close the dialog). */
   onSuccess?: () => void;
-  onMergeConflict?: (branch: string) => void;
+  /**
+   * Called on a 409. For a modular push the parsed per-file `conflict` is provided so
+   * the caller can open the file-aware merge dialog; for a single-file push it is
+   * `undefined` and the caller falls back to the legacy whole-config merge dialog.
+   */
+  onMergeConflict?: (branch: string, conflict?: PushBranchConflict) => void;
 };
 
 function usePushBranch({ onSuccess, onMergeConflict }: UsePushBranchOptions = {}) {
@@ -44,12 +56,18 @@ function usePushBranch({ onSuccess, onMergeConflict }: UsePushBranchOptions = {}
   const clearPushError = () => setPushError(undefined);
 
   const { isPending: isPushPending, mutate: pushBranch } = useMutation({
-    mutationFn: ({ branch, message }: PushBranchPayload) => {
+    mutationFn: ({ branch, message, baseCommitSha }: PushBranchPayload) => {
       if (!configBranch || !configCommitSha) {
         throw new Error('Configuration is not loaded. Please reload and try again.');
       }
 
-      const common = { appSlug, branch, sourceBranch: configBranch, commitSha: configCommitSha, message };
+      const common = {
+        appSlug,
+        branch,
+        sourceBranch: configBranch,
+        commitSha: baseCommitSha ?? configCommitSha,
+        message,
+      };
       // Modular sends the full tree (BE validates merged, then pushes edited files); single-file sends bitrise.yml.
       return isModular
         ? BranchesApi.pushBranch({ ...common, root: getModularConfigTree() })
@@ -100,7 +118,7 @@ function usePushBranch({ onSuccess, onMergeConflict }: UsePushBranchOptions = {}
     onError: (error, { branch }) => {
       if (error instanceof ClientError && error.status === 409) {
         trackPushConfigChangesFailed(configBranch, branch, 'merge_conflict');
-        onMergeConflict?.(branch);
+        onMergeConflict?.(branch, BranchesApi.parsePushConflict(error));
         return;
       }
 


### PR DESCRIPTION
When a modular push 409s, resolve every conflicting module file individually instead of treating the config as one blob.

- New tabbed ModularConfigMergeDialog: one tab per conflicting file, 3-way auto-merge per file (remote-wins + editable), re-push after resolution with the reconciled branch HEAD; loops on nested conflicts.
- BranchesApi.parsePushConflict parses the per-file 409 body; usePushBranch forwards it to onMergeConflict and supports a baseCommitSha override.
- Header opens the new dialog for modular conflicts; the legacy single-file ConfigMergeDialog is left untouched.
- Scoped to the modular path (enable-wfe-modular-yaml-editing); flag-off behaviour is unchanged.