### PR TITLE
Tool catalog: make tool ID a dropdown of known tools

### DIFF
--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -31,7 +31,6 @@ type ToolRowProps = {
   catalog: ToolCatalog | undefined;
   allowUnset?: boolean;
   autoFocus?: boolean;
-  isCatalogReady: boolean;
   isCatalogLoading: boolean;
   onIdChange: (newId: string) => void;
   onStrategyChange: (strategy: VersionStrategy, version: string) => void;
@@ -47,7 +46,6 @@ const ToolRow = ({
   catalog,
   allowUnset,
   autoFocus,
-  isCatalogReady,
   isCatalogLoading,
   onIdChange,
   onStrategyChange,
@@ -58,6 +56,7 @@ const ToolRow = ({
   const [manualOther, setManualOther] = useState(false);
   const [idError, setIdError] = useState<string | undefined>();
 
+  const isCatalogReady = !!catalog;
   const isToolIdKnown = ToolsService.isKnownToolId(catalog, toolId);
   const dropdownOptions = ToolsService.getAvailableToolIdOptions(catalog, toolId, existingToolIds);
 

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -31,8 +31,6 @@ type ToolRowProps = {
   catalog: ToolCatalog | undefined;
   allowUnset?: boolean;
   autoFocus?: boolean;
-  dropdownOptions: { value: string; label: string }[];
-  isToolIdKnown: boolean;
   isCatalogReady: boolean;
   isCatalogLoading: boolean;
   onIdChange: (newId: string) => void;
@@ -49,8 +47,6 @@ const ToolRow = ({
   catalog,
   allowUnset,
   autoFocus,
-  dropdownOptions,
-  isToolIdKnown,
   isCatalogReady,
   isCatalogLoading,
   onIdChange,
@@ -61,6 +57,9 @@ const ToolRow = ({
   // Whether the user has explicitly picked "Other" from the dropdown.
   const [manualOther, setManualOther] = useState(false);
   const [idError, setIdError] = useState<string | undefined>();
+
+  const isToolIdKnown = ToolsService.isKnownToolId(catalog, toolId);
+  const dropdownOptions = ToolsService.getAvailableToolIdOptions(catalog, toolId, existingToolIds);
 
   // Only treat a tool as custom once the catalog has actually resolved. While it's
   // still loading, or if it failed to load, an unknown toolId isn't proof it's custom.
@@ -93,8 +92,8 @@ const ToolRow = ({
       return;
     }
     setIdError(undefined);
+    setManualOther(false);
     if (newId !== toolId) {
-      setManualOther(false);
       onIdChange(newId);
     }
   };
@@ -116,6 +115,7 @@ const ToolRow = ({
             items={dropdownItems}
             value={showCustomInput ? OTHER_VALUE : toolId}
             onValueChange={handleDropdownChange}
+            triggerProps={showCustomInput ? undefined : { autoFocus }}
           />
           {showCustomInput && (
             <BitkitTextInput

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -81,7 +81,9 @@ const ToolRow = ({
     }
     setManualOther(false);
     setIdError(undefined);
-    onIdChange(newValue);
+    if (newValue !== toolId) {
+      onIdChange(newValue);
+    }
   };
 
   const handleIdBlur: FocusEventHandler<HTMLInputElement> = (e) => {

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -6,6 +6,7 @@ import {
   BitkitTextInput,
   IconMinusCircle,
   IconOpenInNew,
+  rem,
 } from '@bitrise/bitkit-v2';
 import { Box } from '@chakra-ui/react/box';
 import { Text } from '@chakra-ui/react/text';
@@ -104,7 +105,7 @@ const ToolRow = ({
   return (
     <Box display="flex" flexDirection="column" gap="8">
       <Box display="flex" alignItems="flex-start" gap="12">
-        <Box display="flex" flexDirection="column" gap="8" width="160px" flexShrink="0">
+        <Box display="flex" flexDirection="column" gap="8" width={rem(160)} flexShrink="0">
           <BitkitSelect
             size="md"
             placeholder="Select one"
@@ -142,7 +143,7 @@ const ToolRow = ({
           {strategy !== 'unset' && (
             <BitkitTextInput
               size="md"
-              width="160px"
+              width={rem(160)}
               flexShrink="0"
               placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
               inputProps={{

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -1,5 +1,14 @@
-import { BitkitIconButton, BitkitNativeSelect, BitkitTextInput, IconMinusCircle } from '@bitrise/bitkit-v2';
+import {
+  BitkitIconButton,
+  BitkitLink,
+  BitkitNativeSelect,
+  BitkitSelect,
+  BitkitTextInput,
+  IconMinusCircle,
+  IconOpenInNew,
+} from '@bitrise/bitkit-v2';
 import { Box } from '@chakra-ui/react/box';
+import { Text } from '@chakra-ui/react/text';
 import { FocusEventHandler, useState } from 'react';
 
 import { VersionStrategy } from '@/core/models/Tools';
@@ -12,6 +21,8 @@ const STRATEGY_LABELS: Record<VersionStrategy, string> = {
   unset: 'Do nothing (unset global setting)',
 };
 
+const OTHER_VALUE = '__other__';
+
 type ToolRowProps = {
   toolId: string;
   strategy: VersionStrategy;
@@ -19,6 +30,10 @@ type ToolRowProps = {
   existingToolIds: string[];
   allowUnset?: boolean;
   autoFocus?: boolean;
+  dropdownOptions: { value: string; label: string }[];
+  isToolIdKnown: boolean;
+  isCatalogReady: boolean;
+  isCatalogLoading: boolean;
   onIdChange: (newId: string) => void;
   onStrategyChange: (strategy: VersionStrategy, version: string) => void;
   onVersionChange: (version: string) => void;
@@ -32,12 +47,39 @@ const ToolRow = ({
   existingToolIds,
   allowUnset,
   autoFocus,
+  dropdownOptions,
+  isToolIdKnown,
+  isCatalogReady,
+  isCatalogLoading,
   onIdChange,
   onStrategyChange,
   onVersionChange,
   onRemove,
 }: ToolRowProps) => {
+  // Whether the user has explicitly picked "Other" from the dropdown.
+  const [manualOther, setManualOther] = useState(false);
   const [idError, setIdError] = useState<string | undefined>();
+
+  // Only treat a tool as custom once the catalog has actually resolved. While it's
+  // still loading, or if it failed to load, an unknown toolId isn't proof it's custom.
+  const showCustomInput = manualOther || (isCatalogReady && toolId !== '' && !isToolIdKnown);
+
+  const dropdownItems = [
+    ...dropdownOptions,
+    // Keep the current value selectable while the catalog hasn't confirmed it one way or the other.
+    ...(!showCustomInput && toolId !== '' && !isToolIdKnown ? [{ value: toolId, label: toolId }] : []),
+    { value: OTHER_VALUE, label: 'Other' },
+  ];
+
+  const handleDropdownChange = (newValue: string) => {
+    if (newValue === OTHER_VALUE) {
+      setManualOther(true);
+      return;
+    }
+    setManualOther(false);
+    setIdError(undefined);
+    onIdChange(newValue);
+  };
 
   const handleIdBlur: FocusEventHandler<HTMLInputElement> = (e) => {
     const newId = e.target.value.trim();
@@ -48,6 +90,7 @@ const ToolRow = ({
     }
     setIdError(undefined);
     if (newId !== toolId) {
+      setManualOther(false);
       onIdChange(newId);
     }
   };
@@ -59,47 +102,75 @@ const ToolRow = ({
   };
 
   return (
-    <Box display="flex" alignItems="flex-start" gap="12">
-      <BitkitTextInput
-        size="md"
-        width="160px"
-        flexShrink="0"
-        placeholder="Tool (ruby, node, etc.)"
-        errorText={idError}
-        inputProps={{ defaultValue: toolId, autoFocus, onBlur: handleIdBlur }}
-      />
-
-      <Box display="flex" flex="1" alignItems="flex-start" gap="8">
-        <BitkitNativeSelect
-          flex="1"
-          size="md"
-          value={strategy}
-          onChange={(e) => handleStrategyChange(e.target.value as VersionStrategy)}
-        >
-          {Object.entries(STRATEGY_LABELS)
-            .filter(([value]) => allowUnset || value !== 'unset')
-            .map(([value, label]) => (
-              <option key={value} value={value}>
-                {label}
-              </option>
-            ))}
-        </BitkitNativeSelect>
-
-        {strategy !== 'unset' && (
-          <BitkitTextInput
+    <Box display="flex" flexDirection="column" gap="8">
+      <Box display="flex" alignItems="flex-start" gap="12">
+        <Box display="flex" flexDirection="column" gap="8" width="160px" flexShrink="0">
+          <BitkitSelect
             size="md"
-            width="160px"
-            flexShrink="0"
-            placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
-            inputProps={{
-              value: version,
-              onChange: (e) => onVersionChange(e.target.value),
-            }}
+            placeholder="Select one"
+            isLoading={isCatalogLoading}
+            items={dropdownItems}
+            value={showCustomInput ? OTHER_VALUE : toolId}
+            onValueChange={handleDropdownChange}
           />
-        )}
+          {showCustomInput && (
+            <BitkitTextInput
+              size="md"
+              placeholder="Tool ID (e.g. deno)"
+              errorText={idError}
+              inputProps={{ defaultValue: toolId, autoFocus, onBlur: handleIdBlur }}
+            />
+          )}
+        </Box>
+
+        <Box display="flex" flex="1" alignItems="flex-start" gap="8">
+          <BitkitNativeSelect
+            flex="1"
+            size="md"
+            value={strategy}
+            onChange={(e) => handleStrategyChange(e.target.value as VersionStrategy)}
+          >
+            {Object.entries(STRATEGY_LABELS)
+              .filter(([value]) => allowUnset || value !== 'unset')
+              .map(([value, label]) => (
+                <option key={value} value={value}>
+                  {label}
+                </option>
+              ))}
+          </BitkitNativeSelect>
+
+          {strategy !== 'unset' && (
+            <BitkitTextInput
+              size="md"
+              width="160px"
+              flexShrink="0"
+              placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
+              inputProps={{
+                value: version,
+                onChange: (e) => onVersionChange(e.target.value),
+              }}
+            />
+          )}
+        </Box>
+
+        <BitkitIconButton variant="tertiary" icon={IconMinusCircle} label="Remove tool" onClick={onRemove} />
       </Box>
 
-      <BitkitIconButton variant="tertiary" icon={IconMinusCircle} label="Remove tool" onClick={onRemove} />
+      {showCustomInput && (
+        <Text textStyle="body/md/regular">
+          The system is designed to support a growing list of tools and languages, but Bitrise only verifies and tests
+          the stability of the most common tools. If you need a tool not listed here, read{' '}
+          <BitkitLink
+            colorVariant="purple"
+            isExternal
+            suffixIcon={IconOpenInNew}
+            href="https://docs.bitrise.io/en/bitrise-ci/configure-builds/configuring-build-settings/configuring-tool-versions#supported-tools"
+          >
+            how to use community plugins
+          </BitkitLink>
+          .
+        </Text>
+      )}
     </Box>
   );
 };

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -109,7 +109,7 @@ const ToolRow = ({
       <Box display="flex" alignItems="flex-start" gap="12">
         <Box display="flex" flexDirection="column" gap="8" width={rem(160)} flexShrink="0">
           <BitkitSelect
-            size="md"
+            size="lg"
             placeholder="Select one"
             isLoading={isCatalogLoading}
             items={dropdownItems}
@@ -119,7 +119,7 @@ const ToolRow = ({
           />
           {showCustomInput && (
             <BitkitTextInput
-              size="md"
+              size="lg"
               placeholder="Tool ID (e.g. deno)"
               errorText={idError}
               inputProps={{ defaultValue: toolId, autoFocus, onBlur: handleIdBlur }}
@@ -127,30 +127,28 @@ const ToolRow = ({
           )}
         </Box>
 
-        <Box display="flex" flex="1" alignItems="flex-start" gap="8">
-          <BitkitSelect
-            flex="1"
-            size="md"
-            items={Object.entries(STRATEGY_LABELS)
-              .filter(([value]) => allowUnset || value !== 'unset')
-              .map(([value, label]) => ({ value, label }))}
-            value={strategy}
-            onValueChange={(v) => handleStrategyChange(v as VersionStrategy)}
-          />
+        <BitkitSelect
+          flex="1"
+          size="lg"
+          items={Object.entries(STRATEGY_LABELS)
+            .filter(([value]) => allowUnset || value !== 'unset')
+            .map(([value, label]) => ({ value, label }))}
+          value={strategy}
+          onValueChange={(v) => handleStrategyChange(v as VersionStrategy)}
+        />
 
-          {strategy !== 'unset' && (
-            <BitkitTextInput
-              size="md"
-              width={rem(120)}
-              flexShrink="0"
-              placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
-              inputProps={{
-                value: version,
-                onChange: (e) => onVersionChange(e.target.value),
-              }}
-            />
-          )}
-        </Box>
+        {strategy !== 'unset' && (
+          <BitkitTextInput
+            size="lg"
+            width={rem(130)}
+            flexShrink="0"
+            placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
+            inputProps={{
+              value: version,
+              onChange: (e) => onVersionChange(e.target.value),
+            }}
+          />
+        )}
 
         <BitkitIconButton variant="tertiary" icon={IconMinusCircle} label="Remove tool" onClick={onRemove} />
       </Box>

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -12,7 +12,7 @@ import { Box } from '@chakra-ui/react/box';
 import { Text } from '@chakra-ui/react/text';
 import { FocusEventHandler, useState } from 'react';
 
-import { VersionStrategy } from '@/core/models/Tools';
+import { ToolCatalog, VersionStrategy } from '@/core/models/Tools';
 import ToolsService from '@/core/services/ToolsService';
 
 const STRATEGY_LABELS: Record<VersionStrategy, string> = {
@@ -29,6 +29,7 @@ type ToolRowProps = {
   strategy: VersionStrategy;
   version: string;
   existingToolIds: string[];
+  catalog: ToolCatalog | undefined;
   allowUnset?: boolean;
   autoFocus?: boolean;
   dropdownOptions: { value: string; label: string }[];
@@ -46,6 +47,7 @@ const ToolRow = ({
   strategy,
   version,
   existingToolIds,
+  catalog,
   allowUnset,
   autoFocus,
   dropdownOptions,
@@ -84,7 +86,7 @@ const ToolRow = ({
 
   const handleIdBlur: FocusEventHandler<HTMLInputElement> = (e) => {
     const newId = e.target.value.trim();
-    const validation = ToolsService.validateToolId(newId, toolId, existingToolIds);
+    const validation = ToolsService.validateToolId(newId, toolId, existingToolIds, catalog);
     if (validation !== true) {
       setIdError(validation);
       return;

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -1,7 +1,6 @@
 import {
   BitkitIconButton,
   BitkitLink,
-  BitkitNativeSelect,
   BitkitSelect,
   BitkitTextInput,
   IconMinusCircle,
@@ -129,25 +128,20 @@ const ToolRow = ({
         </Box>
 
         <Box display="flex" flex="1" alignItems="flex-start" gap="8">
-          <BitkitNativeSelect
+          <BitkitSelect
             flex="1"
             size="md"
-            value={strategy}
-            onChange={(e) => handleStrategyChange(e.target.value as VersionStrategy)}
-          >
-            {Object.entries(STRATEGY_LABELS)
+            items={Object.entries(STRATEGY_LABELS)
               .filter(([value]) => allowUnset || value !== 'unset')
-              .map(([value, label]) => (
-                <option key={value} value={value}>
-                  {label}
-                </option>
-              ))}
-          </BitkitNativeSelect>
+              .map(([value, label]) => ({ value, label }))}
+            value={strategy}
+            onValueChange={(v) => handleStrategyChange(v as VersionStrategy)}
+          />
 
           {strategy !== 'unset' && (
             <BitkitTextInput
               size="md"
-              width={rem(160)}
+              width={rem(120)}
               flexShrink="0"
               placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
               inputProps={{

--- a/source/javascripts/components/ToolVersions/ToolVersions.stories.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { set } from 'es-toolkit/compat';
 import { stringify } from 'yaml';
 
+import ToolCatalogApiMocks from '@/core/api/ToolCatalogApi.mswMocks';
 import YmlUtils from '@/core/utils/YmlUtils';
 
 import ToolVersions from './ToolVersions';
@@ -16,6 +17,11 @@ const meta: Meta<typeof ToolVersions> = {
       </Box>
     ),
   ],
+  parameters: {
+    msw: {
+      handlers: [ToolCatalogApiMocks.getToolCatalog()],
+    },
+  },
 };
 
 export default meta;
@@ -52,3 +58,44 @@ export const WorkflowScope: Story = {
 };
 
 export const Empty: Story = {};
+
+export const CatalogLoading: Story = {
+  ...RootScope,
+  parameters: {
+    ...RootScope.parameters,
+    msw: {
+      handlers: [ToolCatalogApiMocks.getToolCatalogPending()],
+    },
+  },
+};
+
+export const CatalogError: Story = {
+  ...RootScope,
+  parameters: {
+    ...RootScope.parameters,
+    msw: {
+      handlers: [ToolCatalogApiMocks.getToolCatalogError()],
+    },
+  },
+};
+
+export const RealApi: Story = {
+  ...RootScope,
+  parameters: {
+    ...RootScope.parameters,
+    msw: {
+      handlers: [],
+    },
+  },
+};
+
+export const CustomTool: Story = {
+  parameters: {
+    bitriseYmlStore: (() => {
+      const yml = set({ ...TEST_BITRISE_YML }, 'tools', {
+        deno: '2.90.0',
+      });
+      return { yml, ymlDocument: YmlUtils.toDoc(stringify(yml)) };
+    })(),
+  },
+};

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -18,7 +18,6 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
   const [pendingVersion, setPendingVersion] = useState('');
 
   const allowUnset = scope.type === 'workflow';
-  const isCatalogReady = !!catalog;
   const existingToolIds = Object.keys(tools);
 
   const handleAddNew = () => {
@@ -54,7 +53,6 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
               existingToolIds={existingToolIds}
               catalog={catalog}
               allowUnset={allowUnset}
-              isCatalogReady={isCatalogReady}
               isCatalogLoading={isCatalogLoading}
               onIdChange={(newId) => ToolsService.renameTool(toolId, newId, scope)}
               onStrategyChange={(strategy, ver) => ToolsService.setTool(toolId, strategy, ver, scope)}
@@ -72,7 +70,6 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
             catalog={catalog}
             allowUnset={allowUnset}
             autoFocus
-            isCatalogReady={isCatalogReady}
             isCatalogLoading={isCatalogLoading}
             onIdChange={(newId) => {
               ToolsService.setTool(newId, pendingStrategy, pendingVersion, scope);

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -56,10 +56,7 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
               allowUnset={allowUnset}
               isCatalogReady={isCatalogReady}
               isCatalogLoading={isCatalogLoading}
-              onIdChange={(newId) => {
-                ToolsService.deleteTool(toolId, scope);
-                ToolsService.setTool(newId, parsed.strategy, versionValue, scope);
-              }}
+              onIdChange={(newId) => ToolsService.renameTool(toolId, newId, scope)}
               onStrategyChange={(strategy, ver) => ToolsService.setTool(toolId, strategy, ver, scope)}
               onVersionChange={(ver) => ToolsService.setTool(toolId, parsed.strategy, ver, scope)}
               onRemove={() => ToolsService.deleteTool(toolId, scope)}

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -49,6 +49,7 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
               strategy={parsed.strategy}
               version={versionValue}
               existingToolIds={existingToolIds}
+              catalog={catalog}
               allowUnset={allowUnset}
               dropdownOptions={ToolsService.getAvailableToolIdOptions(catalog, toolId, existingToolIds)}
               isToolIdKnown={ToolsService.isKnownToolId(catalog, toolId)}
@@ -70,6 +71,7 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
             strategy={pendingStrategy}
             version={pendingVersion}
             existingToolIds={existingToolIds}
+            catalog={catalog}
             allowUnset={allowUnset}
             autoFocus
             dropdownOptions={ToolsService.getAvailableToolIdOptions(catalog, '', existingToolIds)}

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -1,4 +1,4 @@
-import { BitkitAlert, BitkitButton, BitkitLink } from '@bitrise/bitkit-v2';
+import { BitkitAlert, BitkitButton, BitkitLink, IconOpenInNew, rem } from '@bitrise/bitkit-v2';
 import { Box } from '@chakra-ui/react/box';
 import { Text } from '@chakra-ui/react/text';
 import { useState } from 'react';
@@ -28,12 +28,15 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
   };
 
   return (
-    <Box display="flex" flexDirection="column" gap="24" marginBlockStart="24" maxWidth={640}>
+    <Box display="flex" flexDirection="column" gap="24" marginBlockStart="24" maxWidth={rem(640)}>
       <Box display="flex" flexDirection="column" gap="8">
         <Text textStyle="heading/h3">Tool setup</Text>
         <Text textStyle="body/md/regular" color="text/secondary">
           Configure what tools and versions are required for this workflow to work. Tool setup runs before the first
-          step. <BitkitLink href="#">Learn more</BitkitLink>
+          step.{' '}
+          <BitkitLink href="#" isExternal suffixIcon={IconOpenInNew} colorVariant="purple">
+            Learn more
+          </BitkitLink>
         </Text>
       </Box>
 

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -1,22 +1,25 @@
-import { BitkitButton, BitkitLink } from '@bitrise/bitkit-v2';
+import { BitkitAlert, BitkitButton, BitkitLink } from '@bitrise/bitkit-v2';
 import { Box } from '@chakra-ui/react/box';
 import { Text } from '@chakra-ui/react/text';
 import { useState } from 'react';
 
 import { VersionStrategy } from '@/core/models/Tools';
 import ToolsService, { ToolScope } from '@/core/services/ToolsService';
-import { useToolsForScope } from '@/hooks/useTools';
+import { useToolCatalog, useToolsForScope } from '@/hooks/useTools';
 
 import ToolRow from './ToolRow';
 
 const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
   const scope: ToolScope = workflowId ? { type: 'workflow', workflowId } : { type: 'root' };
   const tools = useToolsForScope(scope);
+  const { data: catalog, isLoading: isCatalogLoading, isError: isCatalogError } = useToolCatalog();
   const [hasPendingRow, setHasPendingRow] = useState(false);
   const [pendingStrategy, setPendingStrategy] = useState<VersionStrategy>('latest-released');
   const [pendingVersion, setPendingVersion] = useState('');
 
   const allowUnset = scope.type === 'workflow';
+  const isCatalogReady = !isCatalogLoading && catalog !== undefined;
+  const existingToolIds = Object.keys(tools);
 
   const handleAddNew = () => {
     setPendingStrategy('latest-released');
@@ -45,8 +48,12 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
               toolId={toolId}
               strategy={parsed.strategy}
               version={versionValue}
-              existingToolIds={Object.keys(tools)}
+              existingToolIds={existingToolIds}
               allowUnset={allowUnset}
+              dropdownOptions={ToolsService.getAvailableToolIdOptions(catalog, toolId, existingToolIds)}
+              isToolIdKnown={ToolsService.isKnownToolId(catalog, toolId)}
+              isCatalogReady={isCatalogReady}
+              isCatalogLoading={isCatalogLoading}
               onIdChange={(newId) => {
                 ToolsService.deleteTool(toolId, scope);
                 ToolsService.setTool(newId, parsed.strategy, versionValue, scope);
@@ -62,9 +69,13 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
             toolId=""
             strategy={pendingStrategy}
             version={pendingVersion}
-            existingToolIds={Object.keys(tools)}
+            existingToolIds={existingToolIds}
             allowUnset={allowUnset}
             autoFocus
+            dropdownOptions={ToolsService.getAvailableToolIdOptions(catalog, '', existingToolIds)}
+            isToolIdKnown={ToolsService.isKnownToolId(catalog, '')}
+            isCatalogReady={isCatalogReady}
+            isCatalogLoading={isCatalogLoading}
             onIdChange={(newId) => {
               ToolsService.setTool(newId, pendingStrategy, pendingVersion, scope);
               setHasPendingRow(false);
@@ -78,6 +89,8 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
           />
         )}
       </Box>
+
+      {isCatalogError && <BitkitAlert variant="warning" messageText="Couldn't load tool suggestions." />}
 
       <BitkitButton
         variant="secondary"

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -18,7 +18,7 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
   const [pendingVersion, setPendingVersion] = useState('');
 
   const allowUnset = scope.type === 'workflow';
-  const isCatalogReady = !isCatalogLoading && catalog !== undefined;
+  const isCatalogReady = !!catalog;
   const existingToolIds = Object.keys(tools);
 
   const handleAddNew = () => {
@@ -51,8 +51,6 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
               existingToolIds={existingToolIds}
               catalog={catalog}
               allowUnset={allowUnset}
-              dropdownOptions={ToolsService.getAvailableToolIdOptions(catalog, toolId, existingToolIds)}
-              isToolIdKnown={ToolsService.isKnownToolId(catalog, toolId)}
               isCatalogReady={isCatalogReady}
               isCatalogLoading={isCatalogLoading}
               onIdChange={(newId) => {
@@ -74,8 +72,6 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
             catalog={catalog}
             allowUnset={allowUnset}
             autoFocus
-            dropdownOptions={ToolsService.getAvailableToolIdOptions(catalog, '', existingToolIds)}
-            isToolIdKnown={ToolsService.isKnownToolId(catalog, '')}
             isCatalogReady={isCatalogReady}
             isCatalogLoading={isCatalogLoading}
             onIdChange={(newId) => {

--- a/source/javascripts/core/api/ToolCatalogApi.mswMocks.ts
+++ b/source/javascripts/core/api/ToolCatalogApi.mswMocks.ts
@@ -1,0 +1,33 @@
+import { delay, http, HttpResponse } from 'msw';
+
+import { ToolCatalogEntry } from '../models/Tools';
+
+const DEFAULT_TOOLS: ToolCatalogEntry[] = [
+  { name: 'golang', aliases: ['go'] },
+  { name: 'nodejs', aliases: ['node'] },
+  { name: 'ruby', aliases: [] },
+  { name: 'python', aliases: [] },
+  { name: 'flutter', aliases: [] },
+];
+
+const CATALOG_URL = 'https://bitrise.io/stacks/tools/v1/catalog.json';
+
+function getToolCatalog() {
+  return http.get(CATALOG_URL, async () => {
+    await delay();
+    return HttpResponse.json({ tools: DEFAULT_TOOLS, timestamp: new Date().toISOString() });
+  });
+}
+
+function getToolCatalogPending() {
+  return http.get(CATALOG_URL, async () => delay('infinite'));
+}
+
+function getToolCatalogError() {
+  return http.get(CATALOG_URL, async () => {
+    await delay();
+    return HttpResponse.json(null, { status: 500 });
+  });
+}
+
+export default { getToolCatalog, getToolCatalogPending, getToolCatalogError };

--- a/source/javascripts/core/services/ToolsService.spec.ts
+++ b/source/javascripts/core/services/ToolsService.spec.ts
@@ -59,6 +59,91 @@ describe('ToolsService', () => {
     });
   });
 
+  describe('getKnownToolIds', () => {
+    it('returns an empty array when there is no catalog', () => {
+      expect(ToolsService.getKnownToolIds(undefined)).toEqual([]);
+    });
+
+    it('includes canonical names and aliases', () => {
+      const catalog = {
+        tools: [{ name: 'golang', aliases: ['go'] }, { name: 'nodejs', aliases: ['node'] }, { name: 'ruby' }],
+      };
+
+      expect(ToolsService.getKnownToolIds(catalog)).toEqual(['golang', 'go', 'nodejs', 'node', 'ruby']);
+    });
+  });
+
+  describe('isKnownToolId', () => {
+    const catalog = { tools: [{ name: 'golang', aliases: ['go'] }] };
+
+    it('matches a canonical name', () => {
+      expect(ToolsService.isKnownToolId(catalog, 'golang')).toBe(true);
+    });
+
+    it('matches an alias', () => {
+      expect(ToolsService.isKnownToolId(catalog, 'go')).toBe(true);
+    });
+
+    it('rejects an unknown id', () => {
+      expect(ToolsService.isKnownToolId(catalog, 'rustc')).toBe(false);
+    });
+
+    it('rejects when there is no catalog', () => {
+      expect(ToolsService.isKnownToolId(undefined, 'golang')).toBe(false);
+    });
+  });
+
+  describe('getToolIdOptions', () => {
+    const catalog = {
+      tools: [{ name: 'golang', aliases: ['go'] }, { name: 'nodejs', aliases: ['node'] }, { name: 'ruby' }],
+    };
+
+    it('lists each tool by its canonical name', () => {
+      expect(ToolsService.getToolIdOptions(catalog, '')).toEqual([
+        { value: 'golang', label: 'golang' },
+        { value: 'nodejs', label: 'nodejs' },
+        { value: 'ruby', label: 'ruby' },
+      ]);
+    });
+
+    it('shows the current alias instead of the canonical name for the matching tool', () => {
+      expect(ToolsService.getToolIdOptions(catalog, 'go')).toEqual([
+        { value: 'go', label: 'go' },
+        { value: 'nodejs', label: 'nodejs' },
+        { value: 'ruby', label: 'ruby' },
+      ]);
+    });
+
+    it('returns an empty array when there is no catalog', () => {
+      expect(ToolsService.getToolIdOptions(undefined, 'go')).toEqual([]);
+    });
+  });
+
+  describe('getAvailableToolIdOptions', () => {
+    const catalog = {
+      tools: [{ name: 'golang', aliases: ['go'] }, { name: 'nodejs', aliases: ['node'] }, { name: 'ruby' }],
+    };
+
+    it('excludes tool IDs already used by another row', () => {
+      expect(ToolsService.getAvailableToolIdOptions(catalog, 'go', ['go', 'ruby'])).toEqual([
+        { value: 'go', label: 'go' },
+        { value: 'nodejs', label: 'nodejs' },
+      ]);
+    });
+
+    it('keeps the current row value even if it is also in existingToolIds', () => {
+      expect(ToolsService.getAvailableToolIdOptions(catalog, 'ruby', ['ruby'])).toEqual([
+        { value: 'golang', label: 'golang' },
+        { value: 'nodejs', label: 'nodejs' },
+        { value: 'ruby', label: 'ruby' },
+      ]);
+    });
+
+    it('returns an empty array when there is no catalog', () => {
+      expect(ToolsService.getAvailableToolIdOptions(undefined, 'go', [])).toEqual([]);
+    });
+  });
+
   describe('validateToolId', () => {
     it('rejects empty and whitespace-only IDs', () => {
       expect(ToolsService.validateToolId('', '')).toBe('Tool ID is required');

--- a/source/javascripts/core/services/ToolsService.spec.ts
+++ b/source/javascripts/core/services/ToolsService.spec.ts
@@ -142,6 +142,20 @@ describe('ToolsService', () => {
     it('returns an empty array when there is no catalog', () => {
       expect(ToolsService.getAvailableToolIdOptions(undefined, 'go', [])).toEqual([]);
     });
+
+    it('excludes the canonical name when an alias is already pinned by another row', () => {
+      expect(ToolsService.getAvailableToolIdOptions(catalog, '', ['go'])).toEqual([
+        { value: 'nodejs', label: 'nodejs' },
+        { value: 'ruby', label: 'ruby' },
+      ]);
+    });
+
+    it('excludes an alias when the canonical name is already pinned by another row', () => {
+      expect(ToolsService.getAvailableToolIdOptions(catalog, '', ['golang'])).toEqual([
+        { value: 'nodejs', label: 'nodejs' },
+        { value: 'ruby', label: 'ruby' },
+      ]);
+    });
   });
 
   describe('validateToolId', () => {
@@ -160,6 +174,16 @@ describe('ToolsService', () => {
 
     it('accepts re-using the original ID when renaming', () => {
       expect(ToolsService.validateToolId('node', 'node', ['node', 'python'])).toBe(true);
+    });
+
+    it('rejects an alias when the canonical name is already pinned by another row', () => {
+      const catalog = { tools: [{ name: 'golang', aliases: ['go'] }] };
+      expect(ToolsService.validateToolId('go', '', ['golang'], catalog)).toBe('Tool ID must be unique');
+    });
+
+    it('rejects the canonical name when an alias is already pinned by another row', () => {
+      const catalog = { tools: [{ name: 'golang', aliases: ['go'] }] };
+      expect(ToolsService.validateToolId('golang', '', ['go'], catalog)).toBe('Tool ID must be unique');
     });
   });
 

--- a/source/javascripts/core/services/ToolsService.spec.ts
+++ b/source/javascripts/core/services/ToolsService.spec.ts
@@ -455,4 +455,52 @@ describe('ToolsService', () => {
       });
     });
   });
+
+  describe('renameTool', () => {
+    describe('root-level', () => {
+      it('renames the entry in place, keeping sibling order and values untouched', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          tools:
+            node: 22:latest
+            python: "3.13.4"
+        `);
+
+        ToolsService.renameTool('node', 'ruby', { type: 'root' });
+
+        expect(getYmlString()).toEqual(yaml`
+          tools:
+            ruby: 22:latest
+            python: "3.13.4"
+        `);
+      });
+    });
+
+    describe('workflow-level', () => {
+      it('renames the entry in place, keeping sibling order and values untouched', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          workflows:
+            primary:
+              tools:
+                node: 22:latest
+                python: "3.13.4"
+        `);
+
+        ToolsService.renameTool('node', 'ruby', { type: 'workflow', workflowId: 'primary' });
+
+        expect(getYmlString()).toEqual(yaml`
+          workflows:
+            primary:
+              tools:
+                ruby: 22:latest
+                python: "3.13.4"
+        `);
+      });
+
+      it('throws when workflow does not exist', () => {
+        updateBitriseYmlDocumentByString(yaml`format_version: '13'`);
+
+        expect(() => ToolsService.renameTool('node', 'ruby', { type: 'workflow', workflowId: 'missing' })).toThrow();
+      });
+    });
+  });
 });

--- a/source/javascripts/core/services/ToolsService.ts
+++ b/source/javascripts/core/services/ToolsService.ts
@@ -1,4 +1,4 @@
-import { ParsedToolVersion, VersionStrategy } from '../models/Tools';
+import { ParsedToolVersion, ToolCatalog, VersionStrategy } from '../models/Tools';
 import { bitriseYmlStore, updateBitriseYmlDocument } from '../stores/BitriseYmlStore';
 import YmlUtils from '../utils/YmlUtils';
 import WorkflowService from './WorkflowService';

--- a/source/javascripts/core/services/ToolsService.ts
+++ b/source/javascripts/core/services/ToolsService.ts
@@ -183,11 +183,22 @@ function deleteTool(toolId: string, scope: ToolScope) {
   });
 }
 
+function renameTool(oldId: string, newId: string, scope: ToolScope) {
+  updateBitriseYmlDocument(({ doc }) => {
+    validateScope(scope, doc);
+
+    const scopePath = getScopePath(scope);
+    YmlUtils.updateKeyByPath(doc, [...scopePath, 'tools', oldId], newId);
+    return doc;
+  });
+}
+
 export type { ToolScope };
 export default {
   parseToolVersion,
   setTool,
   deleteTool,
+  renameTool,
   getKnownToolIds,
   isKnownToolId,
   resolveToolName,

--- a/source/javascripts/core/services/ToolsService.ts
+++ b/source/javascripts/core/services/ToolsService.ts
@@ -70,6 +70,12 @@ function isKnownToolId(catalog: ToolCatalog | undefined, toolId: string): boolea
   return getKnownToolIds(catalog).includes(toolId);
 }
 
+/** Resolves a tool ID (canonical name or alias) to its catalog canonical name, or itself if unknown. */
+function resolveToolName(catalog: ToolCatalog | undefined, id: string): string {
+  const entry = catalog?.tools.find(({ name, aliases }) => name === id || (aliases ?? []).includes(id));
+  return entry?.name ?? id;
+}
+
 /**
  * Builds the tool-ID dropdown options: one per catalog tool, using its canonical name —
  * except the tool matching `toolId` (by name or alias), which is shown using that exact ID
@@ -90,16 +96,25 @@ function getAvailableToolIdOptions(
   toolId: string,
   existingToolIds: string[],
 ): { value: string; label: string }[] {
-  return getToolIdOptions(catalog, toolId).filter(({ value }) => value === toolId || !existingToolIds.includes(value));
+  const usedNames = new Set(existingToolIds.filter((id) => id !== toolId).map((id) => resolveToolName(catalog, id)));
+  return getToolIdOptions(catalog, toolId).filter(
+    ({ value }) => value === toolId || !usedNames.has(resolveToolName(catalog, value)),
+  );
 }
 
-function validateToolId(id: string, initialId: string, existingIds: string[] = []) {
+function validateToolId(id: string, initialId: string, existingIds: string[] = [], catalog?: ToolCatalog) {
   if (!id.trim()) {
     return 'Tool ID is required';
   }
 
-  if (id !== initialId && existingIds.includes(id)) {
-    return 'Tool ID must be unique';
+  if (id !== initialId) {
+    const name = resolveToolName(catalog, id);
+    const isDuplicate = existingIds.some(
+      (existingId) => existingId !== initialId && resolveToolName(catalog, existingId) === name,
+    );
+    if (isDuplicate) {
+      return 'Tool ID must be unique';
+    }
   }
 
   return true;
@@ -175,6 +190,7 @@ export default {
   deleteTool,
   getKnownToolIds,
   isKnownToolId,
+  resolveToolName,
   getToolIdOptions,
   getAvailableToolIdOptions,
   validateToolId,

--- a/source/javascripts/core/services/ToolsService.ts
+++ b/source/javascripts/core/services/ToolsService.ts
@@ -60,6 +60,39 @@ function getScopePath(scope: ToolScope): (string | number)[] {
   return scope.type === 'workflow' ? ['workflows', scope.workflowId] : [];
 }
 
+/** Every tool ID (canonical name or alias) the catalog recognizes. */
+function getKnownToolIds(catalog?: ToolCatalog): string[] {
+  return catalog?.tools.flatMap(({ name, aliases }) => [name, ...(aliases ?? [])]) ?? [];
+}
+
+/** Whether a tool ID matches a catalog entry, by canonical name or alias. */
+function isKnownToolId(catalog: ToolCatalog | undefined, toolId: string): boolean {
+  return getKnownToolIds(catalog).includes(toolId);
+}
+
+/**
+ * Builds the tool-ID dropdown options: one per catalog tool, using its canonical name —
+ * except the tool matching `toolId` (by name or alias), which is shown using that exact ID
+ * so the current selection stays visible without listing the same tool under two IDs.
+ */
+function getToolIdOptions(catalog: ToolCatalog | undefined, toolId: string): { value: string; label: string }[] {
+  return (catalog?.tools ?? []).map(({ name, aliases = [] }) => {
+    const value = toolId === name || aliases.includes(toolId) ? toolId : name;
+    return { value, label: value };
+  });
+}
+
+/**
+ * `getToolIdOptions`, minus tool IDs already used by another row (a row's own ID is always kept).
+ */
+function getAvailableToolIdOptions(
+  catalog: ToolCatalog | undefined,
+  toolId: string,
+  existingToolIds: string[],
+): { value: string; label: string }[] {
+  return getToolIdOptions(catalog, toolId).filter(({ value }) => value === toolId || !existingToolIds.includes(value));
+}
+
 function validateToolId(id: string, initialId: string, existingIds: string[] = []) {
   if (!id.trim()) {
     return 'Tool ID is required';
@@ -140,6 +173,10 @@ export default {
   parseToolVersion,
   setTool,
   deleteTool,
+  getKnownToolIds,
+  isKnownToolId,
+  getToolIdOptions,
+  getAvailableToolIdOptions,
   validateToolId,
   validateToolVersion,
 };


### PR DESCRIPTION
*PR status: Stacked on top of #1834 for now*

Scope of PR: just the tool ID selector. Tool version selection is going to be wired to the catalog API as well in a follow-up PR.

### Decisions

1. Tool catalog doesn't contain all working tools: the dropdown suggests known tools, but users can still type any custom tool ID (via "Other" or when the catalog is loading/errored).
2. Tool alias matching: catalog entries carry a canonical `name` plus `aliases` (e.g. `golang`/`go`), and the dropdown/known-ID logic treats them as equivalent while preserving whichever spelling the user already has in their YAML.
3. Custom tool input with know tool ID: when `Other` and the free-form input is active, typing a known tool ID turns the UI back to a dropdown with that known tool ID selected.