### PR TITLE
Exact tool version dropdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bitrise/bitkit": "^13.359.0",
-        "@bitrise/bitkit-v2": "0.3.278",
+        "@bitrise/bitkit-v2": "0.3.306",
         "@bitrise/languageserver": "github:bitrise-io/bitrise-yml-language-server#d28eca30c83c37e69ad4093681e0152160a8fbb0",
         "@dagrejs/dagre": "^3.0.0",
         "@datadog/browser-rum": "^7.4.0",
@@ -1087,20 +1087,20 @@
       }
     },
     "node_modules/@bitrise/bitkit-v2": {
-      "version": "0.3.278",
-      "resolved": "https://registry.npmjs.org/@bitrise/bitkit-v2/-/bitkit-v2-0.3.278.tgz",
-      "integrity": "sha512-JlD6Ei8d6tWguVQ0VzbUksyMzmjxGHLWbqRRLprpZmc9f6LWXyTf6oDttDew4Fi6xh7vCuJZj4DM66jhMIGApg==",
+      "version": "0.3.306",
+      "resolved": "https://registry.npmjs.org/@bitrise/bitkit-v2/-/bitkit-v2-0.3.306.tgz",
+      "integrity": "sha512-nqZWZvdCS9SdkPbb9a5T7l7zRwHzFz33oV9iLd+RmMQugNyrgKkBouS54wsu6KlwflbRp83xtsFYcZpNcmA9gw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@fontsource-variable/figtree": "^5.2.10",
-        "@fontsource-variable/source-code-pro": "^5.2.7",
-        "es-toolkit": "^1.47.1",
+        "@fontsource-variable/figtree": "^5.3.0",
+        "@fontsource-variable/source-code-pro": "^5.3.0",
+        "es-toolkit": "^1.49.0",
         "react-markdown": "^10.1.0"
       },
       "peerDependencies": {
-        "@chakra-ui/cli": "3.36.0",
-        "@chakra-ui/react": "3.36.0",
+        "@chakra-ui/cli": "3.36.1",
+        "@chakra-ui/react": "3.36.1",
         "@emotion/react": "11.14.0",
         "@emotion/styled": "11.14.1",
         "react": ">=18",
@@ -1156,16 +1156,16 @@
       "license": "MIT"
     },
     "node_modules/@chakra-ui/cli": {
-      "version": "3.36.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/cli/-/cli-3.36.0.tgz",
-      "integrity": "sha512-I41JaWdjaJFJGO5XIdQbol30YFcaWfjz/TTEECYSvyew7KN0aqw9niTBvO1DdBvXn+3g1ycWJ9Sjg3NzDW8S9A==",
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/cli/-/cli-3.36.1.tgz",
+      "integrity": "sha512-W+/rnHgBkJgDmMsQ52gr/+eYgddQFOq/DZXZx9uBLtoX+/NLJG0eTXUcDudR1rkysx+ryeTN4d/vOLxIKPzlOw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@babel/core": "^7.26.0",
         "@babel/parser": "^7.26.0",
         "@babel/plugin-transform-typescript": "^7.26.0",
-        "@clack/prompts": "1.0.1",
+        "@clack/prompts": "1.5.1",
         "@pandacss/is-valid-prop": "1.11.1",
         "@types/babel__core": "^7.20.5",
         "@types/cli-table": "^0.3.4",
@@ -1176,16 +1176,15 @@
         "commander": "14.0.3",
         "debug": "^4.4.3",
         "dotenv": "^17.2.3",
-        "esbuild": "^0.27.3",
-        "globby": "16.1.1",
-        "https-proxy-agent": "^7.0.6",
+        "esbuild": "^0.28.0",
+        "get-tsconfig": "^4.14.0",
+        "globby": "16.2.0",
         "look-it-up": "2.1.0",
-        "node-fetch": "3.3.2",
         "package-manager-detector": "1.6.0",
-        "prettier": "3.8.1",
+        "prettier": "3.8.3",
         "recast": "^0.23.0",
         "scule": "1.3.0",
-        "tsconfck": "^3.1.6",
+        "undici": "^7.24.5",
         "zod": "^3.25.76"
       },
       "bin": {
@@ -1193,448 +1192,6 @@
       },
       "peerDependencies": {
         "@chakra-ui/react": ">=3.0.0-next.0"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
-      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/android-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
-      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/android-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
-      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/android-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
-      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
-      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
-      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
-      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/linux-arm": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
-      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
-      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
-      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
-      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
-      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
-      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
-      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
-      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/linux-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
-      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
-      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
-      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
-      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
-      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
-      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
-      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/@esbuild/win32-x64": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
-      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/@chakra-ui/cli/node_modules/chokidar": {
@@ -1676,71 +1233,10 @@
         "url": "https://dotenvx.com"
       }
     },
-    "node_modules/@chakra-ui/cli/node_modules/esbuild": {
-      "version": "0.27.7",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
-      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.7",
-        "@esbuild/android-arm": "0.27.7",
-        "@esbuild/android-arm64": "0.27.7",
-        "@esbuild/android-x64": "0.27.7",
-        "@esbuild/darwin-arm64": "0.27.7",
-        "@esbuild/darwin-x64": "0.27.7",
-        "@esbuild/freebsd-arm64": "0.27.7",
-        "@esbuild/freebsd-x64": "0.27.7",
-        "@esbuild/linux-arm": "0.27.7",
-        "@esbuild/linux-arm64": "0.27.7",
-        "@esbuild/linux-ia32": "0.27.7",
-        "@esbuild/linux-loong64": "0.27.7",
-        "@esbuild/linux-mips64el": "0.27.7",
-        "@esbuild/linux-ppc64": "0.27.7",
-        "@esbuild/linux-riscv64": "0.27.7",
-        "@esbuild/linux-s390x": "0.27.7",
-        "@esbuild/linux-x64": "0.27.7",
-        "@esbuild/netbsd-arm64": "0.27.7",
-        "@esbuild/netbsd-x64": "0.27.7",
-        "@esbuild/openbsd-arm64": "0.27.7",
-        "@esbuild/openbsd-x64": "0.27.7",
-        "@esbuild/openharmony-arm64": "0.27.7",
-        "@esbuild/sunos-x64": "0.27.7",
-        "@esbuild/win32-arm64": "0.27.7",
-        "@esbuild/win32-ia32": "0.27.7",
-        "@esbuild/win32-x64": "0.27.7"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/node-fetch": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
-      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/@chakra-ui/cli/node_modules/prettier": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-      "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -1765,28 +1261,6 @@
       "funding": {
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@chakra-ui/cli/node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "deprecated": "unmaintained",
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
       }
     },
     "node_modules/@chakra-ui/cli/node_modules/zod": {
@@ -1815,9 +1289,9 @@
       }
     },
     "node_modules/@chakra-ui/react": {
-      "version": "3.36.0",
-      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-3.36.0.tgz",
-      "integrity": "sha512-6AxUbJsC6yyTzPeYL8sxyAL07lflT0NA+S6tcPzEuwdMux+benRMFOpPktnkifWKl/Vq/JD7fhxDyMuDQ4M0gA==",
+      "version": "3.36.1",
+      "resolved": "https://registry.npmjs.org/@chakra-ui/react/-/react-3.36.1.tgz",
+      "integrity": "sha512-8uPVBdkw9CfwDQSGGmNqx8jLygUanV9virh2dwbj3x02Cu5bmw12ZCRdD/RZ+00+KrklJZlVnmG20y7PwLhyqg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1887,26 +1361,33 @@
       }
     },
     "node_modules/@clack/core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-WKeyK3NOBwDOzagPR5H08rFk9D/WuN705yEbuZvKqlkmoLM2woKtXb10OO2k1NoSU4SFG947i2/SCYh+2u5e4g==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@clack/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-FILJa1gGKEFTGZAJE9RpVhrjKz3c3h4ar60dSv6cGuDqufQ84YEIS3GAGvZiN+H6yaLbbvTFNejjCC4tXpZEuw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "picocolors": "^1.0.0",
+        "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@clack/prompts": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.0.1.tgz",
-      "integrity": "sha512-/42G73JkuYdyWZ6m8d/CJtBrGl1Hegyc7Fy78m5Ob+jF85TOUmLR5XLce/U3LxYAw0kJ8CT5aI99RIvPHcGp/Q==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@clack/prompts/-/prompts-1.5.1.tgz",
+      "integrity": "sha512-zccHj2z2oCCO4yrDiRSlFOxWerGqRiysP7a5jPK6uoI9URKAquwY42Dd/iUP8JWHxEzdRe4TlbvZCo8z1/mhrw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@clack/core": "1.0.1",
-        "picocolors": "^1.0.0",
+        "@clack/core": "1.4.1",
+        "fast-string-width": "^3.0.2",
+        "fast-wrap-ansi": "^0.2.0",
         "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 20.12.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -2509,7 +1990,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2526,7 +2006,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2543,7 +2022,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2560,7 +2038,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2577,7 +2054,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2594,7 +2070,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2611,7 +2086,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2628,7 +2102,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2645,7 +2118,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2662,7 +2134,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2679,7 +2150,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2696,7 +2166,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2713,7 +2182,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2730,7 +2198,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2747,7 +2214,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2764,7 +2230,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2781,7 +2246,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2798,7 +2262,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2815,7 +2278,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2832,7 +2294,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2849,7 +2310,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2866,7 +2326,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2883,7 +2342,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2900,7 +2358,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2917,7 +2374,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2934,7 +2390,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3234,18 +2689,18 @@
       "license": "MIT"
     },
     "node_modules/@fontsource-variable/figtree": {
-      "version": "5.2.10",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/figtree/-/figtree-5.2.10.tgz",
-      "integrity": "sha512-a5Gumbpy3mdd+Yg31g6Qb7CmjYbrfyutJa3bWfP5q8A4GclIOwX7mI+ZuSHsJnw/mHvW6r9oh1AHJcJTIxK4JA==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/figtree/-/figtree-5.3.0.tgz",
+      "integrity": "sha512-VRVodD7OiG7apQwE8/2fMjaqpY/a0qRJqL5HtYj8CKIVps+9amaFcdfKmDIf7iqYQx6iPLlArVXAfKeIZmVcNQ==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@fontsource-variable/source-code-pro": {
-      "version": "5.2.7",
-      "resolved": "https://registry.npmjs.org/@fontsource-variable/source-code-pro/-/source-code-pro-5.2.7.tgz",
-      "integrity": "sha512-kZ0VNwnhvSA7vu5MaiO52eicQ4zC+k+8HBLZb+1js0MK/RngLy25NEUFB1y/AKd0ZMwru88T433QBcFf9m/huw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/source-code-pro/-/source-code-pro-5.3.0.tgz",
+      "integrity": "sha512-CxzAbqtNrQ6EQXTb9ovRZIRiOhFPcBQhNKla58K5UV6IMoL/ROkWxXDSBOa/frIDLuV4B5PLHI4R1e9SWVinYg==",
       "license": "OFL-1.1",
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
@@ -10380,6 +9835,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -13114,16 +12570,6 @@
       "dev": true,
       "license": "BSD-2-Clause"
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -13839,7 +13285,6 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -14830,14 +14275,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/fast-string-truncated-width/-/fast-string-truncated-width-3.0.3.tgz",
       "integrity": "sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-string-width": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/fast-string-width/-/fast-string-width-3.0.2.tgz",
       "integrity": "sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
@@ -14847,7 +14290,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/fast-wrap-ansi/-/fast-wrap-ansi-0.2.0.tgz",
       "integrity": "sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-string-width": "^3.0.2"
@@ -14893,9 +14335,9 @@
       }
     },
     "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "license": "ISC",
       "peer": true,
       "dependencies": {
@@ -14938,40 +14380,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
-    "node_modules/fetch-blob/node_modules/web-streams-polyfill": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
-      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/file-entry-cache": {
@@ -15127,19 +14535,6 @@
       },
       "engines": {
         "node": ">= 12.20"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/framer-motion": {
@@ -15442,7 +14837,6 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
       "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -15528,9 +14922,9 @@
       }
     },
     "node_modules/globby": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-16.1.1.tgz",
-      "integrity": "sha512-dW7vl+yiAJSp6aCekaVnVJxurRv7DCOLyXqEG3RYMYUg7AuJ2jCqPkZTA8ooqC2vtnkaMcV5WfFBMuEnTu1OQg==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -15948,6 +15342,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -21239,6 +20634,7 @@
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -23007,7 +22403,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
       "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -24773,7 +24168,6 @@
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
       "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@bitrise/bitkit": "^13.359.0",
-    "@bitrise/bitkit-v2": "0.3.278",
+    "@bitrise/bitkit-v2": "0.3.306",
     "@bitrise/languageserver": "github:bitrise-io/bitrise-yml-language-server#d28eca30c83c37e69ad4093681e0152160a8fbb0",
     "@dagrejs/dagre": "^3.0.0",
     "@datadog/browser-rum": "^7.4.0",

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -193,13 +193,6 @@ const ToolRow = ({
                 applies whenever one is possible at all. */}
             {isExactKnownTool ? (
               <BitkitCombobox
-                // BitkitCombobox snapshots `items` on mount and never resets its own filtered
-                // list. Picking an item narrows that list, and it stays narrowed even after
-                // the popover closes and reopens. The key forces a fresh mount whenever the
-                // list should actually change: another tool's versions, the async load
-                // completing, or the version itself changing (without these, the dropdown
-                // would reopen showing only the previously picked item).
-                key={`${canonicalToolId}:${toolVersions ? 'loaded' : 'pending'}:${version}`}
                 size="lg"
                 placeholder="Select"
                 emptyLabel="No matches"

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -132,9 +132,19 @@ const ToolRow = ({
   // (bare `latest`/`installed`). Only a hint — saving is not blocked.
   const versionError = strategy === 'exact' && version.trim() === '' ? 'Tool version is required' : undefined;
   const displayedVersionError = versionTouched ? versionError : undefined;
-  const displayedVersionWarning = isVersionMissingFromCatalog
+  // Shown next to a value the combobox is displaying as already set, where it may be a
+  // stale or mistaken leftover. Typed values get a different, less alarming message below.
+  const catalogMismatchWarning = isVersionMissingFromCatalog
     ? `${version} isn't in the list of installable versions`
     : undefined;
+  // Shown wherever the user is actually typing a version by hand (via "Other", or because
+  // no suggestions exist at all), where it is an expected, deliberate choice rather than
+  // a possible mistake. Skipped for a custom tool, whose own explanatory paragraph below
+  // already covers this.
+  const customVersionWarning =
+    !showCustomInput && isVersionMissingFromCatalog
+      ? `${version} is a custom version and might not work properly`
+      : undefined;
 
   const dropdownItems = [
     ...dropdownOptions,
@@ -232,7 +242,7 @@ const ToolRow = ({
                   onOpenChange: (details) => !details.open && !manualVersion && setVersionTouched(true),
                 }}
                 errorText={manualVersion ? undefined : displayedVersionError}
-                warningText={manualVersion ? undefined : displayedVersionWarning}
+                warningText={manualVersion ? undefined : catalogMismatchWarning}
                 value={manualVersion ? OTHER_VERSION_VALUE : version || undefined}
                 onValueChange={(newVersion) => {
                   if (newVersion === OTHER_VERSION_VALUE) {
@@ -248,7 +258,7 @@ const ToolRow = ({
                 size="lg"
                 placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
                 errorText={displayedVersionError}
-                warningText={displayedVersionWarning}
+                warningText={customVersionWarning}
                 inputProps={{
                   value: version,
                   onChange: (e) => onVersionChange(e.target.value),
@@ -261,7 +271,7 @@ const ToolRow = ({
                 size="lg"
                 placeholder="e.g. 24.7.0"
                 errorText={displayedVersionError}
-                warningText={displayedVersionWarning}
+                warningText={customVersionWarning}
                 inputProps={{
                   value: version,
                   autoFocus: true,

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -43,8 +43,6 @@ type ToolRowProps = {
   catalog: ToolCatalog | undefined;
   allowUnset?: boolean;
   isCatalogLoading: boolean;
-  /** Bumped by the parent when the user moves on (adds another row) — reveals this row's incomplete-version error. */
-  versionTouchSignal?: number;
   onIdChange: (newId: string) => void;
   onStrategyChange: (strategy: VersionStrategy, version: string) => void;
   onVersionChange: (version: string) => void;
@@ -59,7 +57,6 @@ const ToolRow = ({
   catalog,
   allowUnset,
   isCatalogLoading,
-  versionTouchSignal = 0,
   onIdChange,
   onStrategyChange,
   onVersionChange,
@@ -87,15 +84,6 @@ const ToolRow = ({
   // user has visited and left the field. A config that is already invalid when the row
   // mounts (hand-edited YAML) is flagged immediately — no interaction should be needed.
   const [versionTouched, setVersionTouched] = useState(() => strategy === 'exact' && version === '');
-
-  // Signals seen before this row mounted don't count — only a bump while the row is
-  // alive means the user moved on from it. State is adjusted during render (with the
-  // previous-value guard) instead of in an effect, per React's derived-state guidance.
-  const [seenTouchSignal, setSeenTouchSignal] = useState(versionTouchSignal);
-  if (versionTouchSignal !== seenTouchSignal) {
-    setSeenTouchSignal(versionTouchSignal);
-    setVersionTouched(true);
-  }
 
   const isCatalogReady = !!catalog;
   const isToolIdKnown = ToolsService.isKnownToolId(catalog, toolId);
@@ -135,7 +123,7 @@ const ToolRow = ({
   // Shown next to a value the combobox is displaying as already set, where it may be a
   // stale or mistaken leftover. Typed values get a different, less alarming message below.
   const catalogMismatchWarning = isVersionMissingFromCatalog
-    ? `${version} isn't in the list of installable versions`
+    ? `${version} is not a known version, use at your own risk`
     : undefined;
   // Shown wherever the user is actually typing a version by hand (via "Other", or because
   // no suggestions exist at all), where it is an expected, deliberate choice rather than

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -102,28 +102,15 @@ const ToolRow = ({
   const isVersionMissingFromCatalog =
     !!toolVersions && version !== '' && !ToolsService.isVersionInCatalog(toolVersions, version);
 
-  // BitkitCombobox has no built in way to commit a typed value that does not match a real
-  // item, so it only makes sense while there is at least one real option to pick (loading
-  // counts, it will resolve into one or the other shortly). With nothing to pick, a plain
-  // text input lets the user actually type and save a version.
-  const useVersionDropdown = isExactKnownTool && (isVersionsLoading || versionOptions.length > 0);
-
   // An exact strategy needs a concrete version; prefix strategies are valid without one
-  // (bare `latest`/`installed`). Only a hint — saving is not blocked.
+  // (bare `latest`/`installed`).
   const versionError = strategy === 'exact' && version.trim() === '' ? 'Tool version is required' : undefined;
   const displayedVersionError = versionTouched ? versionError : undefined;
-  // Shown next to a value the combobox is displaying as already set, where it may be a
-  // stale or mistaken leftover. Typed values get a different, less alarming message below.
+  // The version the combobox is displaying as already set isn't among the catalog's
+  // options — likely a stale or mistaken leftover (e.g. from hand-edited YAML).
   const catalogMismatchWarning = isVersionMissingFromCatalog
     ? `${version} is not a known version, use at your own risk`
     : undefined;
-  // Shown wherever the user is typing a version by hand because no suggestions exist,
-  // where it is an expected, deliberate choice rather than a possible mistake. Skipped
-  // for a custom tool, whose own explanatory paragraph below already covers this.
-  const customVersionWarning =
-    !showCustomInput && isVersionMissingFromCatalog
-      ? `${version} is a custom version and might not work properly`
-      : undefined;
 
   const dropdownItems = [
     ...dropdownOptions,
@@ -156,7 +143,7 @@ const ToolRow = ({
   };
 
   const handleStrategyChange = (newStrategy: VersionStrategy) => {
-    // The strategy switch empties the field on the user's behalf — give them a chance
+    // The strategy switch empties the field on the user's behalf -> give them a chance
     // to fill it before flagging it.
     setVersionTouched(false);
     const newVersion = ToolsService.nextVersionOnStrategyChange(strategy, newStrategy, version);
@@ -200,7 +187,9 @@ const ToolRow = ({
 
         {strategy !== 'unset' && (
           <Box display="flex" flexDirection="column" gap="8" width={VERSION_COLUMN_WIDTH} flexShrink="0">
-            {useVersionDropdown ? (
+            {/* A catalog-known tool always has at least one version to offer, so the dropdown
+                applies whenever one is possible at all. */}
+            {isExactKnownTool ? (
               <BitkitCombobox
                 // BitkitCombobox snapshots `items` on mount and never resets its own filtered
                 // list. Picking an item narrows that list, and it stays narrowed even after
@@ -228,7 +217,6 @@ const ToolRow = ({
                 size="lg"
                 placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
                 errorText={displayedVersionError}
-                warningText={customVersionWarning}
                 inputProps={{
                   value: version,
                   onChange: (e) => onVersionChange(e.target.value),
@@ -245,7 +233,7 @@ const ToolRow = ({
       {isExactKnownTool && isVersionsError && (
         <BitkitAlert
           variant="critical"
-          messageText={`Couldn't load the available versions of ${toolId}. You can still type the version by hand.`}
+          messageText={`Couldn't load the available versions of ${toolId}. Try reloading, or set the version directly in the YAML editor.`}
         />
       )}
 

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -148,6 +148,10 @@ const ToolRow = ({
     // it before flagging it.
     if (newVersion !== version) {
       setVersionTouched(false);
+    } else if (newStrategy === 'exact' && newVersion.trim() === '') {
+      // The field was already empty, so it won't hit the branch above -> flag it immediately
+      // since it's already invalid.
+      setVersionTouched(true);
     }
     onStrategyChange(newStrategy, newVersion);
   };

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -1,4 +1,6 @@
 import {
+  BitkitAlert,
+  BitkitCombobox,
   BitkitIconButton,
   BitkitLink,
   BitkitSelect,
@@ -14,6 +16,8 @@ import { useController, useForm } from 'react-hook-form';
 
 import { ToolCatalog, VersionStrategy } from '@/core/models/Tools';
 import ToolsService from '@/core/services/ToolsService';
+import useNavigation from '@/hooks/useNavigation';
+import { useToolVersions } from '@/hooks/useTools';
 
 type ToolRowFormValues = {
   toolId: string;
@@ -28,6 +32,9 @@ const STRATEGY_LABELS: Record<VersionStrategy, string> = {
 
 const OTHER_VALUE = '__other__';
 
+const TOOL_ID_COLUMN_WIDTH = rem(160);
+const VERSION_COLUMN_WIDTH = rem(240);
+
 type ToolRowProps = {
   toolId: string;
   strategy: VersionStrategy;
@@ -36,6 +43,8 @@ type ToolRowProps = {
   catalog: ToolCatalog | undefined;
   allowUnset?: boolean;
   isCatalogLoading: boolean;
+  /** Bumped by the parent when the user moves on (adds another row) — reveals this row's incomplete-version error. */
+  versionTouchSignal?: number;
   onIdChange: (newId: string) => void;
   onStrategyChange: (strategy: VersionStrategy, version: string) => void;
   onVersionChange: (version: string) => void;
@@ -50,11 +59,14 @@ const ToolRow = ({
   catalog,
   allowUnset,
   isCatalogLoading,
+  versionTouchSignal = 0,
   onIdChange,
   onStrategyChange,
   onVersionChange,
   onRemove,
 }: ToolRowProps) => {
+  const { replace } = useNavigation();
+
   // Whether the user has explicitly picked "Other" from the dropdown.
   const [manualOther, setManualOther] = useState(false);
 
@@ -69,6 +81,20 @@ const ToolRow = ({
     rules: { validate: (value) => ToolsService.validateToolId(value.trim(), toolId, existingToolIds, catalog) },
   });
 
+  // Validate eagerly, display lazily: the required-version error only shows once the
+  // user has visited and left the field. A config that is already invalid when the row
+  // mounts (hand-edited YAML) is flagged immediately — no interaction should be needed.
+  const [versionTouched, setVersionTouched] = useState(() => strategy === 'exact' && version === '');
+
+  // Signals seen before this row mounted don't count — only a bump while the row is
+  // alive means the user moved on from it. State is adjusted during render (with the
+  // previous-value guard) instead of in an effect, per React's derived-state guidance.
+  const [seenTouchSignal, setSeenTouchSignal] = useState(versionTouchSignal);
+  if (versionTouchSignal !== seenTouchSignal) {
+    setSeenTouchSignal(versionTouchSignal);
+    setVersionTouched(true);
+  }
+
   const isCatalogReady = !!catalog;
   const isToolIdKnown = ToolsService.isKnownToolId(catalog, toolId);
   const dropdownOptions = ToolsService.getAvailableToolIdOptions(catalog, toolId, existingToolIds);
@@ -76,6 +102,23 @@ const ToolRow = ({
   // Only treat a tool as custom once the catalog has actually resolved. While it's
   // still loading, or if it failed to load, an unknown toolId isn't proof it's custom.
   const showCustomInput = manualOther || (isCatalogReady && toolId !== '' && !isToolIdKnown);
+
+  const useVersionDropdown = strategy === 'exact' && isToolIdKnown && !showCustomInput;
+  const canonicalToolId = ToolsService.resolveToolName(catalog, toolId);
+  const {
+    data: toolVersions,
+    isLoading: isVersionsLoading,
+    isError: isVersionsError,
+  } = useToolVersions(canonicalToolId, useVersionDropdown);
+
+  const versionOptions = ToolsService.getVersionOptions(toolVersions, version);
+  const isVersionMissingFromCatalog =
+    !!toolVersions && version !== '' && !ToolsService.isVersionInCatalog(toolVersions, version);
+
+  // An exact strategy needs a concrete version; prefix strategies are valid without one
+  // (bare `latest`/`installed`). Only a hint — saving is not blocked.
+  const exactVersionValidation = strategy === 'exact' ? ToolsService.validateToolVersion(version) : true;
+  const versionError = exactVersionValidation === true ? undefined : exactVersionValidation;
 
   const dropdownItems = [
     ...dropdownOptions,
@@ -108,15 +151,17 @@ const ToolRow = ({
   };
 
   const handleStrategyChange = (newStrategy: VersionStrategy) => {
-    const isPrefix = (s: VersionStrategy) => s === 'latest-released' || s === 'latest-installed';
-    const newVersion = isPrefix(strategy) && isPrefix(newStrategy) ? version : '';
+    // The strategy switch empties the field on the user's behalf — give them a chance
+    // to fill it before flagging it.
+    setVersionTouched(false);
+    const newVersion = ToolsService.nextVersionOnStrategyChange(strategy, newStrategy, version);
     onStrategyChange(newStrategy, newVersion);
   };
 
   return (
     <Box display="flex" flexDirection="column" gap="8">
       <Box display="flex" alignItems="flex-start" gap="12">
-        <Box display="flex" flexDirection="column" gap="8" width={rem(160)} flexShrink="0">
+        <Box display="flex" flexDirection="column" gap="8" width={TOOL_ID_COLUMN_WIDTH} flexShrink="0">
           <BitkitSelect
             size="lg"
             placeholder="Select one"
@@ -148,21 +193,60 @@ const ToolRow = ({
           onValueChange={(v) => handleStrategyChange(v as VersionStrategy)}
         />
 
-        {strategy !== 'unset' && (
-          <BitkitTextInput
-            size="lg"
-            width={rem(130)}
-            flexShrink="0"
-            placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
-            inputProps={{
-              value: version,
-              onChange: (e) => onVersionChange(e.target.value),
-            }}
-          />
-        )}
+        {strategy !== 'unset' &&
+          (useVersionDropdown ? (
+            <BitkitCombobox
+              // BitkitCombobox snapshots `items` on mount and ignores later changes, so the
+              // key forces a remount whenever the list actually differs: another tool's
+              // versions, the async load completing, or the injected not-in-catalog option
+              // (getVersionOptions adds the current version (even unavailable version) when
+              // the catalog lacks it, and that entry must drop out once a real catalog version
+              // is picked).
+              key={`${canonicalToolId}:${toolVersions ? 'loaded' : 'pending'}:${isVersionMissingFromCatalog ? version : ''}`}
+              size="lg"
+              width={VERSION_COLUMN_WIDTH}
+              flexShrink="0"
+              placeholder="Select"
+              emptyLabel="No matches"
+              items={versionOptions}
+              isLoading={isVersionsLoading}
+              state={isVersionsError ? 'disabled' : undefined}
+              // Closing the menu without picking counts as visiting and leaving the field.
+              comboboxProps={{ onOpenChange: (details) => !details.open && setVersionTouched(true) }}
+              // The disabled fetch-error state has its own alert; a required-error on an
+              // uneditable field would just add noise.
+              errorText={versionTouched && !isVersionsError ? versionError : undefined}
+              warningText={
+                isVersionMissingFromCatalog ? `${version} isn't in the list of installable versions` : undefined
+              }
+              value={version || undefined}
+              onValueChange={(newVersion) => onVersionChange(newVersion ?? '')}
+            />
+          ) : (
+            <BitkitTextInput
+              size="lg"
+              width={VERSION_COLUMN_WIDTH}
+              flexShrink="0"
+              placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
+              errorText={versionTouched ? versionError : undefined}
+              inputProps={{
+                value: version,
+                onChange: (e) => onVersionChange(e.target.value),
+                onBlur: () => setVersionTouched(true),
+              }}
+            />
+          ))}
 
         <BitkitIconButton variant="tertiary" icon={IconMinusCircle} label="Remove tool" onClick={onRemove} />
       </Box>
+
+      {useVersionDropdown && isVersionsError && (
+        <BitkitAlert
+          variant="critical"
+          messageText={`Couldn't load the available versions of ${toolId}. You can still set the version manually in the YAML editor.`}
+          action={{ label: 'Open YAML editor', onClick: () => replace('/yml') }}
+        />
+      )}
 
       {showCustomInput && (
         <Text textStyle="body/md/regular">

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -78,7 +78,7 @@ const ToolRow = ({
   // Validate eagerly, display lazily: the required-version error only shows once the
   // user has visited and left the field. A config that is already invalid when the row
   // mounts (hand-edited YAML) is flagged immediately — no interaction should be needed.
-  const [versionTouched, setVersionTouched] = useState(() => strategy === 'exact' && version === '');
+  const [versionTouched, setVersionTouched] = useState(() => strategy === 'exact' && version.trim() === '');
 
   const isCatalogReady = !!catalog;
   const isToolIdKnown = ToolsService.isKnownToolId(catalog, toolId);
@@ -143,10 +143,12 @@ const ToolRow = ({
   };
 
   const handleStrategyChange = (newStrategy: VersionStrategy) => {
-    // The strategy switch empties the field on the user's behalf -> give them a chance
-    // to fill it before flagging it.
-    setVersionTouched(false);
     const newVersion = ToolsService.nextVersionOnStrategyChange(strategy, newStrategy, version);
+    // The strategy switch empties the field on the user's behalf -> give them a chance to fill
+    // it before flagging it.
+    if (newVersion !== version) {
+      setVersionTouched(false);
+    }
     onStrategyChange(newStrategy, newVersion);
   };
 
@@ -203,9 +205,14 @@ const ToolRow = ({
                 emptyLabel="No matches"
                 items={versionOptions}
                 isLoading={isVersionsLoading}
+                // With no version list there is nothing to pick from. Read-only rather than
+                // disabled, so the configured version stays legible and reachable by keyboard
+                // and screen readers; the alert below points to the YAML editor instead.
+                state={isVersionsError ? 'readOnly' : undefined}
                 // Closing the menu without picking counts as visiting and leaving the field.
                 comboboxProps={{
                   onOpenChange: (details) => !details.open && setVersionTouched(true),
+                  onBlur: () => setVersionTouched(true),
                 }}
                 errorText={displayedVersionError}
                 warningText={catalogMismatchWarning}

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -30,7 +30,6 @@ const STRATEGY_LABELS: Record<VersionStrategy, string> = {
 };
 
 const OTHER_VALUE = '__other__';
-const OTHER_VERSION_VALUE = '__other_version__';
 
 const TOOL_ID_COLUMN_WIDTH = rem(160);
 const VERSION_COLUMN_WIDTH = rem(240);
@@ -76,10 +75,6 @@ const ToolRow = ({
     rules: { validate: (value) => ToolsService.validateToolId(value.trim(), toolId, existingToolIds, catalog) },
   });
 
-  // Whether the user has explicitly picked "Other" from the version dropdown, to enter a
-  // version that is not in the catalog even though real options exist.
-  const [manualVersion, setManualVersion] = useState(false);
-
   // Validate eagerly, display lazily: the required-version error only shows once the
   // user has visited and left the field. A config that is already invalid when the row
   // mounts (hand-edited YAML) is flagged immediately — no interaction should be needed.
@@ -101,10 +96,7 @@ const ToolRow = ({
     isError: isVersionsError,
   } = useToolVersions(canonicalToolId, isExactKnownTool);
 
-  // While the user is entering a custom version via "Other", the current value is left
-  // unpinned: otherwise it would also appear as a separate, seemingly catalog backed
-  // entry, and reselecting it would count as picking a real option and exit "Other".
-  const versionOptions = ToolsService.getVersionOptions(toolVersions, manualVersion ? '' : version);
+  const versionOptions = ToolsService.getVersionOptions(toolVersions, version);
   // toolVersions is undefined both while loading and after a failed fetch, so comparing
   // against it before real data arrives would flash a false "missing" warning.
   const isVersionMissingFromCatalog =
@@ -125,10 +117,9 @@ const ToolRow = ({
   const catalogMismatchWarning = isVersionMissingFromCatalog
     ? `${version} is not a known version, use at your own risk`
     : undefined;
-  // Shown wherever the user is actually typing a version by hand (via "Other", or because
-  // no suggestions exist at all), where it is an expected, deliberate choice rather than
-  // a possible mistake. Skipped for a custom tool, whose own explanatory paragraph below
-  // already covers this.
+  // Shown wherever the user is typing a version by hand because no suggestions exist,
+  // where it is an expected, deliberate choice rather than a possible mistake. Skipped
+  // for a custom tool, whose own explanatory paragraph below already covers this.
   const customVersionWarning =
     !showCustomInput && isVersionMissingFromCatalog
       ? `${version} is a custom version and might not work properly`
@@ -168,7 +159,6 @@ const ToolRow = ({
     // The strategy switch empties the field on the user's behalf — give them a chance
     // to fill it before flagging it.
     setVersionTouched(false);
-    setManualVersion(false);
     const newVersion = ToolsService.nextVersionOnStrategyChange(strategy, newStrategy, version);
     onStrategyChange(newStrategy, newVersion);
   };
@@ -216,30 +206,22 @@ const ToolRow = ({
                 // list. Picking an item narrows that list, and it stays narrowed even after
                 // the popover closes and reopens. The key forces a fresh mount whenever the
                 // list should actually change: another tool's versions, the async load
-                // completing, the version itself changing, or switching in or out of manual
-                // entry (without these, the dropdown would reopen showing only the
-                // previously picked item).
-                key={`${canonicalToolId}:${toolVersions ? 'loaded' : 'pending'}:${version}:${manualVersion}`}
+                // completing, or the version itself changing (without these, the dropdown
+                // would reopen showing only the previously picked item).
+                key={`${canonicalToolId}:${toolVersions ? 'loaded' : 'pending'}:${version}`}
                 size="lg"
                 placeholder="Select"
                 emptyLabel="No matches"
-                items={[...versionOptions, { value: OTHER_VERSION_VALUE, label: 'Other' }]}
+                items={versionOptions}
                 isLoading={isVersionsLoading}
                 // Closing the menu without picking counts as visiting and leaving the field.
                 comboboxProps={{
-                  onOpenChange: (details) => !details.open && !manualVersion && setVersionTouched(true),
+                  onOpenChange: (details) => !details.open && setVersionTouched(true),
                 }}
-                errorText={manualVersion ? undefined : displayedVersionError}
-                warningText={manualVersion ? undefined : catalogMismatchWarning}
-                value={manualVersion ? OTHER_VERSION_VALUE : version || undefined}
-                onValueChange={(newVersion) => {
-                  if (newVersion === OTHER_VERSION_VALUE) {
-                    setManualVersion(true);
-                    return;
-                  }
-                  setManualVersion(false);
-                  onVersionChange(newVersion ?? '');
-                }}
+                errorText={displayedVersionError}
+                warningText={catalogMismatchWarning}
+                value={version || undefined}
+                onValueChange={(newVersion) => onVersionChange(newVersion ?? '')}
               />
             ) : (
               <BitkitTextInput
@@ -249,20 +231,6 @@ const ToolRow = ({
                 warningText={customVersionWarning}
                 inputProps={{
                   value: version,
-                  onChange: (e) => onVersionChange(e.target.value),
-                  onBlur: () => setVersionTouched(true),
-                }}
-              />
-            )}
-            {useVersionDropdown && manualVersion && (
-              <BitkitTextInput
-                size="lg"
-                placeholder="e.g. 24.7.0"
-                errorText={displayedVersionError}
-                warningText={customVersionWarning}
-                inputProps={{
-                  value: version,
-                  autoFocus: true,
                   onChange: (e) => onVersionChange(e.target.value),
                   onBlur: () => setVersionTouched(true),
                 }}

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -18,6 +18,7 @@ import { ToolCatalog, VersionStrategy } from '@/core/models/Tools';
 import ToolsService from '@/core/services/ToolsService';
 import useNavigation from '@/hooks/useNavigation';
 import { useToolVersions } from '@/hooks/useTools';
+import { paths } from '@/routes';
 
 type ToolRowFormValues = {
   toolId: string;
@@ -112,13 +113,11 @@ const ToolRow = ({
   } = useToolVersions(canonicalToolId, useVersionDropdown);
 
   const versionOptions = ToolsService.getVersionOptions(toolVersions, version);
-  const isVersionMissingFromCatalog =
-    !!toolVersions && version !== '' && !ToolsService.isVersionInCatalog(toolVersions, version);
+  const isVersionMissingFromCatalog = version !== '' && !ToolsService.isVersionInCatalog(toolVersions, version);
 
   // An exact strategy needs a concrete version; prefix strategies are valid without one
   // (bare `latest`/`installed`). Only a hint — saving is not blocked.
-  const exactVersionValidation = strategy === 'exact' ? ToolsService.validateToolVersion(version) : true;
-  const versionError = exactVersionValidation === true ? undefined : exactVersionValidation;
+  const versionError = strategy === 'exact' && version.trim() === '' ? 'Tool version is required' : undefined;
 
   const dropdownItems = [
     ...dropdownOptions,
@@ -244,7 +243,7 @@ const ToolRow = ({
         <BitkitAlert
           variant="critical"
           messageText={`Couldn't load the available versions of ${toolId}. You can still set the version manually in the YAML editor.`}
-          action={{ label: 'Open YAML editor', onClick: () => replace('/yml') }}
+          action={{ label: 'Open YAML editor', onClick: () => replace(paths.yml) }}
         />
       )}
 

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -113,7 +113,10 @@ const ToolRow = ({
     isError: isVersionsError,
   } = useToolVersions(canonicalToolId, isExactKnownTool);
 
-  const versionOptions = ToolsService.getVersionOptions(toolVersions, version);
+  // While the user is entering a custom version via "Other", the current value is left
+  // unpinned: otherwise it would also appear as a separate, seemingly catalog backed
+  // entry, and reselecting it would count as picking a real option and exit "Other".
+  const versionOptions = ToolsService.getVersionOptions(toolVersions, manualVersion ? '' : version);
   // toolVersions is undefined both while loading and after a failed fetch, so comparing
   // against it before real data arrives would flash a false "missing" warning.
   const isVersionMissingFromCatalog =

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -30,6 +30,7 @@ const STRATEGY_LABELS: Record<VersionStrategy, string> = {
 };
 
 const OTHER_VALUE = '__other__';
+const OTHER_VERSION_VALUE = '__other_version__';
 
 const TOOL_ID_COLUMN_WIDTH = rem(160);
 const VERSION_COLUMN_WIDTH = rem(240);
@@ -64,7 +65,7 @@ const ToolRow = ({
   onVersionChange,
   onRemove,
 }: ToolRowProps) => {
-  // Whether the user has explicitly picked "Other" from the dropdown.
+  // Whether the user has explicitly picked "Other" from the tool ID dropdown.
   const [manualOther, setManualOther] = useState(false);
 
   const { control } = useForm<ToolRowFormValues>({
@@ -77,6 +78,10 @@ const ToolRow = ({
     name: 'toolId',
     rules: { validate: (value) => ToolsService.validateToolId(value.trim(), toolId, existingToolIds, catalog) },
   });
+
+  // Whether the user has explicitly picked "Other" from the version dropdown, to enter a
+  // version that is not in the catalog even though real options exist.
+  const [manualVersion, setManualVersion] = useState(false);
 
   // Validate eagerly, display lazily: the required-version error only shows once the
   // user has visited and left the field. A config that is already invalid when the row
@@ -100,13 +105,13 @@ const ToolRow = ({
   // still loading, or if it failed to load, an unknown toolId isn't proof it's custom.
   const showCustomInput = manualOther || (isCatalogReady && toolId !== '' && !isToolIdKnown);
 
-  const useVersionDropdown = strategy === 'exact' && isToolIdKnown && !showCustomInput;
+  const isExactKnownTool = strategy === 'exact' && isToolIdKnown && !showCustomInput;
   const canonicalToolId = ToolsService.resolveToolName(catalog, toolId);
   const {
     data: toolVersions,
     isLoading: isVersionsLoading,
     isError: isVersionsError,
-  } = useToolVersions(canonicalToolId, useVersionDropdown);
+  } = useToolVersions(canonicalToolId, isExactKnownTool);
 
   const versionOptions = ToolsService.getVersionOptions(toolVersions, version);
   // toolVersions is undefined both while loading and after a failed fetch, so comparing
@@ -114,9 +119,19 @@ const ToolRow = ({
   const isVersionMissingFromCatalog =
     !!toolVersions && version !== '' && !ToolsService.isVersionInCatalog(toolVersions, version);
 
+  // BitkitCombobox has no built in way to commit a typed value that does not match a real
+  // item, so it only makes sense while there is at least one real option to pick (loading
+  // counts, it will resolve into one or the other shortly). With nothing to pick, a plain
+  // text input lets the user actually type and save a version.
+  const useVersionDropdown = isExactKnownTool && (isVersionsLoading || versionOptions.length > 0);
+
   // An exact strategy needs a concrete version; prefix strategies are valid without one
   // (bare `latest`/`installed`). Only a hint — saving is not blocked.
   const versionError = strategy === 'exact' && version.trim() === '' ? 'Tool version is required' : undefined;
+  const displayedVersionError = versionTouched ? versionError : undefined;
+  const displayedVersionWarning = isVersionMissingFromCatalog
+    ? `${version} isn't in the list of installable versions`
+    : undefined;
 
   const dropdownItems = [
     ...dropdownOptions,
@@ -152,6 +167,7 @@ const ToolRow = ({
     // The strategy switch empties the field on the user's behalf — give them a chance
     // to fill it before flagging it.
     setVersionTouched(false);
+    setManualVersion(false);
     const newVersion = ToolsService.nextVersionOnStrategyChange(strategy, newStrategy, version);
     onStrategyChange(newStrategy, newVersion);
   };
@@ -191,55 +207,73 @@ const ToolRow = ({
           onValueChange={(v) => handleStrategyChange(v as VersionStrategy)}
         />
 
-        {strategy !== 'unset' &&
-          (useVersionDropdown ? (
-            <BitkitCombobox
-              // BitkitCombobox snapshots `items` on mount and never resets its own filtered
-              // list. Picking an item narrows that list, and it stays narrowed even after
-              // the popover closes and reopens. The key forces a fresh mount whenever the
-              // list should actually change: another tool's versions, the async load
-              // completing, or the version itself changing (without `version` here, the
-              // dropdown would reopen showing only the previously picked item).
-              key={`${canonicalToolId}:${toolVersions ? 'loaded' : 'pending'}:${version}`}
-              size="lg"
-              width={VERSION_COLUMN_WIDTH}
-              flexShrink="0"
-              placeholder="Select or type a version"
-              emptyLabel={isVersionsError ? "Couldn't load suggestions" : 'No matches'}
-              items={versionOptions}
-              isLoading={isVersionsLoading}
-              // Suggestions may be missing (fetch failed) or simply empty (no catalog entries yet).
-              // Either way the user can type the version by hand instead of picking from the list.
-              comboboxProps={{
-                allowCustomValue: true,
-                onOpenChange: (details) => !details.open && setVersionTouched(true),
-              }}
-              errorText={versionTouched ? versionError : undefined}
-              warningText={
-                isVersionMissingFromCatalog ? `${version} isn't in the list of installable versions` : undefined
-              }
-              value={version || undefined}
-              onValueChange={(newVersion) => onVersionChange(newVersion ?? '')}
-            />
-          ) : (
-            <BitkitTextInput
-              size="lg"
-              width={VERSION_COLUMN_WIDTH}
-              flexShrink="0"
-              placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
-              errorText={versionTouched ? versionError : undefined}
-              inputProps={{
-                value: version,
-                onChange: (e) => onVersionChange(e.target.value),
-                onBlur: () => setVersionTouched(true),
-              }}
-            />
-          ))}
+        {strategy !== 'unset' && (
+          <Box display="flex" flexDirection="column" gap="8" width={VERSION_COLUMN_WIDTH} flexShrink="0">
+            {useVersionDropdown ? (
+              <BitkitCombobox
+                // BitkitCombobox snapshots `items` on mount and never resets its own filtered
+                // list. Picking an item narrows that list, and it stays narrowed even after
+                // the popover closes and reopens. The key forces a fresh mount whenever the
+                // list should actually change: another tool's versions, the async load
+                // completing, the version itself changing, or switching in or out of manual
+                // entry (without these, the dropdown would reopen showing only the
+                // previously picked item).
+                key={`${canonicalToolId}:${toolVersions ? 'loaded' : 'pending'}:${version}:${manualVersion}`}
+                size="lg"
+                placeholder="Select"
+                emptyLabel="No matches"
+                items={[...versionOptions, { value: OTHER_VERSION_VALUE, label: 'Other' }]}
+                isLoading={isVersionsLoading}
+                // Closing the menu without picking counts as visiting and leaving the field.
+                comboboxProps={{
+                  onOpenChange: (details) => !details.open && !manualVersion && setVersionTouched(true),
+                }}
+                errorText={manualVersion ? undefined : displayedVersionError}
+                warningText={manualVersion ? undefined : displayedVersionWarning}
+                value={manualVersion ? OTHER_VERSION_VALUE : version || undefined}
+                onValueChange={(newVersion) => {
+                  if (newVersion === OTHER_VERSION_VALUE) {
+                    setManualVersion(true);
+                    return;
+                  }
+                  setManualVersion(false);
+                  onVersionChange(newVersion ?? '');
+                }}
+              />
+            ) : (
+              <BitkitTextInput
+                size="lg"
+                placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
+                errorText={displayedVersionError}
+                warningText={displayedVersionWarning}
+                inputProps={{
+                  value: version,
+                  onChange: (e) => onVersionChange(e.target.value),
+                  onBlur: () => setVersionTouched(true),
+                }}
+              />
+            )}
+            {useVersionDropdown && manualVersion && (
+              <BitkitTextInput
+                size="lg"
+                placeholder="e.g. 24.7.0"
+                errorText={displayedVersionError}
+                warningText={displayedVersionWarning}
+                inputProps={{
+                  value: version,
+                  autoFocus: true,
+                  onChange: (e) => onVersionChange(e.target.value),
+                  onBlur: () => setVersionTouched(true),
+                }}
+              />
+            )}
+          </Box>
+        )}
 
         <BitkitIconButton variant="tertiary" icon={IconMinusCircle} label="Remove tool" onClick={onRemove} />
       </Box>
 
-      {useVersionDropdown && isVersionsError && (
+      {isExactKnownTool && isVersionsError && (
         <BitkitAlert
           variant="critical"
           messageText={`Couldn't load the available versions of ${toolId}. You can still type the version by hand.`}

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -16,9 +16,7 @@ import { useController, useForm } from 'react-hook-form';
 
 import { ToolCatalog, VersionStrategy } from '@/core/models/Tools';
 import ToolsService from '@/core/services/ToolsService';
-import useNavigation from '@/hooks/useNavigation';
 import { useToolVersions } from '@/hooks/useTools';
-import { paths } from '@/routes';
 
 type ToolRowFormValues = {
   toolId: string;
@@ -66,8 +64,6 @@ const ToolRow = ({
   onVersionChange,
   onRemove,
 }: ToolRowProps) => {
-  const { replace } = useNavigation();
-
   // Whether the user has explicitly picked "Other" from the dropdown.
   const [manualOther, setManualOther] = useState(false);
 
@@ -113,7 +109,10 @@ const ToolRow = ({
   } = useToolVersions(canonicalToolId, useVersionDropdown);
 
   const versionOptions = ToolsService.getVersionOptions(toolVersions, version);
-  const isVersionMissingFromCatalog = version !== '' && !ToolsService.isVersionInCatalog(toolVersions, version);
+  // toolVersions is undefined both while loading and after a failed fetch, so comparing
+  // against it before real data arrives would flash a false "missing" warning.
+  const isVersionMissingFromCatalog =
+    !!toolVersions && version !== '' && !ToolsService.isVersionInCatalog(toolVersions, version);
 
   // An exact strategy needs a concrete version; prefix strategies are valid without one
   // (bare `latest`/`installed`). Only a hint — saving is not blocked.
@@ -195,26 +194,27 @@ const ToolRow = ({
         {strategy !== 'unset' &&
           (useVersionDropdown ? (
             <BitkitCombobox
-              // BitkitCombobox snapshots `items` on mount and ignores later changes, so the
-              // key forces a remount whenever the list actually differs: another tool's
-              // versions, the async load completing, or the injected not-in-catalog option
-              // (getVersionOptions adds the current version (even unavailable version) when
-              // the catalog lacks it, and that entry must drop out once a real catalog version
-              // is picked).
-              key={`${canonicalToolId}:${toolVersions ? 'loaded' : 'pending'}:${isVersionMissingFromCatalog ? version : ''}`}
+              // BitkitCombobox snapshots `items` on mount and never resets its own filtered
+              // list. Picking an item narrows that list, and it stays narrowed even after
+              // the popover closes and reopens. The key forces a fresh mount whenever the
+              // list should actually change: another tool's versions, the async load
+              // completing, or the version itself changing (without `version` here, the
+              // dropdown would reopen showing only the previously picked item).
+              key={`${canonicalToolId}:${toolVersions ? 'loaded' : 'pending'}:${version}`}
               size="lg"
               width={VERSION_COLUMN_WIDTH}
               flexShrink="0"
-              placeholder="Select"
-              emptyLabel="No matches"
+              placeholder="Select or type a version"
+              emptyLabel={isVersionsError ? "Couldn't load suggestions" : 'No matches'}
               items={versionOptions}
               isLoading={isVersionsLoading}
-              state={isVersionsError ? 'disabled' : undefined}
-              // Closing the menu without picking counts as visiting and leaving the field.
-              comboboxProps={{ onOpenChange: (details) => !details.open && setVersionTouched(true) }}
-              // The disabled fetch-error state has its own alert; a required-error on an
-              // uneditable field would just add noise.
-              errorText={versionTouched && !isVersionsError ? versionError : undefined}
+              // Suggestions may be missing (fetch failed) or simply empty (no catalog entries yet).
+              // Either way the user can type the version by hand instead of picking from the list.
+              comboboxProps={{
+                allowCustomValue: true,
+                onOpenChange: (details) => !details.open && setVersionTouched(true),
+              }}
+              errorText={versionTouched ? versionError : undefined}
               warningText={
                 isVersionMissingFromCatalog ? `${version} isn't in the list of installable versions` : undefined
               }
@@ -242,8 +242,7 @@ const ToolRow = ({
       {useVersionDropdown && isVersionsError && (
         <BitkitAlert
           variant="critical"
-          messageText={`Couldn't load the available versions of ${toolId}. You can still set the version manually in the YAML editor.`}
-          action={{ label: 'Open YAML editor', onClick: () => replace(paths.yml) }}
+          messageText={`Couldn't load the available versions of ${toolId}. You can still type the version by hand.`}
         />
       )}
 

--- a/source/javascripts/components/ToolVersions/ToolVersions.stories.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.stories.tsx
@@ -19,7 +19,7 @@ const meta: Meta<typeof ToolVersions> = {
   ],
   parameters: {
     msw: {
-      handlers: [ToolCatalogApiMocks.getToolCatalog()],
+      handlers: [ToolCatalogApiMocks.getToolCatalog(), ToolCatalogApiMocks.getToolVersions()],
     },
   },
 };
@@ -97,5 +97,47 @@ export const CustomTool: Story = {
       });
       return { yml, ymlDocument: YmlUtils.toDoc(stringify(yml)) };
     })(),
+  },
+};
+
+export const VersionNotInCatalog: Story = {
+  parameters: {
+    bitriseYmlStore: (() => {
+      const yml = set({ ...TEST_BITRISE_YML }, 'tools', {
+        nodejs: '999.999.999',
+      });
+      return { yml, ymlDocument: YmlUtils.toDoc(stringify(yml)) };
+    })(),
+  },
+};
+
+export const EmptyExactVersion: Story = {
+  parameters: {
+    bitriseYmlStore: (() => {
+      const yml = set({ ...TEST_BITRISE_YML }, 'tools', {
+        nodejs: '',
+      });
+      return { yml, ymlDocument: YmlUtils.toDoc(stringify(yml)) };
+    })(),
+  },
+};
+
+export const VersionsLoading: Story = {
+  ...RootScope,
+  parameters: {
+    ...RootScope.parameters,
+    msw: {
+      handlers: [ToolCatalogApiMocks.getToolCatalog(), ToolCatalogApiMocks.getToolVersionsPending()],
+    },
+  },
+};
+
+export const VersionsError: Story = {
+  ...RootScope,
+  parameters: {
+    ...RootScope.parameters,
+    msw: {
+      handlers: [ToolCatalogApiMocks.getToolCatalog(), ToolCatalogApiMocks.getToolVersionsError()],
+    },
   },
 };

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -32,9 +32,6 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
   const [hasPendingRow, setHasPendingRow] = useState(false);
   const [pendingStrategy, setPendingStrategy] = useState<VersionStrategy>('latest-released');
   const [pendingVersion, setPendingVersion] = useState('');
-  // Bumped when a new row is added: moving on to another row counts as leaving the
-  // existing ones, so their incomplete-version errors become visible.
-  const [versionTouchSignal, setVersionTouchSignal] = useState(0);
 
   const allowUnset = scope.type === 'workflow';
   const existingToolIds = Object.keys(tools);
@@ -43,7 +40,6 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
     setPendingStrategy('latest-released');
     setPendingVersion('');
     setHasPendingRow(true);
-    setVersionTouchSignal((signal) => signal + 1);
   };
 
   return (
@@ -99,7 +95,6 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
               catalog={catalog}
               allowUnset={allowUnset}
               isCatalogLoading={isCatalogLoading}
-              versionTouchSignal={versionTouchSignal}
               onIdChange={(newId) => ToolsService.renameTool(toolId, newId, scope)}
               onStrategyChange={(strategy, ver) => ToolsService.setTool(toolId, strategy, ver, scope)}
               onVersionChange={(ver) => ToolsService.setTool(toolId, parsed.strategy, ver, scope)}

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -32,6 +32,9 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
   const [hasPendingRow, setHasPendingRow] = useState(false);
   const [pendingStrategy, setPendingStrategy] = useState<VersionStrategy>('latest-released');
   const [pendingVersion, setPendingVersion] = useState('');
+  // Bumped when a new row is added: moving on to another row counts as leaving the
+  // existing ones, so their incomplete-version errors become visible.
+  const [versionTouchSignal, setVersionTouchSignal] = useState(0);
 
   const allowUnset = scope.type === 'workflow';
   const existingToolIds = Object.keys(tools);
@@ -40,10 +43,11 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
     setPendingStrategy('latest-released');
     setPendingVersion('');
     setHasPendingRow(true);
+    setVersionTouchSignal((signal) => signal + 1);
   };
 
   return (
-    <Stack gap="24" marginBlockStart="24" maxWidth={rem(640)}>
+    <Stack gap="24" marginBlockStart="24" maxWidth={rem(800)}>
       <Stack gap="4">
         <Text textStyle="heading/h3">Tool setup</Text>
         <Text textStyle="body/md/regular" color="text/secondary">
@@ -95,6 +99,7 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
               catalog={catalog}
               allowUnset={allowUnset}
               isCatalogLoading={isCatalogLoading}
+              versionTouchSignal={versionTouchSignal}
               onIdChange={(newId) => ToolsService.renameTool(toolId, newId, scope)}
               onStrategyChange={(strategy, ver) => ToolsService.setTool(toolId, strategy, ver, scope)}
               onVersionChange={(ver) => ToolsService.setTool(toolId, parsed.strategy, ver, scope)}

--- a/source/javascripts/core/api/ToolCatalogApi.mswMocks.ts
+++ b/source/javascripts/core/api/ToolCatalogApi.mswMocks.ts
@@ -10,7 +10,23 @@ const DEFAULT_TOOLS: ToolCatalogEntry[] = [
   { name: 'flutter', aliases: [] },
 ];
 
-const CATALOG_URL = 'https://bitrise.io/stacks/tools/v1/catalog.json';
+const BASE_URL = 'https://bitrise.io/stacks/tools/v1';
+const CATALOG_URL = `${BASE_URL}/catalog.json`;
+// Also matches catalog.json — always register a catalog handler BEFORE a versions handler.
+const TOOL_VERSIONS_URL = `${BASE_URL}/:toolFile`;
+
+const DEFAULT_VERSIONS: Record<string, string[]> = {
+  golang: ['1.25.7', '1.25.6', '1.24.2', '1.23.0'],
+  nodejs: [
+    // Long, unsorted list on purpose: exercises newest-first sorting and type-to-filter.
+    ...['24.0.0', '24.1.0', '24.2.0', '22.4.1', '22.11.0', '22.12.0', '20.9.0', '20.10.0', '20.11.1', '18.20.4'],
+    'lts-iron',
+  ],
+  ruby: ['3.4.2', '3.3.6', '3.2.6'],
+  python: ['3.13.4', '3.12.8', '3.11.11'],
+  // In the catalog, but no published versions yet.
+  flutter: [],
+};
 
 function getToolCatalog() {
   return http.get(CATALOG_URL, async () => {
@@ -30,4 +46,30 @@ function getToolCatalogError() {
   });
 }
 
-export default { getToolCatalog, getToolCatalogPending, getToolCatalogError };
+function getToolVersions() {
+  return http.get(TOOL_VERSIONS_URL, async ({ params }) => {
+    const toolId = String(params.toolFile).replace(/\.json$/, '');
+    await delay();
+    return HttpResponse.json({ versions: DEFAULT_VERSIONS[toolId] ?? ['1.0.0'], timestamp: new Date().toISOString() });
+  });
+}
+
+function getToolVersionsPending() {
+  return http.get(TOOL_VERSIONS_URL, async () => delay('infinite'));
+}
+
+function getToolVersionsError() {
+  return http.get(TOOL_VERSIONS_URL, async () => {
+    await delay();
+    return HttpResponse.json(null, { status: 500 });
+  });
+}
+
+export default {
+  getToolCatalog,
+  getToolCatalogPending,
+  getToolCatalogError,
+  getToolVersions,
+  getToolVersionsPending,
+  getToolVersionsError,
+};

--- a/source/javascripts/core/api/ToolCatalogApi.mswMocks.ts
+++ b/source/javascripts/core/api/ToolCatalogApi.mswMocks.ts
@@ -2,7 +2,13 @@ import { delay, http, HttpResponse } from 'msw';
 
 import { ToolCatalogEntry } from '../models/Tools';
 
-const DEFAULT_TOOLS: ToolCatalogEntry[] = [
+const BASE_URL = 'https://bitrise.io/stacks/tools/v1';
+const CATALOG_INDEX_URL = `${BASE_URL}/catalog.json`;
+// Per-tool catalogs sit next to the index under the same base URL, so this pattern also
+// matches catalog.json — toolIdFromFile below tells the two apart.
+const TOOL_VERSIONS_URL = `${BASE_URL}/:file`;
+
+const CATALOG: ToolCatalogEntry[] = [
   { name: 'golang', aliases: ['go'] },
   { name: 'nodejs', aliases: ['node'] },
   { name: 'ruby', aliases: [] },
@@ -10,12 +16,9 @@ const DEFAULT_TOOLS: ToolCatalogEntry[] = [
   { name: 'flutter', aliases: [] },
 ];
 
-const BASE_URL = 'https://bitrise.io/stacks/tools/v1';
-const CATALOG_URL = `${BASE_URL}/catalog.json`;
-// Also matches catalog.json — always register a catalog handler BEFORE a versions handler.
-const TOOL_VERSIONS_URL = `${BASE_URL}/:toolFile`;
-
-const DEFAULT_VERSIONS: Record<string, string[]> = {
+// A tool is only listed in the catalog once it has at least one published version, so every
+// entry here has a non-empty list — keep it that way when adding tools.
+const VERSIONS: Record<string, string[]> = {
   golang: ['1.25.7', '1.25.6', '1.24.2', '1.23.0'],
   nodejs: [
     // Long, unsorted list on purpose: exercises newest-first sorting and type-to-filter.
@@ -24,23 +27,33 @@ const DEFAULT_VERSIONS: Record<string, string[]> = {
   ],
   ruby: ['3.4.2', '3.3.6', '3.2.6'],
   python: ['3.13.4', '3.12.8', '3.11.11'],
-  // In the catalog, but no published versions yet.
-  flutter: [],
+  flutter: ['3.35.1', '3.32.0', '3.29.3'],
 };
 
+/**
+ * The tool ID for a `TOOL_VERSIONS_URL` match, or undefined when the match is actually the
+ * catalog index. Every versions handler checks this first and returns no response for the
+ * index, which makes MSW fall through to whichever catalog handler is registered — so the two
+ * sets of handlers can be combined in either order.
+ */
+function toolIdFromFile(file: unknown): string | undefined {
+  const name = String(file);
+  return name === 'catalog.json' ? undefined : name.replace(/\.json$/, '');
+}
+
 function getToolCatalog() {
-  return http.get(CATALOG_URL, async () => {
+  return http.get(CATALOG_INDEX_URL, async () => {
     await delay();
-    return HttpResponse.json({ tools: DEFAULT_TOOLS, timestamp: new Date().toISOString() });
+    return HttpResponse.json({ tools: CATALOG, timestamp: new Date().toISOString() });
   });
 }
 
 function getToolCatalogPending() {
-  return http.get(CATALOG_URL, async () => delay('infinite'));
+  return http.get(CATALOG_INDEX_URL, async () => delay('infinite'));
 }
 
 function getToolCatalogError() {
-  return http.get(CATALOG_URL, async () => {
+  return http.get(CATALOG_INDEX_URL, async () => {
     await delay();
     return HttpResponse.json(null, { status: 500 });
   });
@@ -48,18 +61,28 @@ function getToolCatalogError() {
 
 function getToolVersions() {
   return http.get(TOOL_VERSIONS_URL, async ({ params }) => {
-    const toolId = String(params.toolFile).replace(/\.json$/, '');
+    const toolId = toolIdFromFile(params.file);
+    if (!toolId) {
+      return undefined;
+    }
+
     await delay();
-    return HttpResponse.json({ versions: DEFAULT_VERSIONS[toolId] ?? ['1.0.0'], timestamp: new Date().toISOString() });
+    return HttpResponse.json({ versions: VERSIONS[toolId] ?? ['1.0.0'], timestamp: new Date().toISOString() });
   });
 }
 
 function getToolVersionsPending() {
-  return http.get(TOOL_VERSIONS_URL, async () => delay('infinite'));
+  return http.get(TOOL_VERSIONS_URL, async ({ params }) =>
+    toolIdFromFile(params.file) ? delay('infinite') : undefined,
+  );
 }
 
 function getToolVersionsError() {
-  return http.get(TOOL_VERSIONS_URL, async () => {
+  return http.get(TOOL_VERSIONS_URL, async ({ params }) => {
+    if (!toolIdFromFile(params.file)) {
+      return undefined;
+    }
+
     await delay();
     return HttpResponse.json(null, { status: 500 });
   });

--- a/source/javascripts/core/api/ToolCatalogApi.spec.ts
+++ b/source/javascripts/core/api/ToolCatalogApi.spec.ts
@@ -103,7 +103,9 @@ describe('ToolCatalogApi', () => {
       });
     });
 
-    it('returns an empty version list unchanged', async () => {
+    // The catalog never publishes a tool without versions, but an empty array is still a
+    // well-formed payload: it must pass through rather than throw like a missing `versions` key.
+    it('keeps a well-formed but empty version array instead of throwing', async () => {
       jest.spyOn(Client, 'get').mockResolvedValue({ versions: [] });
 
       await expect(ToolCatalogApi.getToolVersions('nodejs')).resolves.toEqual({

--- a/source/javascripts/core/services/ToolsService.spec.ts
+++ b/source/javascripts/core/services/ToolsService.spec.ts
@@ -289,35 +289,6 @@ describe('ToolsService', () => {
     });
   });
 
-  describe('validateToolVersion', () => {
-    it('rejects empty and whitespace-only versions', () => {
-      expect(ToolsService.validateToolVersion('')).toBe('Tool version is required');
-      expect(ToolsService.validateToolVersion('   ')).toBe('Tool version is required');
-    });
-
-    it('rejects a leading colon', () => {
-      expect(ToolsService.validateToolVersion(':latest')).toBe('Tool version must not start with ":"');
-    });
-
-    it('rejects a trailing colon with no suffix', () => {
-      expect(ToolsService.validateToolVersion('22:')).toBe(
-        'Tool version must specify "latest" or "installed" after ":"',
-      );
-    });
-
-    it('rejects unknown suffixes after a colon', () => {
-      expect(ToolsService.validateToolVersion('22:beta')).toBe('Tool version suffix must be "latest" or "installed"');
-      expect(ToolsService.validateToolVersion('foo:bar')).toBe('Tool version suffix must be "latest" or "installed"');
-    });
-
-    it.each([['latest'], ['installed'], ['unset'], ['22:latest'], ['3.3:installed'], ['3'], ['3.3'], ['3.13.4']])(
-      'accepts %p',
-      (raw: string) => {
-        expect(ToolsService.validateToolVersion(raw)).toBe(true);
-      },
-    );
-  });
-
   describe('setTool', () => {
     it('throws when using "unset" strategy at root scope', () => {
       expect(() => ToolsService.setTool('node', 'unset', '', { type: 'root' })).toThrow();

--- a/source/javascripts/core/services/ToolsService.spec.ts
+++ b/source/javascripts/core/services/ToolsService.spec.ts
@@ -1,6 +1,11 @@
 import ToolsService from '@/core/services/ToolsService';
 
+import { ToolVersions } from '../models/Tools';
 import { getYmlString, updateBitriseYmlDocumentByString } from '../stores/BitriseYmlStore';
+
+function versionCatalog(toolId: string, versions: string[], isSemver = true): ToolVersions {
+  return { toolId, versions: versions.map((version) => ({ version, isSemver })) };
+}
 
 describe('ToolsService', () => {
   describe('parseToolVersion', () => {
@@ -90,6 +95,103 @@ describe('ToolsService', () => {
 
     it('rejects when there is no catalog', () => {
       expect(ToolsService.isKnownToolId(undefined, 'golang')).toBe(false);
+    });
+  });
+
+  describe('getVersionOptions', () => {
+    it('sorts semver versions newest first', () => {
+      const catalog = versionCatalog('nodejs', ['22.4.1', '24.0.0', '22.11.0']);
+
+      expect(ToolsService.getVersionOptions(catalog, '')).toEqual([
+        { value: '24.0.0', label: '24.0.0' },
+        { value: '22.11.0', label: '22.11.0' },
+        { value: '22.4.1', label: '22.4.1' },
+      ]);
+    });
+
+    it('appends non-semver versions after semver ones, in catalog order', () => {
+      const catalog: ToolVersions = {
+        toolId: 'nodejs',
+        versions: [
+          { version: 'lts-iron', isSemver: false },
+          { version: '22.4.1', isSemver: true },
+          { version: '24.0.0', isSemver: true },
+          { version: 'nightly', isSemver: false },
+        ],
+      };
+
+      expect(ToolsService.getVersionOptions(catalog, '').map(({ value }) => value)).toEqual([
+        '24.0.0',
+        '22.4.1',
+        'lts-iron',
+        'nightly',
+      ]);
+    });
+
+    it('injects a current version missing from the catalog at the top', () => {
+      const catalog = versionCatalog('nodejs', ['24.0.0']);
+
+      expect(ToolsService.getVersionOptions(catalog, '18.9.9').map(({ value }) => value)).toEqual(['18.9.9', '24.0.0']);
+    });
+
+    it('does not duplicate a current version that is already in the catalog', () => {
+      const catalog = versionCatalog('nodejs', ['24.0.0', '22.4.1']);
+
+      expect(ToolsService.getVersionOptions(catalog, '22.4.1').map(({ value }) => value)).toEqual(['24.0.0', '22.4.1']);
+    });
+
+    it('ignores an empty current version', () => {
+      expect(ToolsService.getVersionOptions(versionCatalog('nodejs', ['24.0.0']), '')).toEqual([
+        { value: '24.0.0', label: '24.0.0' },
+      ]);
+    });
+
+    it('returns only the current version when the catalog is undefined', () => {
+      expect(ToolsService.getVersionOptions(undefined, '18.9.9')).toEqual([{ value: '18.9.9', label: '18.9.9' }]);
+      expect(ToolsService.getVersionOptions(undefined, '')).toEqual([]);
+    });
+
+    it('handles a tool whose published version list is empty', () => {
+      const catalog = versionCatalog('nodejs', []);
+
+      expect(ToolsService.getVersionOptions(catalog, '')).toEqual([]);
+      expect(ToolsService.getVersionOptions(catalog, '18.9.9')).toEqual([{ value: '18.9.9', label: '18.9.9' }]);
+    });
+  });
+
+  describe('isVersionInCatalog', () => {
+    const catalog = versionCatalog('nodejs', ['24.0.0', '22.4.1']);
+
+    it('finds a version present in the catalog', () => {
+      expect(ToolsService.isVersionInCatalog(catalog, '22.4.1')).toBe(true);
+    });
+
+    it('rejects a version missing from the catalog', () => {
+      expect(ToolsService.isVersionInCatalog(catalog, '18.9.9')).toBe(false);
+    });
+
+    it('rejects when the catalog is undefined', () => {
+      expect(ToolsService.isVersionInCatalog(undefined, '24.0.0')).toBe(false);
+    });
+  });
+
+  describe('nextVersionOnStrategyChange', () => {
+    it('keeps the prefix when moving between the two prefix strategies', () => {
+      expect(ToolsService.nextVersionOnStrategyChange('latest-released', 'latest-installed', '22')).toBe('22');
+      expect(ToolsService.nextVersionOnStrategyChange('latest-installed', 'latest-released', '3.3')).toBe('3.3');
+    });
+
+    it('clears the value when switching from exact to a prefix strategy', () => {
+      expect(ToolsService.nextVersionOnStrategyChange('exact', 'latest-released', '22.4.1')).toBe('');
+    });
+
+    it('clears the value when switching from a prefix strategy to exact', () => {
+      expect(ToolsService.nextVersionOnStrategyChange('latest-released', 'exact', '22')).toBe('');
+    });
+
+    it('clears the value when switching to unset', () => {
+      expect(ToolsService.nextVersionOnStrategyChange('exact', 'unset', '22.4.1')).toBe('');
+      expect(ToolsService.nextVersionOnStrategyChange('latest-released', 'unset', '22')).toBe('');
     });
   });
 

--- a/source/javascripts/core/services/ToolsService.spec.ts
+++ b/source/javascripts/core/services/ToolsService.spec.ts
@@ -531,7 +531,7 @@ describe('ToolsService', () => {
 
   describe('renameTool', () => {
     describe('root-level', () => {
-      it('renames the entry in place, keeping sibling order and values untouched', () => {
+      it('renames the entry in place, keeping sibling order and dropping the stale prefix', () => {
         updateBitriseYmlDocumentByString(yaml`
           tools:
             node: 22:latest
@@ -542,14 +542,42 @@ describe('ToolsService', () => {
 
         expect(getYmlString()).toEqual(yaml`
           tools:
-            ruby: 22:latest
+            ruby: latest
             python: "3.13.4"
+        `);
+      });
+
+      it('clears an exact version, keeping the exact strategy', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          tools:
+            python: "3.13.4"
+        `);
+
+        ToolsService.renameTool('python', 'ruby', { type: 'root' });
+
+        expect(getYmlString()).toEqual(yaml`
+          tools:
+            ruby: ""
+        `);
+      });
+
+      it('leaves the unset strategy untouched', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          tools:
+            node: unset
+        `);
+
+        ToolsService.renameTool('node', 'ruby', { type: 'root' });
+
+        expect(getYmlString()).toEqual(yaml`
+          tools:
+            ruby: unset
         `);
       });
     });
 
     describe('workflow-level', () => {
-      it('renames the entry in place, keeping sibling order and values untouched', () => {
+      it('renames the entry in place, keeping sibling order and dropping the stale prefix', () => {
         updateBitriseYmlDocumentByString(yaml`
           workflows:
             primary:
@@ -564,7 +592,7 @@ describe('ToolsService', () => {
           workflows:
             primary:
               tools:
-                ruby: 22:latest
+                ruby: latest
                 python: "3.13.4"
         `);
       });

--- a/source/javascripts/core/services/ToolsService.spec.ts
+++ b/source/javascripts/core/services/ToolsService.spec.ts
@@ -169,10 +169,6 @@ describe('ToolsService', () => {
     it('rejects a version missing from the catalog', () => {
       expect(ToolsService.isVersionInCatalog(catalog, '18.9.9')).toBe(false);
     });
-
-    it('rejects when the catalog is undefined', () => {
-      expect(ToolsService.isVersionInCatalog(undefined, '24.0.0')).toBe(false);
-    });
   });
 
   describe('nextVersionOnStrategyChange', () => {

--- a/source/javascripts/core/services/ToolsService.spec.ts
+++ b/source/javascripts/core/services/ToolsService.spec.ts
@@ -150,13 +150,6 @@ describe('ToolsService', () => {
       expect(ToolsService.getVersionOptions(undefined, '18.9.9')).toEqual([{ value: '18.9.9', label: '18.9.9' }]);
       expect(ToolsService.getVersionOptions(undefined, '')).toEqual([]);
     });
-
-    it('handles a tool whose published version list is empty', () => {
-      const catalog = versionCatalog('nodejs', []);
-
-      expect(ToolsService.getVersionOptions(catalog, '')).toEqual([]);
-      expect(ToolsService.getVersionOptions(catalog, '18.9.9')).toEqual([{ value: '18.9.9', label: '18.9.9' }]);
-    });
   });
 
   describe('isVersionInCatalog', () => {
@@ -568,6 +561,33 @@ describe('ToolsService', () => {
         expect(getYmlString()).toEqual(yaml`
           tools:
             ruby: unset
+        `);
+      });
+
+      it('clears an unquoted numeric version written by hand', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          tools:
+            python: 3.13
+        `);
+
+        ToolsService.renameTool('python', 'ruby', { type: 'root' });
+
+        expect(getYmlString()).toEqual(yaml`
+          tools:
+            ruby: ""
+        `);
+      });
+
+      it('throws when the tool does not exist', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          tools:
+            node: latest
+        `);
+
+        expect(() => ToolsService.renameTool('python', 'ruby', { type: 'root' })).toThrow();
+        expect(getYmlString()).toEqual(yaml`
+          tools:
+            node: latest
         `);
       });
     });

--- a/source/javascripts/core/services/ToolsService.ts
+++ b/source/javascripts/core/services/ToolsService.ts
@@ -1,4 +1,6 @@
-import { ParsedToolVersion, ToolCatalog, VersionStrategy } from '../models/Tools';
+import semver from 'semver';
+
+import { ParsedToolVersion, ToolCatalog, ToolVersions, VersionStrategy } from '../models/Tools';
 import { bitriseYmlStore, updateBitriseYmlDocument } from '../stores/BitriseYmlStore';
 import YmlUtils from '../utils/YmlUtils';
 import WorkflowService from './WorkflowService';
@@ -74,6 +76,46 @@ function isKnownToolId(catalog: ToolCatalog | undefined, toolId: string): boolea
 function resolveToolName(catalog: ToolCatalog | undefined, id: string): string {
   const entry = catalog?.tools.find(({ name, aliases }) => name === id || (aliases ?? []).includes(id));
   return entry?.name ?? id;
+}
+
+/**
+ * Builds the exact-version dropdown options: semver versions sorted newest first,
+ * then non-semver versions in catalog order. A non-empty `currentVersion` missing
+ * from the catalog is injected at the top so the dropdown always reflects what's
+ * in the YAML instead of showing an empty selection.
+ */
+function getVersionOptions(
+  toolVersions: ToolVersions | undefined,
+  currentVersion: string,
+): { value: string; label: string }[] {
+  const versions = toolVersions?.versions ?? [];
+  const ordered = [
+    ...versions
+      .filter(({ isSemver }) => isSemver)
+      .map(({ version }) => version)
+      .sort(semver.rcompare),
+    ...versions.filter(({ isSemver }) => !isSemver).map(({ version }) => version),
+  ];
+
+  if (currentVersion && !ordered.includes(currentVersion)) {
+    ordered.unshift(currentVersion);
+  }
+
+  return ordered.map((version) => ({ value: version, label: version }));
+}
+
+function isVersionInCatalog(toolVersions: ToolVersions | undefined, version: string): boolean {
+  return (toolVersions?.versions ?? []).some((entry) => entry.version === version);
+}
+
+/**
+ * The version value to keep when the row's strategy changes: a prefix survives
+ * moving between the two prefix strategies; any other change clears the value,
+ * because exact versions and prefixes aren't interchangeable.
+ */
+function nextVersionOnStrategyChange(prev: VersionStrategy, next: VersionStrategy, version: string): string {
+  const isPrefix = (s: VersionStrategy) => s === 'latest-released' || s === 'latest-installed';
+  return isPrefix(prev) && isPrefix(next) ? version : '';
 }
 
 /**
@@ -202,6 +244,9 @@ export default {
   getKnownToolIds,
   isKnownToolId,
   resolveToolName,
+  getVersionOptions,
+  isVersionInCatalog,
+  nextVersionOnStrategyChange,
   getToolIdOptions,
   getAvailableToolIdOptions,
   validateToolId,

--- a/source/javascripts/core/services/ToolsService.ts
+++ b/source/javascripts/core/services/ToolsService.ts
@@ -199,12 +199,34 @@ function deleteTool(toolId: string, scope: ToolScope) {
   });
 }
 
+/**
+ * The value to keep when a tool entry is renamed to a different tool: the strategy
+ * carries over, but any exact version or prefix is dropped, because it belonged to the
+ * previous tool and is very unlikely to be valid for the new one.
+ */
+function clearVersionOnRename(parsed: ParsedToolVersion): ParsedToolVersion {
+  switch (parsed.strategy) {
+    case 'exact':
+      return { strategy: 'exact', version: '' };
+    case 'unset':
+      return parsed;
+    default:
+      return { strategy: parsed.strategy };
+  }
+}
+
 function renameTool(oldId: string, newId: string, scope: ToolScope) {
   updateBitriseYmlDocument(({ doc }) => {
     validateScope(scope, doc);
 
     const scopePath = getScopePath(scope);
-    YmlUtils.updateKeyByPath(doc, [...scopePath, 'tools', oldId], newId);
+    const toolsPath = [...scopePath, 'tools'];
+    const tools = YmlUtils.getMapIn(doc, toolsPath, true);
+    const parsed = parseToolVersion(tools.get(oldId) as string);
+
+    YmlUtils.updateKeyByPath(doc, [...toolsPath, oldId], newId);
+    YmlUtils.setIn(tools, [newId], serializeToolVersion(clearVersionOnRename(parsed)), false);
+
     return doc;
   });
 }

--- a/source/javascripts/core/services/ToolsService.ts
+++ b/source/javascripts/core/services/ToolsService.ts
@@ -162,32 +162,6 @@ function validateToolId(id: string, initialId: string, existingIds: string[] = [
   return true;
 }
 
-function validateToolVersion(raw: string) {
-  if (!raw.trim()) {
-    return 'Tool version is required';
-  }
-
-  const colonIndex = raw.indexOf(':');
-  if (colonIndex >= 0) {
-    const prefix = raw.slice(0, colonIndex);
-    const suffix = raw.slice(colonIndex + 1);
-
-    if (!prefix) {
-      return 'Tool version must not start with ":"';
-    }
-
-    if (!suffix) {
-      return 'Tool version must specify "latest" or "installed" after ":"';
-    }
-
-    if (suffix.toLowerCase() !== 'latest' && suffix.toLowerCase() !== 'installed') {
-      return 'Tool version suffix must be "latest" or "installed"';
-    }
-  }
-
-  return true;
-}
-
 function setTool(toolId: string, strategy: VersionStrategy, inputValue: string, scope: ToolScope) {
   if (strategy === 'unset' && scope.type === 'root') {
     throw new Error('Cannot use "unset" strategy at root scope');
@@ -250,5 +224,4 @@ export default {
   getToolIdOptions,
   getAvailableToolIdOptions,
   validateToolId,
-  validateToolVersion,
 };

--- a/source/javascripts/core/services/ToolsService.ts
+++ b/source/javascripts/core/services/ToolsService.ts
@@ -104,8 +104,8 @@ function getVersionOptions(
   return ordered.map((version) => ({ value: version, label: version }));
 }
 
-function isVersionInCatalog(toolVersions: ToolVersions | undefined, version: string): boolean {
-  return (toolVersions?.versions ?? []).some((entry) => entry.version === version);
+function isVersionInCatalog(toolVersions: ToolVersions, version: string): boolean {
+  return toolVersions.versions.some((entry) => entry.version === version);
 }
 
 /**
@@ -204,7 +204,7 @@ function deleteTool(toolId: string, scope: ToolScope) {
  * carries over, but any exact version or prefix is dropped, because it belonged to the
  * previous tool and is very unlikely to be valid for the new one.
  */
-function clearVersionOnRename(parsed: ParsedToolVersion): ParsedToolVersion {
+function nextParsedVersionOnRename(parsed: ParsedToolVersion): ParsedToolVersion {
   switch (parsed.strategy) {
     case 'exact':
       return { strategy: 'exact', version: '' };
@@ -222,10 +222,14 @@ function renameTool(oldId: string, newId: string, scope: ToolScope) {
     const scopePath = getScopePath(scope);
     const toolsPath = [...scopePath, 'tools'];
     const tools = YmlUtils.getMapIn(doc, toolsPath, true);
+    // Read the old entry's version before the key is renamed out from under it.
     const parsed = parseToolVersion(tools.get(oldId) as string);
 
+    // Move the entry to its new key...
     YmlUtils.updateKeyByPath(doc, [...toolsPath, oldId], newId);
-    YmlUtils.setIn(tools, [newId], serializeToolVersion(clearVersionOnRename(parsed)), false);
+    // ...then overwrite its value: an exact version or prefix picked for the old tool is
+    // very unlikely to be valid for the new one, so only the strategy carries over.
+    YmlUtils.setIn(tools, [newId], serializeToolVersion(nextParsedVersionOnRename(parsed)), false);
 
     return doc;
   });

--- a/source/javascripts/core/services/ToolsService.ts
+++ b/source/javascripts/core/services/ToolsService.ts
@@ -221,14 +221,16 @@ function renameTool(oldId: string, newId: string, scope: ToolScope) {
 
     const scopePath = getScopePath(scope);
     const toolsPath = [...scopePath, 'tools'];
-    const tools = YmlUtils.getMapIn(doc, toolsPath, true);
-    // Read the old entry's version before the key is renamed out from under it.
-    const parsed = parseToolVersion(tools.get(oldId) as string);
 
-    // Move the entry to its new key...
+    // Move the entry to its new key first. This throws if there is no such entry, before
+    // anything else touches it.
     YmlUtils.updateKeyByPath(doc, [...toolsPath, oldId], newId);
-    // ...then overwrite its value: an exact version or prefix picked for the old tool is
-    // very unlikely to be valid for the new one, so only the strategy carries over.
+
+    const tools = YmlUtils.getMapIn(doc, toolsPath, true);
+    // A hand-edited YAML value may be a number (`python: 3.13`) or empty rather than a string.
+    const parsed = parseToolVersion(String(tools.get(newId) ?? ''));
+    // Then overwrite its value: an exact version or prefix picked for the old tool is very
+    // unlikely to be valid for the new one, so only the strategy carries over.
     YmlUtils.setIn(tools, [newId], serializeToolVersion(nextParsedVersionOnRename(parsed)), false);
 
     return doc;


### PR DESCRIPTION
When a tool row's strategy is Exact, the free-text input becomes a filterable dropdown of concrete versions from the tool catalog. Free text remains for prefix strategies and custom tools.

- If the value (already set in yml) in not in the catalog, that value kept, but a warning is displayed
- If the version fetch fails, the field becomes read-only (keeping the current value visible) and an alert links to editing the version manually in the YAML tab
- If the user moves focus away from an empty exact input, an error message is shown
- Renaming a tool to a different one clears its version/prefix, since a value picked for the old tool is very unlikely to be valid for the new one. The strategy (exact/latest/installed/unset) is carried over though.

NOTE: There is no input validation when clicking save.
