### PR TITLE
Modular YAML manual-review fixes 5: jump-to-def scoping, read-only CTAs, editable module default (BIVS-3664)

### DIFF
--- a/source/javascripts/hooks/useContainerWorkflowUsage.spec.tsx
+++ b/source/javascripts/hooks/useContainerWorkflowUsage.spec.tsx
@@ -6,7 +6,7 @@ import { renderHook } from '@testing-library/react';
 import { EntityIndex, TreeNode } from '@/core/models/Tree';
 import { initializeModularConfig } from '@/core/stores/BitriseYmlStore';
 
-import useContainerWorkflowUsage from './useContainerWorkflowUsage';
+import useContainerWorkflowUsage, { useContainerUsageByWorkflow } from './useContainerWorkflowUsage';
 
 const SHA = 'a1b2c3d4e5f6789012345678901234567890abcd';
 const EMPTY_INDEX: EntityIndex = { workflows: {}, pipelines: {}, stepBundles: {}, containers: {} };
@@ -103,5 +103,30 @@ describe('useContainerWorkflowUsage', () => {
         ['ec3', []],
       ]),
     );
+  });
+});
+
+describe('useContainerUsageByWorkflow', () => {
+  it('maps each using workflow to only the modules where it actually references the container', () => {
+    const root: TreeNode = {
+      nodeId: 'root',
+      path: 'bitrise.yml',
+      contents:
+        'containers:\n  ec1:\n    type: execution\n    image: ubuntu:22.04\n' +
+        // root's wf-x uses ec1.
+        'workflows:\n  wf-x:\n    steps:\n      - script:\n          execution_container: ec1\n',
+      source: null,
+      commitSha: SHA,
+      editable: true,
+      includes: [
+        // A same-named wf-x lives in the module but does NOT use ec1 — must not be listed.
+        leaf('n_mod', 'mod.yml', 'workflows:\n  wf-x:\n    steps:\n      - script: {}\n'),
+      ],
+    };
+    initializeModularConfig({ root, entityIndex: EMPTY_INDEX, branch: 'main', commitSha: SHA });
+
+    const { result } = renderHook(() => useContainerUsageByWorkflow('ec1'));
+
+    expect(result.current).toEqual(new Map([['wf-x', ['root']]]));
   });
 });

--- a/source/javascripts/hooks/useContainerWorkflowUsage.ts
+++ b/source/javascripts/hooks/useContainerWorkflowUsage.ts
@@ -34,4 +34,39 @@ function useContainerWorkflowUsage(id?: string) {
   });
 }
 
+/**
+ * For a container, the modules in which each using workflow actually references it — keyed by
+ * workflow id. Unlike jumping by the entity index (which lists every module that *defines* a
+ * same-named workflow), this points only at the files where that workflow really uses the container,
+ * so the usage jump-to-definition doesn't offer an unrelated same-named workflow from another module.
+ * Empty node-id lists in single-file mode (there are no modules to jump between).
+ */
+function useContainerUsageByWorkflow(containerId: string): Map<string, string[]> {
+  return useBitriseYmlStore((state) => {
+    const usage = new Map<string, string[]>();
+    const slices = state.tree ? Object.values(state.files) : [];
+
+    if (slices.length === 0) {
+      ContainerService.getWorkflowsUsingContainer(state.ymlDocument, containerId).forEach((workflowId) => {
+        if (!usage.has(workflowId)) {
+          usage.set(workflowId, []);
+        }
+      });
+      return usage;
+    }
+
+    slices.forEach((slice) => {
+      ContainerService.getWorkflowsUsingContainer(slice.ymlDocument, containerId).forEach((workflowId) => {
+        const nodeIds = usage.get(workflowId) ?? [];
+        if (!nodeIds.includes(slice.nodeId)) {
+          nodeIds.push(slice.nodeId);
+        }
+        usage.set(workflowId, nodeIds);
+      });
+    });
+    return usage;
+  });
+}
+
+export { useContainerUsageByWorkflow };
 export default useContainerWorkflowUsage;

--- a/source/javascripts/hooks/useTargetBasedTriggers.spec.tsx
+++ b/source/javascripts/hooks/useTargetBasedTriggers.spec.tsx
@@ -1,0 +1,50 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+
+import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { initializeModularConfig } from '@/core/stores/BitriseYmlStore';
+
+import { useTriggerDefiningNodeIds } from './useTargetBasedTriggers';
+
+const SHA = 'a1b2c3d4e5f6789012345678901234567890abcd';
+const EMPTY_INDEX: EntityIndex = { workflows: {}, pipelines: {}, stepBundles: {}, containers: {} };
+
+const leaf = (nodeId: string, path: string, contents: string): TreeNode => ({
+  nodeId,
+  path,
+  contents,
+  source: { path, repository: null, branch: null, tag: null, commit: null },
+  commitSha: SHA,
+  editable: true,
+  includes: [],
+});
+
+describe('useTriggerDefiningNodeIds', () => {
+  it('lists only the files that actually carry a trigger for a target, not every defining file', () => {
+    const root: TreeNode = {
+      nodeId: 'root',
+      path: 'bitrise.yml',
+      contents:
+        'workflows:\n' +
+        // wf-a is defined here but has no trigger — must NOT be attributed to root.
+        '  wf-a:\n    steps: []\n' +
+        // wf-b's only trigger lives here.
+        '  wf-b:\n    triggers:\n      push:\n        - branch: main\n',
+      source: null,
+      commitSha: SHA,
+      editable: true,
+      includes: [
+        // wf-a's trigger lives only in the module.
+        leaf('n_mod', 'mod.yml', 'workflows:\n  wf-a:\n    triggers:\n      push:\n        - branch: dev\n'),
+      ],
+    };
+    initializeModularConfig({ root, entityIndex: EMPTY_INDEX, branch: 'main', commitSha: SHA });
+
+    const { result } = renderHook(() => useTriggerDefiningNodeIds());
+
+    expect(result.current.get('workflows#wf-a')).toEqual(['n_mod']);
+    expect(result.current.get('workflows#wf-b')).toEqual(['root']);
+  });
+});

--- a/source/javascripts/hooks/useTargetBasedTriggers.ts
+++ b/source/javascripts/hooks/useTargetBasedTriggers.ts
@@ -1,3 +1,4 @@
+import { TriggersModel } from '@/core/models/BitriseYml';
 import { TargetBasedTrigger, TriggerSource } from '@/core/models/Trigger';
 import EntityIndexService from '@/core/services/EntityIndexService';
 import TreeService from '@/core/services/TreeService';
@@ -74,5 +75,37 @@ function useTriggersGroupedByFile(triggers: TargetBasedTrigger[]): TriggerFileGr
   });
 }
 
-export { useAllTargetBasedTriggers, useTriggersGroupedByFile };
+/**
+ * node_ids of the files that actually define a target-based trigger for each `${source}#${sourceId}`
+ * target. Unlike the entity index (which lists every file *defining* a workflow/pipeline), this only
+ * counts files whose `triggers` block yields at least one push/pull_request/tag trigger — so the
+ * merged view's jump-to-definition can point at the modules that really carry a trigger, not every
+ * module that happens to define the target. Empty in single-file mode.
+ */
+function useTriggerDefiningNodeIds(): Map<string, string[]> {
+  return useBitriseYmlStore((s) => {
+    const result = new Map<string, string[]>();
+    if (!s.tree) {
+      return result;
+    }
+    const sources: TriggerSource[] = ['workflows', 'pipelines'];
+    Object.values(s.files).forEach((slice) => {
+      const yml = slice.ymlDocument.toJSON() as Partial<
+        Record<TriggerSource, Record<string, { triggers?: TriggersModel }>>
+      > | null;
+      sources.forEach((source) => {
+        Object.entries(yml?.[source] ?? {}).forEach(([sourceId, target]) => {
+          const items = TriggerService.toTargetBasedTriggers(source, sourceId, target?.triggers);
+          if (items.push.length || items.pull_request.length || items.tag.length) {
+            const key = `${source}#${sourceId}`;
+            result.set(key, [...(result.get(key) ?? []), slice.nodeId]);
+          }
+        });
+      });
+    });
+    return result;
+  });
+}
+
+export { useAllTargetBasedTriggers, useTriggerDefiningNodeIds, useTriggersGroupedByFile };
 export default useTargetBasedTriggers;

--- a/source/javascripts/hooks/useTargetBasedTriggers.ts
+++ b/source/javascripts/hooks/useTargetBasedTriggers.ts
@@ -80,12 +80,13 @@ function useTriggersGroupedByFile(triggers: TargetBasedTrigger[]): TriggerFileGr
  * target. Unlike the entity index (which lists every file *defining* a workflow/pipeline), this only
  * counts files whose `triggers` block yields at least one push/pull_request/tag trigger — so the
  * merged view's jump-to-definition can point at the modules that really carry a trigger, not every
- * module that happens to define the target. Empty in single-file mode.
+ * module that happens to define the target. Empty in single-file mode. Only the merged view renders
+ * the jump, so callers pass `enabled = isMergedView` to skip the per-file scan everywhere else.
  */
-function useTriggerDefiningNodeIds(): Map<string, string[]> {
+function useTriggerDefiningNodeIds(enabled = true): Map<string, string[]> {
   return useBitriseYmlStore((s) => {
     const result = new Map<string, string[]>();
-    if (!s.tree) {
+    if (!enabled || !s.tree) {
       return result;
     }
     const sources: TriggerSource[] = ['workflows', 'pipelines'];
@@ -98,7 +99,12 @@ function useTriggerDefiningNodeIds(): Map<string, string[]> {
           const items = TriggerService.toTargetBasedTriggers(source, sourceId, target?.triggers);
           if (items.push.length || items.pull_request.length || items.tag.length) {
             const key = `${source}#${sourceId}`;
-            result.set(key, [...(result.get(key) ?? []), slice.nodeId]);
+            const nodeIds = result.get(key);
+            if (nodeIds) {
+              nodeIds.push(slice.nodeId);
+            } else {
+              result.set(key, [slice.nodeId]);
+            }
           }
         });
       });

--- a/source/javascripts/pages/ContainersPage/components/ContainerUsageDialog.tsx
+++ b/source/javascripts/pages/ContainersPage/components/ContainerUsageDialog.tsx
@@ -20,7 +20,7 @@ const ContainerUsageDialog = (props: ContainerUsageDialogProps) => {
           {selectedContainerId}
         </Text>{' '}
         is used in {workflowsUsedByContainer.length} Workflow{workflowsUsedByContainer.length !== 1 ? 's' : ''}.
-        <ContainerUsageTable workflows={workflowsUsedByContainer} />
+        <ContainerUsageTable containerId={selectedContainerId} workflows={workflowsUsedByContainer} />
         <Divider color="border/regular" />
       </DialogBody>
       <DialogFooter />

--- a/source/javascripts/pages/ContainersPage/components/ContainerUsageTable.tsx
+++ b/source/javascripts/pages/ContainersPage/components/ContainerUsageTable.tsx
@@ -2,19 +2,22 @@ import { Table, Tbody, Td, Text, Th, Thead, Tr } from '@bitrise/bitkit';
 import { BitkitControlButton, IconArrowNortheast } from '@bitrise/bitkit-v2';
 
 import CrossFileJumpButton from '@/components/JumpToDefinitionLink/CrossFileJumpButton';
+import { useContainerUsageByWorkflow } from '@/hooks/useContainerWorkflowUsage';
 import useNavigation from '@/hooks/useNavigation';
 import { useTree } from '@/hooks/useTree';
 
 type Props = {
+  containerId: string;
   workflows: string[];
 };
 
-const ContainerUsageTable = ({ workflows }: Props) => {
+const ContainerUsageTable = ({ containerId, workflows }: Props) => {
   const { replace } = useNavigation();
-  // Modular: usage can span modules, so jump to the using workflow's definition (a file picker when
-  // it's defined in several files) — that's where the container reference lives. Non-modular: plain
-  // navigation to the Workflows page.
+  // Modular: usage can span modules, so jump to the using workflow's definition — but only to the
+  // modules where that workflow actually references this container, not every module that happens to
+  // define a same-named workflow. Non-modular: plain navigation to the Workflows page.
   const isModular = Boolean(useTree());
+  const usageByWorkflow = useContainerUsageByWorkflow(containerId);
 
   return (
     <Table isFixed variant="borderless" mt="24">
@@ -32,7 +35,12 @@ const ContainerUsageTable = ({ workflows }: Props) => {
             </Td>
             <Td>
               {isModular ? (
-                <CrossFileJumpButton kind="workflows" id={workflowId} label="Go to Workflow" />
+                <CrossFileJumpButton
+                  kind="workflows"
+                  id={workflowId}
+                  nodeIds={usageByWorkflow.get(workflowId)}
+                  label="Go to Workflow"
+                />
               ) : (
                 <BitkitControlButton
                   size="xs"

--- a/source/javascripts/pages/ContainersPage/components/DeleteContainerDialog.tsx
+++ b/source/javascripts/pages/ContainersPage/components/DeleteContainerDialog.tsx
@@ -76,7 +76,7 @@ const DeleteContainerDialog = (props: DeleteContainerDialogProps) => {
         </Text>
         {type === 'definition' && workflowsUsedByContainer.length > 0 && (
           <>
-            <ContainerUsageTable workflows={workflowsUsedByContainer} />
+            <ContainerUsageTable containerId={selectedContainerId} workflows={workflowsUsedByContainer} />
             <Divider color="border/regular" />
           </>
         )}

--- a/source/javascripts/pages/PipelinesPage/components/EmptyStates/GraphPipelineCanvasEmptyState.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/EmptyStates/GraphPipelineCanvasEmptyState.tsx
@@ -1,10 +1,14 @@
 import { Button, EmptyState, EmptyStateProps } from '@bitrise/bitkit';
 
+import { useIsReadOnlyView } from '@/hooks/useTree';
+
 type Props = Omit<EmptyStateProps, 'title'> & {
   onAddWorkflow: VoidFunction;
 };
 
 const GraphPipelineCanvasEmptyState = ({ onAddWorkflow, ...props }: Props) => {
+  const isReadOnlyView = useIsReadOnlyView();
+
   return (
     <EmptyState
       {...props}
@@ -12,9 +16,12 @@ const GraphPipelineCanvasEmptyState = ({ onAddWorkflow, ...props }: Props) => {
       title="Welcome to the Pipeline canvas"
       description="Start building your graph by adding Workflow nodes to the canvas."
     >
-      <Button size="md" leftIconName="Plus" onClick={onAddWorkflow}>
-        Add Workflow
-      </Button>
+      {/* Read-only views (merged config, cross-repo/ref files) can't add workflows — show no CTA. */}
+      {!isReadOnlyView && (
+        <Button size="md" leftIconName="Plus" onClick={onAddWorkflow}>
+          Add Workflow
+        </Button>
+      )}
     </EmptyState>
   );
 };

--- a/source/javascripts/pages/StacksAndMachinesPage/tabs/DefaultTab.tsx
+++ b/source/javascripts/pages/StacksAndMachinesPage/tabs/DefaultTab.tsx
@@ -62,8 +62,10 @@ const DefaultTab = () => {
     );
   }
 
-  // Module tab that doesn't define the default: show the inherited default read-only, sourced from the
-  // defining module, with a jump to where it's actually defined.
+  // Module tab that doesn't define its own default: pre-fill the inherited value (sourced from the
+  // defining module) and show where it currently comes from + a jump, but keep the selectors editable
+  // so the module can set its own default — editing writes it to this file. (The merged/ghost views
+  // stay read-only via useIsReadOnlyView, independent of this.)
   if (isModular && !hasLocalDefault) {
     if (!inheritedDefault) {
       return (
@@ -80,7 +82,6 @@ const DefaultTab = () => {
         <DefaultStackAndMachine
           definingPath={inheritedDefault.definingPath}
           value={inheritedDefault.value}
-          readOnly
           selectsTrailing={<JumpToFileButton nodeId={inheritedDefault.nodeIds[0]} />}
         />
       </TabContainer>

--- a/source/javascripts/pages/TriggersPage/components/TargetBasedTriggers/TargetBasedTriggers.tsx
+++ b/source/javascripts/pages/TriggersPage/components/TargetBasedTriggers/TargetBasedTriggers.tsx
@@ -22,7 +22,11 @@ import TriggerConditions from '@/components/unified-editor/Triggers/TriggerCondi
 import { trackEditTrigger, trackTriggerEnabledToggled } from '@/core/analytics/TriggerAnalytics';
 import { TargetBasedTrigger, TriggerSource, TriggerType, TYPE_MAP } from '@/core/models/Trigger';
 import TriggerService from '@/core/services/TriggerService';
-import { useAllTargetBasedTriggers, useTriggersGroupedByFile } from '@/hooks/useTargetBasedTriggers';
+import {
+  useAllTargetBasedTriggers,
+  useTriggerDefiningNodeIds,
+  useTriggersGroupedByFile,
+} from '@/hooks/useTargetBasedTriggers';
 import { useIsMergedConfigSelected, useIsReadOnlyView } from '@/hooks/useTree';
 
 import AddTriggerButton from './AddTriggerButton';
@@ -77,6 +81,9 @@ const TargetBasedTriggers = () => {
   // Merged (read-only) view: group by the source file of each trigger's target.
   // Only group on the merged tab; elsewhere there's nothing to group, so skip the work entirely.
   const fileGroups = useTriggersGroupedByFile(isMergedView ? sortedFilteredTriggers : []);
+  // The files that actually carry a trigger for each target — so the jump-to-definition lists only
+  // the modules where a trigger really lives, not every module that defines the workflow/pipeline.
+  const triggerNodesBySource = useTriggerDefiningNodeIds();
 
   const handleOpenDialog = (trigger: TargetBasedTrigger) => {
     setEditedItem(trigger);
@@ -144,8 +151,11 @@ const TargetBasedTriggers = () => {
             </Checkbox>
             {isReadOnlyView ? (
               // Read-only (merged/ghost): no edit/delete CTAs (BIVS-3721). When the target is grouped,
-              // collapse to a jump-to-definition arrow; otherwise show nothing.
-              useJump && <CrossFileJumpButton kind={source} id={sourceId} />
+              // collapse to a jump-to-definition arrow over the modules that actually carry a trigger;
+              // otherwise show nothing.
+              useJump && (
+                <CrossFileJumpButton kind={source} id={sourceId} nodeIds={triggerNodesBySource.get(trigger.source)} />
+              )
             ) : (
               <>
                 <IconButton

--- a/source/javascripts/pages/TriggersPage/components/TargetBasedTriggers/TargetBasedTriggers.tsx
+++ b/source/javascripts/pages/TriggersPage/components/TargetBasedTriggers/TargetBasedTriggers.tsx
@@ -83,7 +83,8 @@ const TargetBasedTriggers = () => {
   const fileGroups = useTriggersGroupedByFile(isMergedView ? sortedFilteredTriggers : []);
   // The files that actually carry a trigger for each target — so the jump-to-definition lists only
   // the modules where a trigger really lives, not every module that defines the workflow/pipeline.
-  const triggerNodesBySource = useTriggerDefiningNodeIds();
+  // Only the merged view renders the jump, so skip the per-file scan otherwise.
+  const triggerNodesBySource = useTriggerDefiningNodeIds(isMergedView);
 
   const handleOpenDialog = (trigger: TargetBasedTrigger) => {
     setEditedItem(trigger);


### PR DESCRIPTION
Follow-up review fixes for the modular-YAML manual review ([BIVS-3664](https://bitrise.atlassian.net/browse/BIVS-3664)), on top of #1835 (already merged). Small, self-contained fixes surfaced while re-testing the merged work.

## Read-only / merged views
- **[BIVS-3721](https://bitrise.atlassian.net/browse/BIVS-3721)** — an empty graph pipeline showed the "Add Workflow" empty-state CTA even on the merged/ghost read-only views. Gate it on `useIsReadOnlyView` (hidden, not disabled); the informational title + description stay.

## Jump-to-definition scoping
- **[BIVS-3706](https://bitrise.atlassian.net/browse/BIVS-3706)** — on the merged Triggers page, a target's jump-to-definition listed every module that *defines* the workflow/pipeline, even ones with no trigger on it. New `useTriggerDefiningNodeIds` scopes the jump to the modules that actually carry a push/pull_request/tag trigger for that target.
- **[BIVS-3708](https://bitrise.atlassian.net/browse/BIVS-3708)** — the container usage table's "Go to Workflow" jump listed every module defining a same-named workflow, even ones that don't use the container. New `useContainerUsageByWorkflow` maps each using workflow to only the files where it actually references the container, and scopes the jump to those.

## Stacks & Machines
- **[BIVS-3714](https://bitrise.atlassian.net/browse/BIVS-3714)** — a module that doesn't define its own default stack/machine had its selectors force-disabled. Drop the forced read-only so an (editable) module tab can set its own default (editing writes it to that file); the value is still pre-filled from the inherited default with its "Defined in …" provenance + jump. Merged/ghost views stay read-only via `useIsReadOnlyView`.

## Tests
- Added `useTargetBasedTriggers.spec` (trigger-defining nodes) and a `useContainerUsageByWorkflow` case in `useContainerWorkflowUsage.spec`. Full unit suite green (1381).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[BIVS-3664]: https://bitrise.atlassian.net/browse/BIVS-3664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BIVS-3721]: https://bitrise.atlassian.net/browse/BIVS-3721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BIVS-3706]: https://bitrise.atlassian.net/browse/BIVS-3706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BIVS-3708]: https://bitrise.atlassian.net/browse/BIVS-3708?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BIVS-3714]: https://bitrise.atlassian.net/browse/BIVS-3714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ