### PR TITLE
Update @bitrise/bitkit-v2 to 0.3.278

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bitrise/bitkit": "^13.358.0",
-        "@bitrise/bitkit-v2": "0.3.274",
+        "@bitrise/bitkit-v2": "0.3.278",
         "@bitrise/languageserver": "git+https://github.com/bitrise-io/bitrise-yml-language-server.git#833b15995769404349b63986ea779b60fccce531",
         "@dagrejs/dagre": "^3.0.0",
         "@datadog/browser-rum": "^7.3.0",
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/@bitrise/bitkit-v2": {
-      "version": "0.3.274",
-      "resolved": "https://registry.npmjs.org/@bitrise/bitkit-v2/-/bitkit-v2-0.3.274.tgz",
-      "integrity": "sha512-Q2D7f2T75G5sAARuP01rtxMlNF/okIHN0PDSWBEgGV2R97JabEQzVLVsN/HwLQhi055I8/Z5EwGGu8SrE7AsWw==",
+      "version": "0.3.278",
+      "resolved": "https://registry.npmjs.org/@bitrise/bitkit-v2/-/bitkit-v2-0.3.278.tgz",
+      "integrity": "sha512-JlD6Ei8d6tWguVQ0VzbUksyMzmjxGHLWbqRRLprpZmc9f6LWXyTf6oDttDew4Fi6xh7vCuJZj4DM66jhMIGApg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@bitrise/bitkit": "^13.358.0",
-    "@bitrise/bitkit-v2": "0.3.274",
+    "@bitrise/bitkit-v2": "0.3.278",
     "@bitrise/languageserver": "git+https://github.com/bitrise-io/bitrise-yml-language-server.git#833b15995769404349b63986ea779b60fccce531",
     "@dagrejs/dagre": "^3.0.0",
     "@datadog/browser-rum": "^7.3.0",


### PR DESCRIPTION
## Summary

Bumps `@bitrise/bitkit-v2` from `0.3.274` to `0.3.278`, pulling in the latest Bitkit v2 component library updates (including `BitkitTextInput` improvements) ahead of introducing the Bitkit TextInput in the Workflow Editor.

## Changes

- `package.json`: `@bitrise/bitkit-v2` `0.3.274` → `0.3.278`
- `package-lock.json`: updated to match
- Restored the trailing newline at the end of `package.json`

## Test plan

- [ ] `npm install` resolves cleanly
- [ ] `npm run build` succeeds
- [ ] `npm run lint` passes
- [ ] Existing Bitkit v2 components render without regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)