### PR TITLE
Modular YAML manual-review fixes 6: permanent read-only banner, hide AI in modular, disabled-field tooltip (BIVS-3664)

### DIFF
--- a/source/javascripts/components/ReadOnlyViewNotification.tsx
+++ b/source/javascripts/components/ReadOnlyViewNotification.tsx
@@ -1,14 +1,11 @@
 import { BitkitAlert } from '@bitrise/bitkit-v2';
-import { useState } from 'react';
 
-import { useReadOnlyView, useSelectedNodeId } from '@/hooks/useTree';
+import { useReadOnlyView } from '@/hooks/useTree';
 
 const ReadOnlyViewNotification = () => {
   const { isReadOnly, isMergedConfig } = useReadOnlyView();
-  const selectedNodeId = useSelectedNodeId();
-  const [dismissedNodeId, setDismissedNodeId] = useState<string>();
 
-  if (!isReadOnly || dismissedNodeId === selectedNodeId) {
+  if (!isReadOnly) {
     return null;
   }
 
@@ -16,12 +13,12 @@ const ReadOnlyViewNotification = () => {
     ? 'Merged view of the configuration is read-only. You can only edit the module files.'
     : 'Files included from another repository, branch, tag or commit are read-only.';
 
+  // A permanent reminder of why the view is read-only — neither the merged view nor a cross-repo/ref
+  // file can be edited for the whole time it's open, so the banner isn't dismissible (BIVS-3732).
   return (
     <BitkitAlert
       variant="info"
       messageText={messageText}
-      dismissible
-      onClose={() => setDismissedNodeId(selectedNodeId)}
       position="absolute"
       // The YmlPage editor wrapper already has 12px block padding, so flush-top lands 12px below the tab bar.
       insetBlockStart="0"

--- a/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
+++ b/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
@@ -1,4 +1,4 @@
-import { Box, Link, Notification } from '@bitrise/bitkit';
+import { Box, Link, Notification, Tooltip } from '@bitrise/bitkit';
 import { ReactNode, RefObject, useCallback, useRef } from 'react';
 import { useResizeObserver } from 'usehooks-ts';
 
@@ -125,38 +125,40 @@ const StackAndMachine = ({
       machineTypeName={selectedMachineType.name}
       stackName={selectedStack.name}
     >
-      <Box ref={ref} display="flex" flexDir={orientation === 'horizontal' ? 'row' : 'column'} gap="24">
-        <StackSelector
-          stack={selectedStack}
-          isLoading={isLoading}
-          isDisabled={isReadOnlyView}
-          isInvalid={isInvalidStack && !isLoading}
-          optionGroups={stackOptionGroups}
-          onChange={(selectedStackValue, useRollbackVersionChecked) =>
-            handleChange(selectedStackValue, selectedMachineType.value, useRollbackVersionChecked)
-          }
-          isRollbackVersionAvailable={!!availableRollbackVersion}
-          disableRollbackOption={disableRollbackOption}
-          useRollbackVersion={useRollbackVersion}
-          width={orientation === 'horizontal' ? '50%' : undefined}
-        />
-        <MachineTypeSelector
-          machineType={selectedMachineType}
-          isLoading={isLoading}
-          isInvalid={isInvalidMachineType && !isLoading}
-          isDisabled={isMachineTypeSelectionDisabled || isReadOnlyView}
-          optionGroups={machineOptionGroups}
-          onChange={(selectedMachineTypeValue) => handleChange(selectedStack.value, selectedMachineTypeValue)}
-          selectedRegion={data?.region}
-          width={orientation === 'horizontal' ? '50%' : undefined}
-        />
-        {selectsTrailing && (
-          // Align with the select inputs (which sit below their labels), not the label row.
-          <Box alignSelf={orientation === 'horizontal' ? 'flex-start' : 'flex-end'} marginBlockStart="24">
-            {selectsTrailing}
-          </Box>
-        )}
-      </Box>
+      <Tooltip label="Read-only here — edit it in the module file that defines it." isDisabled={!isReadOnlyView}>
+        <Box ref={ref} display="flex" flexDir={orientation === 'horizontal' ? 'row' : 'column'} gap="24">
+          <StackSelector
+            stack={selectedStack}
+            isLoading={isLoading}
+            isDisabled={isReadOnlyView}
+            isInvalid={isInvalidStack && !isLoading}
+            optionGroups={stackOptionGroups}
+            onChange={(selectedStackValue, useRollbackVersionChecked) =>
+              handleChange(selectedStackValue, selectedMachineType.value, useRollbackVersionChecked)
+            }
+            isRollbackVersionAvailable={!!availableRollbackVersion}
+            disableRollbackOption={disableRollbackOption}
+            useRollbackVersion={useRollbackVersion}
+            width={orientation === 'horizontal' ? '50%' : undefined}
+          />
+          <MachineTypeSelector
+            machineType={selectedMachineType}
+            isLoading={isLoading}
+            isInvalid={isInvalidMachineType && !isLoading}
+            isDisabled={isMachineTypeSelectionDisabled || isReadOnlyView}
+            optionGroups={machineOptionGroups}
+            onChange={(selectedMachineTypeValue) => handleChange(selectedStack.value, selectedMachineTypeValue)}
+            selectedRegion={data?.region}
+            width={orientation === 'horizontal' ? '50%' : undefined}
+          />
+          {selectsTrailing && (
+            // Align with the select inputs (which sit below their labels), not the label row.
+            <Box alignSelf={orientation === 'horizontal' ? 'flex-start' : 'flex-end'} marginBlockStart="24">
+              {selectsTrailing}
+            </Box>
+          )}
+        </Box>
+      </Tooltip>
       {useRollbackVersion && (
         <Notification flex="0" marginBlockStart="12" status="warning">
           Previous version is a rollback option we provide if your build is failing after a Stack Update. Please keep in

--- a/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
+++ b/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
@@ -125,40 +125,50 @@ const StackAndMachine = ({
       machineTypeName={selectedMachineType.name}
       stackName={selectedStack.name}
     >
-      <Tooltip label="Read-only here — edit it in the module file that defines it." isDisabled={!isReadOnlyView}>
-        <Box ref={ref} display="flex" flexDir={orientation === 'horizontal' ? 'row' : 'column'} gap="24">
-          <StackSelector
-            stack={selectedStack}
-            isLoading={isLoading}
-            isDisabled={isReadOnlyView}
-            isInvalid={isInvalidStack && !isLoading}
-            optionGroups={stackOptionGroups}
-            onChange={(selectedStackValue, useRollbackVersionChecked) =>
-              handleChange(selectedStackValue, selectedMachineType.value, useRollbackVersionChecked)
-            }
-            isRollbackVersionAvailable={!!availableRollbackVersion}
-            disableRollbackOption={disableRollbackOption}
-            useRollbackVersion={useRollbackVersion}
-            width={orientation === 'horizontal' ? '50%' : undefined}
-          />
-          <MachineTypeSelector
-            machineType={selectedMachineType}
-            isLoading={isLoading}
-            isInvalid={isInvalidMachineType && !isLoading}
-            isDisabled={isMachineTypeSelectionDisabled || isReadOnlyView}
-            optionGroups={machineOptionGroups}
-            onChange={(selectedMachineTypeValue) => handleChange(selectedStack.value, selectedMachineTypeValue)}
-            selectedRegion={data?.region}
-            width={orientation === 'horizontal' ? '50%' : undefined}
-          />
-          {selectsTrailing && (
-            // Align with the select inputs (which sit below their labels), not the label row.
-            <Box alignSelf={orientation === 'horizontal' ? 'flex-start' : 'flex-end'} marginBlockStart="24">
-              {selectsTrailing}
-            </Box>
-          )}
-        </Box>
-      </Tooltip>
+      <Box display="flex" flexDir={orientation === 'horizontal' ? 'row' : 'column'} gap="24">
+        {/* Tooltip wraps only the selectors — not selectsTrailing, whose jump button has its own tooltip. */}
+        <Tooltip label="Read-only here — edit it in the module file that defines it." isDisabled={!isReadOnlyView}>
+          <Box
+            ref={ref}
+            display="flex"
+            flexDir={orientation === 'horizontal' ? 'row' : 'column'}
+            gap="24"
+            flex={orientation === 'horizontal' ? '1' : undefined}
+            minW="0"
+          >
+            <StackSelector
+              stack={selectedStack}
+              isLoading={isLoading}
+              isDisabled={isReadOnlyView}
+              isInvalid={isInvalidStack && !isLoading}
+              optionGroups={stackOptionGroups}
+              onChange={(selectedStackValue, useRollbackVersionChecked) =>
+                handleChange(selectedStackValue, selectedMachineType.value, useRollbackVersionChecked)
+              }
+              isRollbackVersionAvailable={!!availableRollbackVersion}
+              disableRollbackOption={disableRollbackOption}
+              useRollbackVersion={useRollbackVersion}
+              width={orientation === 'horizontal' ? '50%' : undefined}
+            />
+            <MachineTypeSelector
+              machineType={selectedMachineType}
+              isLoading={isLoading}
+              isInvalid={isInvalidMachineType && !isLoading}
+              isDisabled={isMachineTypeSelectionDisabled || isReadOnlyView}
+              optionGroups={machineOptionGroups}
+              onChange={(selectedMachineTypeValue) => handleChange(selectedStack.value, selectedMachineTypeValue)}
+              selectedRegion={data?.region}
+              width={orientation === 'horizontal' ? '50%' : undefined}
+            />
+          </Box>
+        </Tooltip>
+        {selectsTrailing && (
+          // Align with the select inputs (which sit below their labels), not the label row.
+          <Box alignSelf={orientation === 'horizontal' ? 'flex-start' : 'flex-end'} marginBlockStart="24">
+            {selectsTrailing}
+          </Box>
+        )}
+      </Box>
       {useRollbackVersion && (
         <Notification flex="0" marginBlockStart="12" status="warning">
           Previous version is a rollback option we provide if your build is failing after a Stack Update. Please keep in

--- a/source/javascripts/hooks/useAIButton.spec.tsx
+++ b/source/javascripts/hooks/useAIButton.spec.tsx
@@ -1,0 +1,52 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+
+import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { bitriseYmlStore, initializeModularConfig } from '@/core/stores/BitriseYmlStore';
+
+import useAIButton from './useAIButton';
+
+// The CI config expert agent and the workspace enablement are the other two gates; force them on so
+// the test isolates the modular gate added in BIVS-3735.
+jest.mock('@/core/analytics/SegmentBaseTracking', () => ({ __esModule: true, segmentTrack: jest.fn() }));
+jest.mock('@/hooks/useFeatureFlag', () => ({ __esModule: true, default: () => true }));
+jest.mock('@/core/utils/PageProps', () => ({
+  __esModule: true,
+  default: {
+    settings: () => ({ ai: { ciConfigExpert: {} } }),
+    appSlug: () => 'app-slug',
+    app: () => ({}),
+  },
+}));
+
+const SHA = 'a1b2c3d4e5f6789012345678901234567890abcd';
+const EMPTY_INDEX: EntityIndex = { workflows: {}, pipelines: {}, stepBundles: {}, containers: {} };
+const ROOT: TreeNode = {
+  nodeId: 'root',
+  path: 'bitrise.yml',
+  contents: 'format_version: "13"\n',
+  source: null,
+  commitSha: SHA,
+  editable: true,
+  includes: [],
+};
+
+describe('useAIButton', () => {
+  it('is visible in a non-modular config', () => {
+    bitriseYmlStore.setState({ tree: undefined });
+
+    const { result } = renderHook(() => useAIButton({ action: 'explain_workflow' }));
+
+    expect(result.current.isVisible).toBe(true);
+  });
+
+  it('is hidden in a modular config (BIVS-3735)', () => {
+    initializeModularConfig({ root: ROOT, entityIndex: EMPTY_INDEX, branch: 'main', commitSha: SHA });
+
+    const { result } = renderHook(() => useAIButton({ action: 'explain_workflow' }));
+
+    expect(result.current.isVisible).toBe(false);
+  });
+});

--- a/source/javascripts/hooks/useAIButton.ts
+++ b/source/javascripts/hooks/useAIButton.ts
@@ -9,6 +9,7 @@ import WindowUtils from '@/core/utils/WindowUtils';
 import useCurrentPage from '@/hooks/useCurrentPage';
 import useFeatureFlag from '@/hooks/useFeatureFlag';
 import useParentMessageListener from '@/hooks/useParentMessageListener';
+import { useTree } from '@/hooks/useTree';
 
 type OpenCiConfigExpertPayload = {
   action: string;
@@ -56,9 +57,13 @@ const useAIButton = (options: UseAIButtonOptions): UseAIButtonResult => {
     setIsAgenticRunInProgress(false);
   });
 
+  // The CI config expert operates on the whole bitrise.yml; modular configs aren't handled yet, so
+  // hide every AI entry point while a modular config is open rather than offer a broken action (BIVS-3735).
+  const isModular = Boolean(useTree());
+
   const ciConfigExpert = PageProps.settings()?.ai.ciConfigExpert;
   const isEnabledByWorkspace = !!ciConfigExpert && ciConfigExpert.disabled !== 'by-workspace';
-  const isVisible = enableCiConfigExpertAgent && isEnabledByWorkspace;
+  const isVisible = enableCiConfigExpertAgent && isEnabledByWorkspace && !isModular;
 
   let tooltipLabel;
   let isDisabled = false;


### PR DESCRIPTION
Modular-YAML manual-review UX fixes ([BIVS-3664](https://bitrise.atlassian.net/browse/BIVS-3664)), follow-up to #1835 / #1838. Small, self-contained changes from UX feedback on the modular editing views.

## Changes
- **[BIVS-3732](https://bitrise.atlassian.net/browse/BIVS-3732)** — the read-only banner in the modular YAML editor is now permanent (no close button). It explains why the view can't be edited (merged view, or a cross-repo/ref file), and that reason holds for the whole time the view is open, so it shouldn't be dismissible. Dropped the per-node dismissal state too.
- **[BIVS-3735](https://bitrise.atlassian.net/browse/BIVS-3735)** — hide all AI (CI config expert) entry points in modular configs. The expert operates on the whole `bitrise.yml` and doesn't handle modular configs yet, so its buttons (Workflow "Explain", "Create with AI" empty states/selectors, pipeline toolbar/drawer) would be broken there. Gated `useAIButton.isVisible` on `!isModular` — every entry point renders off that flag, so this hides them all at once; non-modular is unaffected.
- **[BIVS-3734](https://bitrise.atlassian.net/browse/BIVS-3734)** — the disabled Stack & Machine selectors now have a hover tooltip explaining the read-only state: "Read-only here — edit it in the module file that defines it."

## Notes
- 3734: no `shouldWrapChildren` needed — the wrapped node is a `Box` that receives hover over its disabled descendants, and Chakra v2 Tooltip merges the child ref so the responsive-orientation `useResizeObserver` keeps working. Both verified in Storybook.
- Full unit suite green (1411).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[BIVS-3664]: https://bitrise.atlassian.net/browse/BIVS-3664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BIVS-3732]: https://bitrise.atlassian.net/browse/BIVS-3732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BIVS-3735]: https://bitrise.atlassian.net/browse/BIVS-3735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BIVS-3734]: https://bitrise.atlassian.net/browse/BIVS-3734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ