### PR TITLE
feat: gate Bitrise LSP Monaco integration behind feature flag

### DIFF
--- a/source/javascripts/hooks/useFeatureFlag.ts
+++ b/source/javascripts/hooks/useFeatureFlag.ts
@@ -5,6 +5,7 @@ const defaultValues = {
   'enable-branch-switching': false,
   'enable-wfe-tool-versions': false,
   'enable-wfe-modular-yaml-editing': false,
+  'enable-wfe-bitrise-lsp-integration': false,
 };
 
 type FeatureFlags = typeof defaultValues;

--- a/source/javascripts/hooks/useYmlLanguageServices.ts
+++ b/source/javascripts/hooks/useYmlLanguageServices.ts
@@ -3,15 +3,23 @@ import { useEffect } from 'react';
 
 import { bitriseYmlStore, getYmlString, setValidationStatus } from '@/core/stores/BitriseYmlStore';
 import MonacoUtils from '@/core/utils/MonacoUtils';
+import useFeatureFlag from '@/hooks/useFeatureFlag';
 
 export const BACKGROUND_MODEL_URI = monaco.Uri.parse('file:///bitrise.yml');
 
 function useYmlLanguageServices() {
+  const enableBitriseLsp = useFeatureFlag('enable-wfe-bitrise-lsp-integration');
+
   useEffect(() => {
     // Configure Monaco language services (idempotent — safe to call multiple times)
     MonacoUtils.configureForYaml(monaco);
     MonacoUtils.configureEnvVarsCompletionProvider(monaco);
-    MonacoUtils.configureBitriseLanguageServer(monaco);
+    // The Bitrise LSP integration runs a Monaco worker that queries Algolia (steplib_steps)
+    // on every document change for diagnostics/completion/hover. Gate it behind a flag so it
+    // can be disabled without a deploy. When off, editing falls back to plain monaco-yaml.
+    if (enableBitriseLsp) {
+      MonacoUtils.configureBitriseLanguageServer(monaco);
+    }
 
     // Create or reuse the background model
     let model = monaco.editor.getModel(BACKGROUND_MODEL_URI);
@@ -79,7 +87,7 @@ function useYmlLanguageServices() {
       // Disposing it while workers are in-flight causes "Model is disposed" errors.
       // The model lives for the entire app session — monaco.editor.getModel() reuses it.
     };
-  }, []);
+  }, [enableBitriseLsp]);
 }
 
 export default useYmlLanguageServices;


### PR DESCRIPTION
## What

Gate the Bitrise YAML **LSP Monaco integration** behind a new feature flag `enable-wfe-bitrise-lsp-integration` (default `false`).

- `useFeatureFlag.ts`: add the flag to `defaultValues`.
- `useYmlLanguageServices.ts`: wrap `MonacoUtils.configureBitriseLanguageServer(monaco)` in `if (enableBitriseLsp)` and add it to the effect deps. When off, editing falls back to plain `monaco-yaml`.

## Why

Algolia **search requests** on the `steplib_steps` index jumped ~**45x** (~2k → 80–90k/day) starting **April 2026**, aligned with the LSP releases that added completion + diagnostics (`#13`–`#17`).

Root cause: the LSP runs a Monaco **web worker** that queries Algolia per step on every document change (diagnostics `getStepVersions`). The `algoliasearch` **worker** and **node** builds default to `createNullCache()`, so these lookups are **uncached** — every keystroke re-fires one query per step. The caching `browser` build is only used on the main thread (which the LSP never runs on).

Attribution (Algolia dashboard):
- **63%** `app.bitrise.io` (JS clients) = in-browser LSP worker
- **37%** `None` (Node.js clients) = standalone LSP (editors/CI) + reindex job
- `localhost` only 0.30% → local CLI-plugin usage is negligible

## Scope / notes for reviewers

- This is a **mitigation / kill-switch**, not the durable fix. It lets us disable the Algolia-heavy LSP without a deploy (flag resolved via LaunchDarkly/Datadog).
- The **durable fix lives in `bitrise-yml-language-server`**: pass an explicit `createMemoryCache()` to the `algoliasearch` client so the worker/node builds cache too. After that lands, flip this flag back on.
- Intentionally **not** gated: the separate WFE `configureEnvVarsCompletionProvider` (browser main-thread, cached, rare) and the Node-side LSP.
- Flag OFF→ON takes effect on the next editor mount; ON→OFF fully applies on reload (no un-configure path).
- Local override: `ld.local.json` → `{"enable-wfe-bitrise-lsp-integration": true}`.

## Testing

- ESLint clean on both files (also via husky lint-staged on commit).
- Not gating changes any product logic beyond the conditional; no unit test added (no existing spec for this hook; the change is a single flag gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)