### PR TITLE
Reflect Stable-before-Edge stack order in fixtures

### DIFF
--- a/source/javascripts/core/api/StacksAndMachinesApi.mswMocks.ts
+++ b/source/javascripts/core/api/StacksAndMachinesApi.mswMocks.ts
@@ -52,6 +52,61 @@ const DEFAULT_MACHINES: MachineApiItem[] = [
 function groupedStacks(options?: Options): StackGroupApiItem[] {
   return [
     {
+      label: 'Stable Stacks',
+      status: 'stable' as StackStatus,
+      stacks: [
+        {
+          id: 'osx-xcode-16.0.x',
+          title: 'Xcode 16.0.x',
+          status: 'stable',
+          os: 'macos',
+          description:
+            'Xcode 16.0 based on macOS 14.5 Sonoma.\n\nThe Android SDK and other common mobile tools are also installed.',
+          machines:
+            options?.privateCloud === 'no-machines'
+              ? []
+              : ['m1.medium', 'm1.large', 'm2.medium', 'm2.large', 'm2.x-large'],
+        },
+        {
+          id: 'osx-xcode-15.0.x',
+          title: 'Xcode 15.0.x',
+          status: 'stable',
+          os: 'macos',
+          description:
+            'Xcode 15.0 based on macOS 14.1 Sonoma.\n\nThe Android SDK and other common mobile tools are also installed.',
+          machines: options?.privateCloud === 'no-machines' ? [] : ['m1.medium', 'm1.large', 'm2.medium', 'm2.large'],
+          rollback_version: {
+            'm1.medium': {
+              paying: '2-82-0',
+            },
+            'm1.large': {
+              paying: '2-82-0',
+            },
+            'm2.medium': {
+              free: '2-82-0',
+              paying: '2-82-0',
+            },
+            'm2.large': {
+              free: '2-82-0',
+              paying: '2-82-0',
+            },
+          },
+        },
+        {
+          id: 'ubuntu-jammy-22.04-bitrise-2024',
+          title: 'Ubuntu Jammy - Bitrise 2024 Edition',
+          status: 'stable',
+          os: 'linux',
+          description:
+            'Docker container environment based on Ubuntu 22.04. Preinstalled Android SDK and other common tools.',
+          machines:
+            options?.privateCloud === 'no-machines'
+              ? []
+              : ['standard', 'intel.medium', 'intel.large', 'amd.medium', 'amd.large', 'amd.x-large'],
+        },
+      ],
+    },
+    {
       label: 'Edge Stacks',
       status: 'edge' as StackStatus,
       stacks: [
@@ -120,61 +175,6 @@ function groupedStacks(options?: Options): StackGroupApiItem[] {
                   'machine-z1',
                   'machine-z2',
                 ],
-        },
-      ],
-    },
-    {
-      label: 'Stable Stacks',
-      status: 'stable' as StackStatus,
-      stacks: [
-        {
-          id: 'osx-xcode-16.0.x',
-          title: 'Xcode 16.0.x',
-          status: 'stable',
-          os: 'macos',
-          description:
-            'Xcode 16.0 based on macOS 14.5 Sonoma.\n\nThe Android SDK and other common mobile tools are also installed.',
-          machines:
-            options?.privateCloud === 'no-machines'
-              ? []
-              : ['m1.medium', 'm1.large', 'm2.medium', 'm2.large', 'm2.x-large'],
-        },
-        {
-          id: 'osx-xcode-15.0.x',
-          title: 'Xcode 15.0.x',
-          status: 'stable',
-          os: 'macos',
-          description:
-            'Xcode 15.0 based on macOS 14.1 Sonoma.\n\nThe Android SDK and other common mobile tools are also installed.',
-          machines: options?.privateCloud === 'no-machines' ? [] : ['m1.medium', 'm1.large', 'm2.medium', 'm2.large'],
-          rollback_version: {
-            'm1.medium': {
-              paying: '2-82-0',
-            },
-            'm1.large': {
-              paying: '2-82-0',
-            },
-            'm2.medium': {
-              free: '2-82-0',
-              paying: '2-82-0',
-            },
-            'm2.large': {
-              free: '2-82-0',
-              paying: '2-82-0',
-            },
-          },
-        },
-        {
-          id: 'ubuntu-jammy-22.04-bitrise-2024',
-          title: 'Ubuntu Jammy - Bitrise 2024 Edition',
-          status: 'stable',
-          os: 'linux',
-          description:
-            'Docker container environment based on Ubuntu 22.04. Preinstalled Android SDK and other common tools.',
-          machines:
-            options?.privateCloud === 'no-machines'
-              ? []
-              : ['standard', 'intel.medium', 'intel.large', 'amd.medium', 'amd.large', 'amd.x-large'],
         },
       ],
     },

--- a/source/javascripts/core/services/StackAndMachineService.spec.ts
+++ b/source/javascripts/core/services/StackAndMachineService.spec.ts
@@ -71,14 +71,14 @@ const stacks: Stack[] = [
 
 const groupedStacks: StackGroup[] = [
   {
-    label: 'Edge Stacks',
-    status: 'edge',
-    stacks: stacks.filter((stack) => stack.status === 'edge'),
-  },
-  {
     label: 'Stable Stacks',
     status: 'stable',
     stacks: stacks.filter((stack) => stack.status === 'stable'),
+  },
+  {
+    label: 'Edge Stacks',
+    status: 'edge',
+    stacks: stacks.filter((stack) => stack.status === 'edge'),
   },
   {
     label: 'Uncategorized Stacks',
@@ -254,17 +254,17 @@ describe('StackAndMachineService', () => {
           options: [{ value: '', label: 'Default - Xcode 15.0.x', status: 'stable', os: 'macos' }],
         },
         {
-          label: 'Edge Stacks',
-          status: 'edge',
-          options: groupedStacks
-            .filter((stackGroup) => stackGroup.status === 'edge')
-            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
-        },
-        {
           label: 'Stable Stacks',
           status: 'stable',
           options: groupedStacks
             .filter((stackGroup) => stackGroup.status === 'stable')
+            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
+        },
+        {
+          label: 'Edge Stacks',
+          status: 'edge',
+          options: groupedStacks
+            .filter((stackGroup) => stackGroup.status === 'edge')
             .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
         },
         {
@@ -366,17 +366,17 @@ describe('StackAndMachineService', () => {
           options: [{ value: '', label: 'Default - Xcode 16.0.x', status: 'stable', os: 'macos' }],
         },
         {
-          label: 'Edge Stacks',
-          status: 'edge',
-          options: groupedStacks
-            .filter((stackGroup) => stackGroup.status === 'edge')
-            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
-        },
-        {
           label: 'Stable Stacks',
           status: 'stable',
           options: groupedStacks
             .filter((stackGroup) => stackGroup.status === 'stable')
+            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
+        },
+        {
+          label: 'Edge Stacks',
+          status: 'edge',
+          options: groupedStacks
+            .filter((stackGroup) => stackGroup.status === 'edge')
             .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
         },
         {
@@ -485,17 +485,17 @@ describe('StackAndMachineService', () => {
           options: [{ label: 'Default - Xcode 15.0.x', value: '', status: 'stable', os: 'macos' }],
         },
         {
-          label: 'Edge Stacks',
-          status: 'edge',
-          options: groupedStacks
-            .filter((stackGroup) => stackGroup.status === 'edge')
-            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
-        },
-        {
           label: 'Stable Stacks',
           status: 'stable',
           options: groupedStacks
             .filter((stackGroup) => stackGroup.status === 'stable')
+            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
+        },
+        {
+          label: 'Edge Stacks',
+          status: 'edge',
+          options: groupedStacks
+            .filter((stackGroup) => stackGroup.status === 'edge')
             .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
         },
         {
@@ -561,17 +561,17 @@ describe('StackAndMachineService', () => {
           options: [{ value: '', label: 'Invalid Default Stack - osx-xcode-11', status: 'unknown', os: 'unknown' }],
         },
         {
-          label: 'Edge Stacks',
-          status: 'edge',
-          options: groupedStacks
-            .filter((stackGroup) => stackGroup.status === 'edge')
-            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
-        },
-        {
           label: 'Stable Stacks',
           status: 'stable',
           options: groupedStacks
             .filter((stackGroup) => stackGroup.status === 'stable')
+            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
+        },
+        {
+          label: 'Edge Stacks',
+          status: 'edge',
+          options: groupedStacks
+            .filter((stackGroup) => stackGroup.status === 'edge')
             .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
         },
         {
@@ -636,17 +636,17 @@ describe('StackAndMachineService', () => {
           options: [{ value: '', label: 'Default - Xcode 15.0.x', status: 'stable', os: 'macos' }],
         },
         {
-          label: 'Edge Stacks',
-          status: 'edge',
-          options: groupedStacks
-            .filter((stackGroup) => stackGroup.status === 'edge')
-            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
-        },
-        {
           label: 'Stable Stacks',
           status: 'stable',
           options: groupedStacks
             .filter((stackGroup) => stackGroup.status === 'stable')
+            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
+        },
+        {
+          label: 'Edge Stacks',
+          status: 'edge',
+          options: groupedStacks
+            .filter((stackGroup) => stackGroup.status === 'edge')
             .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
         },
         {
@@ -751,17 +751,17 @@ describe('StackAndMachineService', () => {
           options: [{ value: '', label: 'Default - Xcode 15.0.x', status: 'stable', os: 'macos' }],
         },
         {
-          label: 'Edge Stacks',
-          status: 'edge',
-          options: groupedStacks
-            .filter((stackGroup) => stackGroup.status === 'edge')
-            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
-        },
-        {
           label: 'Stable Stacks',
           status: 'stable',
           options: groupedStacks
             .filter((stackGroup) => stackGroup.status === 'stable')
+            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
+        },
+        {
+          label: 'Edge Stacks',
+          status: 'edge',
+          options: groupedStacks
+            .filter((stackGroup) => stackGroup.status === 'edge')
             .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
         },
         {
@@ -873,17 +873,17 @@ describe('StackAndMachineService', () => {
           ],
         },
         {
-          label: 'Edge Stacks',
-          status: 'edge',
-          options: groupedStacks
-            .filter((stackGroup) => stackGroup.status === 'edge')
-            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
-        },
-        {
           label: 'Stable Stacks',
           status: 'stable',
           options: groupedStacks
             .filter((stackGroup) => stackGroup.status === 'stable')
+            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
+        },
+        {
+          label: 'Edge Stacks',
+          status: 'edge',
+          options: groupedStacks
+            .filter((stackGroup) => stackGroup.status === 'edge')
             .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
         },
         {
@@ -1073,17 +1073,17 @@ describe('StackAndMachineService', () => {
           options: [{ value: '', label: 'Default - Xcode 15.0.x', status: 'stable', os: 'macos' }],
         },
         {
-          label: 'Edge Stacks',
-          status: 'edge',
-          options: groupedStacks
-            .filter((stackGroup) => stackGroup.status === 'edge')
-            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
-        },
-        {
           label: 'Stable Stacks',
           status: 'stable',
           options: groupedStacks
             .filter((stackGroup) => stackGroup.status === 'stable')
+            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
+        },
+        {
+          label: 'Edge Stacks',
+          status: 'edge',
+          options: groupedStacks
+            .filter((stackGroup) => stackGroup.status === 'edge')
             .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
         },
         {
@@ -1150,17 +1150,17 @@ describe('StackAndMachineService', () => {
           options: [{ value: '', label: 'Default - Xcode 15.0.x', status: 'stable', os: 'macos' }],
         },
         {
-          label: 'Edge Stacks',
-          status: 'edge',
-          options: groupedStacks
-            .filter((stackGroup) => stackGroup.status === 'edge')
-            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
-        },
-        {
           label: 'Stable Stacks',
           status: 'stable',
           options: groupedStacks
             .filter((stackGroup) => stackGroup.status === 'stable')
+            .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
+        },
+        {
+          label: 'Edge Stacks',
+          status: 'edge',
+          options: groupedStacks
+            .filter((stackGroup) => stackGroup.status === 'edge')
             .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
         },
         {
@@ -1486,17 +1486,17 @@ describe('StackAndMachineService', () => {
         // Stack options
         expect(result.stackOptionGroups).toEqual([
           {
-            label: 'Edge Stacks',
-            status: 'edge',
-            options: groupedStacks
-              .filter((stackGroup) => stackGroup.status === 'edge')
-              .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
-          },
-          {
             label: 'Stable Stacks',
             status: 'stable',
             options: groupedStacks
               .filter((stackGroup) => stackGroup.status === 'stable')
+              .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
+          },
+          {
+            label: 'Edge Stacks',
+            status: 'edge',
+            options: groupedStacks
+              .filter((stackGroup) => stackGroup.status === 'edge')
               .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
           },
           {
@@ -1599,17 +1599,17 @@ describe('StackAndMachineService', () => {
         // Stack options
         expect(result.stackOptionGroups).toEqual([
           {
-            label: 'Edge Stacks',
-            status: 'edge',
-            options: groupedStacks
-              .filter((stackGroup) => stackGroup.status === 'edge')
-              .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
-          },
-          {
             label: 'Stable Stacks',
             status: 'stable',
             options: groupedStacks
               .filter((stackGroup) => stackGroup.status === 'stable')
+              .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
+          },
+          {
+            label: 'Edge Stacks',
+            status: 'edge',
+            options: groupedStacks
+              .filter((stackGroup) => stackGroup.status === 'edge')
               .flatMap((stackGroup) => stackGroup.stacks.map(StackAndMachineService.toStackOption)),
           },
           {


### PR DESCRIPTION
## What

Fixture-only update to match the new backend stack group order (**Stable → Edge → Uncategorized → Frozen**):

- `StacksAndMachinesApi.mswMocks.ts` — reorder the `grouped_stacks` mock so Stable comes before Edge.
- `StackAndMachineService.spec.ts` — reorder the shared `groupedStacks` input fixture and every `stackOptionGroups` expectation to match.

## Why

The Workflow Editor renders whatever order the API returns, so there is **no production code change** here — only fixtures/tests, so Storybook and unit tests mirror production.

The actual ordering change lives in the backend: bitrise-io/bitrise-website#20110.

## Verification

- `StackAndMachineService.spec.ts` — 49/49 pass.
- eslint clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)