### PR TITLE
Misc UI fixes 3: read-only add buttons, tab dots, modular containers, push/update-config polish

### DIFF
--- a/source/javascripts/components/Navigation.tsx
+++ b/source/javascripts/components/Navigation.tsx
@@ -138,7 +138,7 @@ const Navigation = (props: Props) => {
           icon="Steps"
           intercomTarget="Step Bundles Page Navigation Item"
         >
-          Step Bundles
+          Step bundles
         </NavigationItem>
         <NavigationItem
           path={withSearchParams(paths.secrets)}

--- a/source/javascripts/components/unified-editor/ChangedModulesNote/ChangedModulesNote.tsx
+++ b/source/javascripts/components/unified-editor/ChangedModulesNote/ChangedModulesNote.tsx
@@ -1,0 +1,25 @@
+import { BitkitNoteCard } from '@bitrise/bitkit-v2';
+
+import useChangedModules, { moduleCountLabel } from '@/hooks/useChangedModules';
+
+/**
+ * Info note listing the changed module files by full path (e.g. the push / update-config dialogs).
+ * Renders nothing for a single-file config or when nothing changed.
+ */
+const ChangedModulesNote = () => {
+  const changedModules = useChangedModules();
+
+  if (changedModules.length === 0) {
+    return null;
+  }
+
+  return (
+    <BitkitNoteCard
+      status="info"
+      title={moduleCountLabel(changedModules.length)}
+      message={changedModules.map((module) => module.path).join(', ')}
+    />
+  );
+};
+
+export default ChangedModulesNote;

--- a/source/javascripts/components/unified-editor/EntitySelector/EntitySelector.tsx
+++ b/source/javascripts/components/unified-editor/EntitySelector/EntitySelector.tsx
@@ -96,7 +96,8 @@ const EntitySelector = (props: EntitySelectorProps) => {
           description="Modify your search to get results"
         />
       )}
-      {(!!onCreate || isAIButtonVisible) && (
+      {/* Read-only views (merged config, cross-repo/ref files) can't create — show no footer at all. */}
+      {!isReadOnlyView && (!!onCreate || isAIButtonVisible) && (
         <Box
           paddingY="8"
           position="sticky"
@@ -115,7 +116,6 @@ const EntitySelector = (props: EntitySelectorProps) => {
               leftIconName="Plus"
               variant="tertiary"
               width="100%"
-              isDisabled={isReadOnlyView}
               onClick={handleCreate}
             >
               Create {entityName}
@@ -137,7 +137,7 @@ const EntitySelector = (props: EntitySelectorProps) => {
                 }
                 variant="tertiary"
                 width="100%"
-                isDisabled={isAIButtonDisabled || isReadOnlyView}
+                isDisabled={isAIButtonDisabled}
                 onClick={handleCreateWithAI}
               >
                 Create {entityName} with AI

--- a/source/javascripts/components/unified-editor/PushBranchDialog/PushBranchDialog.tsx
+++ b/source/javascripts/components/unified-editor/PushBranchDialog/PushBranchDialog.tsx
@@ -13,6 +13,8 @@ import { Controller, useForm, useWatch } from 'react-hook-form';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
 import { PushBranchPayload } from '@/hooks/usePushBranch';
 
+import ChangedModulesNote from '../ChangedModulesNote/ChangedModulesNote';
+
 type Props = {
   isOpen: boolean;
   onClose: () => void;
@@ -94,6 +96,7 @@ const PushBranchDialog = ({ isOpen, onClose, isPushPending, pushError, onPush, o
         </>
       }
     >
+      <ChangedModulesNote />
       <BitkitRadioGroup
         aria-label="Target branch"
         layout="horizontal"

--- a/source/javascripts/components/unified-editor/PushBranchDialog/PushBranchDialog.tsx
+++ b/source/javascripts/components/unified-editor/PushBranchDialog/PushBranchDialog.tsx
@@ -36,7 +36,7 @@ function validateBranchName(branch: string): string | true {
     GIT_BRANCH_INVALID_START.test(branch) ||
     GIT_BRANCH_INVALID_END.test(branch)
   ) {
-    return 'Invalid branch name. Must follow git branch naming rules.';
+    return 'Invalid branch name. Must follow Git branch naming rules.';
   }
   return true;
 }
@@ -123,7 +123,7 @@ const PushBranchDialog = ({ isOpen, onClose, isPushPending, pushError, onPush, o
           <BitkitTextInput
             label="Target branch"
             placeholder="new-branch-name"
-            helperText="Must follow git branch naming rules."
+            helperText="Must follow Git branch naming rules."
             state={isCurrentBranch ? 'readOnly' : undefined}
             errorText={fieldState.error?.message}
             inputProps={field}
@@ -138,7 +138,7 @@ const PushBranchDialog = ({ isOpen, onClose, isPushPending, pushError, onPush, o
           <BitkitTextArea
             label="Commit message"
             placeholder="e.g. Update bitrise.yml via Workflow Editor"
-            helperText="Appears in your git commit history."
+            helperText="Appears in your Git commit history."
             textareaProps={field}
           />
         )}

--- a/source/javascripts/components/unified-editor/Triggers/TargetBasedTriggers/TargetBasedTriggersCard.tsx
+++ b/source/javascripts/components/unified-editor/Triggers/TargetBasedTriggers/TargetBasedTriggersCard.tsx
@@ -55,16 +55,11 @@ const TriggerCard = ({
           onUpdateEnabled={onUpdateTriggerEnabled}
         />
       ))}
-      <Button
-        margin="12"
-        size="md"
-        variant="tertiary"
-        leftIconName="Plus"
-        isDisabled={isReadOnly}
-        onClick={() => onAddTrigger(triggerType)}
-      >
-        Add trigger
-      </Button>
+      {!isReadOnly && (
+        <Button margin="12" size="md" variant="tertiary" leftIconName="Plus" onClick={() => onAddTrigger(triggerType)}>
+          Add trigger
+        </Button>
+      )}
     </ExpandableCard>
   );
 };

--- a/source/javascripts/components/unified-editor/Triggers/TargetBasedTriggers/TargetBasedTriggersTabContent.tsx
+++ b/source/javascripts/components/unified-editor/Triggers/TargetBasedTriggers/TargetBasedTriggersTabContent.tsx
@@ -79,7 +79,7 @@ const TargetBasedTriggersTabContent = (props: Props) => {
           label="Enable triggers"
           helperText="When disabled and saved, none of the triggers below will execute a build."
           isChecked={triggers.enabled !== false}
-          isDisabled={isReadOnly}
+          isReadOnly={isReadOnly}
           onChange={handleGlobalTriggerEnabledToggled}
         />
       </Card>

--- a/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
+++ b/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
@@ -2,7 +2,6 @@ import {
   BitkitButton,
   BitkitControlButton,
   BitkitDialog,
-  BitkitNoteCard,
   BitkitSectionHeading,
   createBitkitToast,
   IconCopy,
@@ -16,11 +15,13 @@ import { useEffect, useState } from 'react';
 import { useCopyToClipboard } from 'usehooks-ts';
 
 import { trackCopyYmlClicked, trackDownloadYmlClicked } from '@/core/analytics/ConfigManagementAnalytics';
-import { getFileYmlString, getYmlString, isFileDirty } from '@/core/stores/BitriseYmlStore';
+import { getFileYmlString, getYmlString } from '@/core/stores/BitriseYmlStore';
 import { download } from '@/core/utils/CommonUtils';
 import PageProps from '@/core/utils/PageProps';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
-import { useShallow } from '@/hooks/useShallow';
+import useChangedModules, { moduleCountLabel } from '@/hooks/useChangedModules';
+
+import ChangedModulesNote from '../ChangedModulesNote/ChangedModulesNote';
 
 type Props = {
   isOpen: boolean;
@@ -34,8 +35,6 @@ type ChangedFileRow = {
   getContent: () => string;
 };
 
-const moduleCountLabel = (count: number) => `${count} ${count === 1 ? 'module' : 'modules'} changed`;
-
 const UpdateConfigurationDialog = ({ isOpen, onClose }: Props) => {
   const [, copyToClipboard] = useCopyToClipboard();
   const { defaultBranch, gitRepoSlug } = PageProps.app() ?? {};
@@ -48,15 +47,7 @@ const UpdateConfigurationDialog = ({ isOpen, onClose }: Props) => {
   }, [isOpen]);
 
   const isModular = useBitriseYmlStore((s) => Boolean(s.tree));
-  const changedModules = useBitriseYmlStore(
-    useShallow((s) =>
-      !s.tree
-        ? []
-        : Object.values(s.files)
-            .filter((slice) => isFileDirty(slice))
-            .map((slice) => ({ nodeId: slice.nodeId, path: slice.path })),
-    ),
-  );
+  const changedModules = useChangedModules();
 
   // Single config → one synthetic "bitrise.yml" row (the whole config); modular → one row per changed module file.
   const rows: ChangedFileRow[] = isModular
@@ -116,13 +107,7 @@ const UpdateConfigurationDialog = ({ isOpen, onClose }: Props) => {
       }
     >
       <Box display="flex" flexDirection="column" gap="24">
-        {isModular && (
-          <BitkitNoteCard
-            status="info"
-            title={moduleCountLabel(changedModules.length)}
-            message={changedModules.map((module) => module.path).join(', ')}
-          />
-        )}
+        <ChangedModulesNote />
 
         <Text textStyle="body/lg/regular" color="text/body">
           {isModular ? (

--- a/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
+++ b/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.tsx
@@ -16,7 +16,6 @@ import { useEffect, useState } from 'react';
 import { useCopyToClipboard } from 'usehooks-ts';
 
 import { trackCopyYmlClicked, trackDownloadYmlClicked } from '@/core/analytics/ConfigManagementAnalytics';
-import TreeService from '@/core/services/TreeService';
 import { getFileYmlString, getYmlString, isFileDirty } from '@/core/stores/BitriseYmlStore';
 import { download } from '@/core/utils/CommonUtils';
 import PageProps from '@/core/utils/PageProps';
@@ -55,17 +54,17 @@ const UpdateConfigurationDialog = ({ isOpen, onClose }: Props) => {
         ? []
         : Object.values(s.files)
             .filter((slice) => isFileDirty(slice))
-            .map((slice) => ({ nodeId: slice.nodeId, path: slice.path, name: TreeService.fileName(slice.path) })),
+            .map((slice) => ({ nodeId: slice.nodeId, path: slice.path })),
     ),
   );
 
   // Single config → one synthetic "bitrise.yml" row (the whole config); modular → one row per changed module file.
   const rows: ChangedFileRow[] = isModular
-    ? changedModules.map(({ nodeId, path, name }) => ({
+    ? changedModules.map(({ nodeId, path }) => ({
         key: nodeId,
-        name,
-        // Full path (slashes → dashes) as the download filename so same-named modules in different
-        // folders don't collide; the basename stays the displayed label (full paths are in the note above).
+        // Show the full module path; download it flattened (slashes → dashes) so same-named modules
+        // in different folders don't collide as downloaded files.
+        name: path,
         downloadName: path.replace(/\//g, '-'),
         getContent: () => getFileYmlString(nodeId),
       }))

--- a/source/javascripts/hooks/useChangedModules.ts
+++ b/source/javascripts/hooks/useChangedModules.ts
@@ -1,0 +1,21 @@
+import { isFileDirty } from '@/core/stores/BitriseYmlStore';
+
+import useBitriseYmlStore from './useBitriseYmlStore';
+import { useShallow } from './useShallow';
+
+export type ChangedModule = { nodeId: string; path: string };
+
+/** The changed (unsaved) module files of a modular config; empty for a single-file config. */
+export default function useChangedModules(): ChangedModule[] {
+  return useBitriseYmlStore(
+    useShallow((s) =>
+      !s.tree
+        ? []
+        : Object.values(s.files)
+            .filter((slice) => isFileDirty(slice))
+            .map((slice) => ({ nodeId: slice.nodeId, path: slice.path })),
+    ),
+  );
+}
+
+export const moduleCountLabel = (count: number) => `${count} ${count === 1 ? 'module' : 'modules'} changed`;

--- a/source/javascripts/hooks/useChangedModules.ts
+++ b/source/javascripts/hooks/useChangedModules.ts
@@ -6,11 +6,17 @@ export type ChangedModule = { nodeId: string; path: string };
 
 /** The changed (unsaved) module files of a modular config; empty for a single-file config. */
 export default function useChangedModules(): ChangedModule[] {
-  // Return the store's own slice objects (which already carry `nodeId`/`path`) rather than freshly
-  // mapped ones, so useBitriseYmlStore's internal useShallow can short-circuit when the changed set is
-  // unchanged — mapping to new objects each call would defeat shallow equality and re-render on every
-  // store update.
-  return useBitriseYmlStore((s) => (s.tree ? Object.values(s.files).filter((slice) => isFileDirty(slice)) : []));
+  // useBitriseYmlStore compares selector results with deep equality (dequal), so it already
+  // short-circuits when the changed set is unchanged regardless of allocations. Project to just
+  // { nodeId, path } (the fields consumers use) to keep that comparison bounded — returning full
+  // FileSlice objects would make dequal deep-walk each slice's YAML document on every change.
+  return useBitriseYmlStore((s) =>
+    s.tree
+      ? Object.values(s.files)
+          .filter((slice) => isFileDirty(slice))
+          .map((slice) => ({ nodeId: slice.nodeId, path: slice.path }))
+      : [],
+  );
 }
 
 export const moduleCountLabel = (count: number) => `${count} ${count === 1 ? 'module' : 'modules'} changed`;

--- a/source/javascripts/hooks/useChangedModules.ts
+++ b/source/javascripts/hooks/useChangedModules.ts
@@ -6,14 +6,11 @@ export type ChangedModule = { nodeId: string; path: string };
 
 /** The changed (unsaved) module files of a modular config; empty for a single-file config. */
 export default function useChangedModules(): ChangedModule[] {
-  // useBitriseYmlStore already wraps the selector in useShallow, so a new array each render is fine.
-  return useBitriseYmlStore((s) =>
-    !s.tree
-      ? []
-      : Object.values(s.files)
-          .filter((slice) => isFileDirty(slice))
-          .map((slice) => ({ nodeId: slice.nodeId, path: slice.path })),
-  );
+  // Return the store's own slice objects (which already carry `nodeId`/`path`) rather than freshly
+  // mapped ones, so useBitriseYmlStore's internal useShallow can short-circuit when the changed set is
+  // unchanged — mapping to new objects each call would defeat shallow equality and re-render on every
+  // store update.
+  return useBitriseYmlStore((s) => (s.tree ? Object.values(s.files).filter((slice) => isFileDirty(slice)) : []));
 }
 
 export const moduleCountLabel = (count: number) => `${count} ${count === 1 ? 'module' : 'modules'} changed`;

--- a/source/javascripts/hooks/useChangedModules.ts
+++ b/source/javascripts/hooks/useChangedModules.ts
@@ -1,20 +1,18 @@
 import { isFileDirty } from '@/core/stores/BitriseYmlStore';
 
 import useBitriseYmlStore from './useBitriseYmlStore';
-import { useShallow } from './useShallow';
 
 export type ChangedModule = { nodeId: string; path: string };
 
 /** The changed (unsaved) module files of a modular config; empty for a single-file config. */
 export default function useChangedModules(): ChangedModule[] {
-  return useBitriseYmlStore(
-    useShallow((s) =>
-      !s.tree
-        ? []
-        : Object.values(s.files)
-            .filter((slice) => isFileDirty(slice))
-            .map((slice) => ({ nodeId: slice.nodeId, path: slice.path })),
-    ),
+  // useBitriseYmlStore already wraps the selector in useShallow, so a new array each render is fine.
+  return useBitriseYmlStore((s) =>
+    !s.tree
+      ? []
+      : Object.values(s.files)
+          .filter((slice) => isFileDirty(slice))
+          .map((slice) => ({ nodeId: slice.nodeId, path: slice.path })),
   );
 }
 

--- a/source/javascripts/hooks/useContainers.spec.tsx
+++ b/source/javascripts/hooks/useContainers.spec.tsx
@@ -62,4 +62,24 @@ describe('useContainers', () => {
     expect(result.current[ContainerType.Execution].map((c) => c.id)).toEqual(['exec-root']);
     expect(result.current[ContainerType.Service].map((c) => c.id)).toEqual(['svc-mod']);
   });
+
+  it('lets an including file outrank the files it includes for a duplicate container id', () => {
+    const root: TreeNode = {
+      nodeId: 'root',
+      path: 'bitrise.yml',
+      contents: 'containers:\n  dup:\n    type: execution\n    image: ubuntu:22.04\n',
+      source: null,
+      commitSha: SHA,
+      editable: true,
+      includes: [leaf('n_mod', 'mod.yml', 'containers:\n  dup:\n    type: service\n    image: postgres:16\n')],
+    };
+    initializeModularConfig({ root, entityIndex: ENTITY_INDEX, branch: 'main', commitSha: SHA });
+
+    const { result } = renderHook(() => useContainers());
+
+    // The root (including file) wins, so `dup` is grouped as execution — not the module's service.
+    expect(result.current.all).toHaveLength(1);
+    expect(result.current[ContainerType.Execution].map((c) => c.id)).toEqual(['dup']);
+    expect(result.current[ContainerType.Service]).toHaveLength(0);
+  });
 });

--- a/source/javascripts/hooks/useContainers.spec.tsx
+++ b/source/javascripts/hooks/useContainers.spec.tsx
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+
+import { ContainerType } from '@/core/models/Container';
+import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { initializeBitriseYmlDocument, initializeModularConfig } from '@/core/stores/BitriseYmlStore';
+
+import useContainers from './useContainers';
+
+const SHA = 'a1b2c3d4e5f6789012345678901234567890abcd';
+
+const leaf = (nodeId: string, path: string, contents: string): TreeNode => ({
+  nodeId,
+  path,
+  contents,
+  source: { path, repository: null, branch: null, tag: null, commit: null },
+  commitSha: SHA,
+  editable: true,
+  includes: [],
+});
+
+const ENTITY_INDEX: EntityIndex = { workflows: {}, pipelines: {}, stepBundles: {}, containers: {} };
+
+describe('useContainers', () => {
+  it('lists containers from the single config document', () => {
+    initializeBitriseYmlDocument({
+      ymlString: 'containers:\n  local-ctr:\n    type: execution\n    image: ubuntu:22.04\n',
+      version: '1',
+    });
+
+    const { result } = renderHook(() => useContainers());
+
+    expect(result.current.all.map((c) => c.id)).toEqual(['local-ctr']);
+    expect(result.current[ContainerType.Execution].map((c) => c.id)).toEqual(['local-ctr']);
+    expect(result.current[ContainerType.Service]).toHaveLength(0);
+  });
+
+  it('aggregates containers across all module files in a modular config', () => {
+    const root: TreeNode = {
+      nodeId: 'root',
+      path: 'bitrise.yml',
+      contents: 'containers:\n  exec-root:\n    type: execution\n    image: ubuntu:22.04\n',
+      source: null,
+      commitSha: SHA,
+      editable: true,
+      includes: [
+        leaf(
+          'n_svc',
+          'containers/services.yml',
+          'containers:\n  svc-mod:\n    type: service\n    image: postgres:16\n',
+        ),
+      ],
+    };
+    initializeModularConfig({ root, entityIndex: ENTITY_INDEX, branch: 'main', commitSha: SHA });
+
+    const { result } = renderHook(() => useContainers());
+
+    // A container defined in a module file (services.yml) is listed alongside the root's.
+    expect(result.current.all.map((c) => c.id).sort()).toEqual(['exec-root', 'svc-mod']);
+    expect(result.current[ContainerType.Execution].map((c) => c.id)).toEqual(['exec-root']);
+    expect(result.current[ContainerType.Service].map((c) => c.id)).toEqual(['svc-mod']);
+  });
+});

--- a/source/javascripts/hooks/useContainers.ts
+++ b/source/javascripts/hooks/useContainers.ts
@@ -14,7 +14,7 @@ type ReturnValue = {
 
 // Merge a modular config's containers post-order (included files first, then the including file) so a
 // node outranks the files it includes — matching modular precedence when the same container id is
-// defined in more than one file. (toJSON is cached per document identity, so this stays cheap.)
+// defined in more than one file.
 function collectContainers(node: TreeNode, files: Record<string, FileSlice>, acc: Containers): void {
   node.includes.forEach((child) => collectContainers(child, files, acc));
   const slice = files[node.nodeId];

--- a/source/javascripts/hooks/useContainers.ts
+++ b/source/javascripts/hooks/useContainers.ts
@@ -1,5 +1,7 @@
+import { Containers } from '@/core/models/BitriseYml';
 import { Container, ContainerType } from '@/core/models/Container';
 import ContainerService from '@/core/services/ContainerService';
+import YmlUtils from '@/core/utils/YmlUtils';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
 
 type ReturnValue = {
@@ -9,8 +11,15 @@ type ReturnValue = {
 };
 
 function useContainers(): ReturnValue {
-  return useBitriseYmlStore(({ yml }) => {
-    const containers = ContainerService.getAllContainers(yml.containers || {});
+  return useBitriseYmlStore((s) => {
+    // Modular: containers can be defined in any module file (all of them are part of the merged
+    // config), so aggregate across every file — the active doc's `yml.containers` only holds the
+    // current file's. Single-file: just that one document. (toJSON is cached per document identity.)
+    const merged: Containers = s.tree
+      ? Object.assign({}, ...Object.values(s.files).map((slice) => YmlUtils.toJSON(slice.ymlDocument).containers ?? {}))
+      : (s.yml.containers ?? {});
+
+    const containers = ContainerService.getAllContainers(merged);
     return {
       all: containers,
       [ContainerType.Execution]: containers.filter((c) => c.userValues.type === ContainerType.Execution),

--- a/source/javascripts/hooks/useContainers.ts
+++ b/source/javascripts/hooks/useContainers.ts
@@ -1,6 +1,8 @@
 import { Containers } from '@/core/models/BitriseYml';
 import { Container, ContainerType } from '@/core/models/Container';
+import { TreeNode } from '@/core/models/Tree';
 import ContainerService from '@/core/services/ContainerService';
+import { FileSlice } from '@/core/stores/BitriseYmlStore';
 import YmlUtils from '@/core/utils/YmlUtils';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
 
@@ -10,14 +12,27 @@ type ReturnValue = {
   [ContainerType.Service]: Container[];
 };
 
+// Merge a modular config's containers post-order (included files first, then the including file) so a
+// node outranks the files it includes — matching modular precedence when the same container id is
+// defined in more than one file. (toJSON is cached per document identity, so this stays cheap.)
+function collectContainers(node: TreeNode, files: Record<string, FileSlice>, acc: Containers): void {
+  node.includes.forEach((child) => collectContainers(child, files, acc));
+  const slice = files[node.nodeId];
+  if (slice) {
+    Object.assign(acc, YmlUtils.toJSON(slice.ymlDocument).containers ?? {});
+  }
+}
+
 function useContainers(): ReturnValue {
   return useBitriseYmlStore((s) => {
-    // Modular: containers can be defined in any module file (all of them are part of the merged
-    // config), so aggregate across every file — the active doc's `yml.containers` only holds the
-    // current file's. Single-file: just that one document. (toJSON is cached per document identity.)
-    const merged: Containers = s.tree
-      ? Object.assign({}, ...Object.values(s.files).map((slice) => YmlUtils.toJSON(slice.ymlDocument).containers ?? {}))
-      : (s.yml.containers ?? {});
+    // Modular: containers can be defined in any module file (all are part of the merged config), so
+    // aggregate across every file — the active doc's `yml.containers` only holds the current file's.
+    const merged: Containers = {};
+    if (s.tree) {
+      collectContainers(s.tree, s.files, merged);
+    } else {
+      Object.assign(merged, s.yml.containers ?? {});
+    }
 
     const containers = ContainerService.getAllContainers(merged);
     return {

--- a/source/javascripts/hooks/usePushBranch.ts
+++ b/source/javascripts/hooks/usePushBranch.ts
@@ -80,7 +80,7 @@ function usePushBranch({ onSuccess, onMergeConflict }: UsePushBranchOptions = {}
       trackPushConfigChangesSucceeded(configBranch, branch);
       toast({
         title: 'Changes pushed successfully',
-        description: 'Continue in your git provider and open a pull request.',
+        description: 'Continue in your Git provider and open a pull request.',
         status: 'success',
         isClosable: true,
         action: data?.pr_url

--- a/source/javascripts/pages/TriggersPage/components/TargetBasedTriggers/AddTriggerButton.tsx
+++ b/source/javascripts/pages/TriggersPage/components/TargetBasedTriggers/AddTriggerButton.tsx
@@ -10,9 +10,14 @@ type Props = {
 const AddTriggerButton = ({ onAddTrigger }: Props) => {
   const isReadOnlyView = useIsReadOnlyView();
 
+  // Read-only views (merged config, cross-repo/ref files) can't add — show no button at all.
+  if (isReadOnlyView) {
+    return null;
+  }
+
   return (
     <Menu>
-      <MenuButton as={Button} variant="secondary" size="md" leftIconName="Plus" isDisabled={isReadOnlyView}>
+      <MenuButton as={Button} variant="secondary" size="md" leftIconName="Plus">
         Add trigger
       </MenuButton>
       <MenuList>

--- a/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
+++ b/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
@@ -328,8 +328,8 @@ const ConfigurationYmlSourceDialog = ({ isOpen, onClose }: ConfigurationYmlStora
       titleText: 'Storage successfully changed',
       messageText:
         selectedStorage === 'git'
-          ? `From now you can manage your Configuration YAML in the project's Git repository.`
-          : 'From now you can manage your Configuration YAML on bitrise.io.',
+          ? `From now on, you can manage your Configuration YAML in the project's Git repository.`
+          : 'From now on, you can manage your Configuration YAML on bitrise.io.',
     });
     trackStorageSuccessfullyChanged(selectedStorage);
     forceRefreshStates();

--- a/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
+++ b/source/javascripts/pages/YmlPage/components/ConfigurationYmlStorageDialog.tsx
@@ -328,7 +328,7 @@ const ConfigurationYmlSourceDialog = ({ isOpen, onClose }: ConfigurationYmlStora
       titleText: 'Storage successfully changed',
       messageText:
         selectedStorage === 'git'
-          ? `From now you can manage your Configuration YAML in the project's git repository.`
+          ? `From now you can manage your Configuration YAML in the project's Git repository.`
           : 'From now you can manage your Configuration YAML on bitrise.io.',
     });
     trackStorageSuccessfullyChanged(selectedStorage);

--- a/source/javascripts/pages/YmlPage/components/OpenFileTabs/OpenFileTabs.tsx
+++ b/source/javascripts/pages/YmlPage/components/OpenFileTabs/OpenFileTabs.tsx
@@ -15,9 +15,8 @@ const OpenFileTabs = () => {
 
   const discardTab = fileTabs.find((tab) => tab.nodeId === discardNodeId);
 
-  // A purple dot marks an unsaved file; a saved file gets the neutral default dot (which becomes a
-  // close button on hover).
-  const tabStatusColor = (tab: FileTabInfo) => (tab.isDirty ? 'purple' : 'neutral');
+  // A purple dot marks an unsaved file; a saved (unchanged) file has no dot.
+  const tabStatusColor = (tab: FileTabInfo) => (tab.isDirty ? 'purple' : undefined);
 
   // Closing a tab with unsaved edits prompts first; a clean tab closes immediately.
   const handleClose = (tab: FileTabInfo) => {


### PR DESCRIPTION
A batch of small modular-YAML / read-only-view fixes and copy tweaks. Reviewable commit-by-commit.

## Changes

1. **File-tab dots** — a saved (unchanged) file tab shows no dot; only a **purple** dot when the file has unsaved changes. Hover-to-close still works.

2. **Hide (not disable) add buttons in read-only views** — in merged config / cross-file (read-only) views the "add" affordances render nothing instead of a disabled button, matching the workflow/pipeline/step-bundle add buttons: `TargetBasedTriggersCard` "Add trigger", `AddTriggerButton` (Triggers page), and the `EntitySelector` "Create …" footer. Editing controls stay disabled (they show the value read-only).

3. **Full module path in the update-config download list** — the "Update configuration YAML" dialog shows each changed module's full path (e.g. `ci_config/pipelines/pipelines.yml`); the download filename stays the flattened path (`ci_config-pipelines-pipelines.yml`) so same-named modules don't collide.

4. **Changed-modules note on the push dialog** — the "Push changes" dialog shows the same "N modules changed" + full-paths info note as the update-config dialog. Extracted into a shared `ChangedModulesNote` component backed by a `useChangedModules` hook, reused by both dialogs.

5. **"Enable triggers" read-only variant** — in read-only views the toggle uses the Toggle's read-only variant instead of a plain disable (workflow + pipeline triggers).

6. **Capitalize "Git"** — proper-noun casing in the push dialog helper texts / validation error, the pull-request toast, and the Configuration YAML storage dialog.

7. **Sidebar label** — "Step Bundles" → "Step bundles".

8. **Modular containers are selectable across files** — a container defined in a module file (e.g. `new5.yml`) is now listed in the container selector while editing another file (e.g. `bitrise.yml`). `useContainers` aggregates containers across every file of the modular config instead of only the active document. Also drops a redundant `useShallow` wrap in `useChangedModules`. Adds specs.

## Verification

- `tsc --noEmit`: 0 errors
- `eslint`: 0 errors
- `jest`: 1367/1367 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)