### PR TITLE
Clean up enable-wfe-step-bundles-when-to-run feature flag

### DIFF
--- a/source/javascripts/components/unified-editor/StepBundleConfig/tabs/StepBundleConfigurationTab.tsx
+++ b/source/javascripts/components/unified-editor/StepBundleConfig/tabs/StepBundleConfigurationTab.tsx
@@ -2,7 +2,6 @@ import { Box } from '@bitrise/bitkit';
 import { ChangeEventHandler } from 'react';
 
 import StepBundleService from '@/core/services/StepBundleService';
-import useFeatureFlag from '@/hooks/useFeatureFlag';
 
 import WhenToRunCard from '../../WhenToRunCard/WhenToRunCard';
 import { useStepBundleConfigContext } from '../StepBundleConfig.context';
@@ -10,8 +9,6 @@ import StepBundleConfigInputs from '../StepBundleConfigInputs';
 
 const StepBundleConfigurationTab = () => {
   const { stepBundle, stepBundleId, parentStepBundleId, parentWorkflowId, stepIndex } = useStepBundleConfigContext();
-
-  const isWhenToRunEnabled = useFeatureFlag('enable-wfe-step-bundles-when-to-run');
 
   const defaultValues = stepBundle?.defaultValues ?? {};
   const userValues = stepBundle?.userValues ?? {};
@@ -54,16 +51,14 @@ const StepBundleConfigurationTab = () => {
 
   return (
     <Box display="flex" flexDir="column" gap="12">
-      {isWhenToRunEnabled && (
-        <WhenToRunCard
-          defaultValuesRunIf={isDefaultMode ? undefined : defaultValues.run_if}
-          isAlwaysRun={mergedValues.is_always_run}
-          onIsAlwaysRunChange={onIsAlwaysRunChange}
-          onIsAlwaysRunReset={userValues.is_always_run !== undefined ? onIsAlwaysRunReset : undefined}
-          onRunIfChange={onRunIfChange}
-          userValuesRunIf={isDefaultMode ? defaultValues.run_if : userValues.run_if}
-        />
-      )}
+      <WhenToRunCard
+        defaultValuesRunIf={isDefaultMode ? undefined : defaultValues.run_if}
+        isAlwaysRun={mergedValues.is_always_run}
+        onIsAlwaysRunChange={onIsAlwaysRunChange}
+        onIsAlwaysRunReset={userValues.is_always_run !== undefined ? onIsAlwaysRunReset : undefined}
+        onRunIfChange={onRunIfChange}
+        userValuesRunIf={isDefaultMode ? defaultValues.run_if : userValues.run_if}
+      />
       <StepBundleConfigInputs />
     </Box>
   );

--- a/source/javascripts/hooks/useFeatureFlag.ts
+++ b/source/javascripts/hooks/useFeatureFlag.ts
@@ -1,7 +1,6 @@
 import GlobalProps from '@/core/utils/GlobalProps';
 
 const defaultValues = {
-  'enable-wfe-step-bundles-when-to-run': false,
   'enable-ci-config-expert-agent': false,
   'enable-branch-switching': false,
   'enable-wfe-tool-versions': false,

--- a/source/javascripts/pages/StepBundlesPage/StepBundlesPage.stories.tsx
+++ b/source/javascripts/pages/StepBundlesPage/StepBundlesPage.stories.tsx
@@ -1,14 +1,10 @@
 import { Box } from '@bitrise/bitkit';
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { set } from 'es-toolkit/compat';
 
 import StepBundlesPage from './StepBundlesPage';
 
 export default {
   component: StepBundlesPage,
-  beforeEach: () => {
-    set(window, 'parent.globalProps.featureFlags.account.enable-wfe-step-bundles-when-to-run', true);
-  },
   parameters: {
     layout: 'fullscreen',
   },

--- a/source/javascripts/pages/WorkflowsPage/WorkflowsPage.stories.tsx
+++ b/source/javascripts/pages/WorkflowsPage/WorkflowsPage.stories.tsx
@@ -69,9 +69,6 @@ export const CliMode: Story = {
 };
 
 export const WebsiteMode: Story = {
-  beforeEach: () => {
-    set(window, 'parent.globalProps.featureFlags.account.enable-wfe-step-bundles-when-to-run', true);
-  },
   parameters: {
     msw: {
       handlers: [


### PR DESCRIPTION
## Summary

The `enable-wfe-step-bundles-when-to-run` feature flag is fully rolled out, so this removes it and keeps the enabled path — the `WhenToRunCard` is now always rendered in the step bundle configuration tab.

## Changes

- `StepBundleConfigurationTab.tsx` — drop the `useFeatureFlag` gate; `WhenToRunCard` renders unconditionally.
- `useFeatureFlag.ts` — remove the flag from `defaultValues`.
- `StepBundlesPage.stories.tsx` / `WorkflowsPage.stories.tsx` — remove the `beforeEach` that forced the flag on (and the now-unused `set` import in the step bundles story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)