### PR TITLE
refactor(modular): build entity index in WFE, drop BE index consumption [BIVS-3728]

### DIFF
--- a/source/javascripts/components/FileTreeViewer/FileTreeViewer.stories.tsx
+++ b/source/javascripts/components/FileTreeViewer/FileTreeViewer.stories.tsx
@@ -3,7 +3,7 @@ import { BitkitTabs } from '@bitrise/bitkit-v2';
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { useRef, useState } from 'react';
 
-import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { TreeNode } from '@/core/models/Tree';
 import { initializeModularConfig } from '@/core/stores/BitriseYmlStore';
 
 import FileTreeViewer from './FileTreeViewer';
@@ -70,12 +70,10 @@ const ROOT: TreeNode = {
   ],
 };
 
-const ENTITY_INDEX: EntityIndex = { workflows: {}, pipelines: {}, stepBundles: {} };
-
 export default {
   component: FileTreeViewer,
   beforeEach: () => {
-    initializeModularConfig({ root: ROOT, entityIndex: ENTITY_INDEX, branch: 'main', commitSha: ROOT.commitSha });
+    initializeModularConfig({ root: ROOT, branch: 'main', commitSha: ROOT.commitSha });
   },
   decorators: [
     (Story) => (

--- a/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.stories.tsx
+++ b/source/javascripts/components/unified-editor/UpdateConfigurationDialog/UpdateConfigurationDialog.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { delay, http, HttpResponse } from 'msw';
 
-import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { TreeNode } from '@/core/models/Tree';
 import { bitriseYmlStore, initializeModularConfig, updateFileDocument } from '@/core/stores/BitriseYmlStore';
 import YmlUtils from '@/core/utils/YmlUtils';
 import { getCiConfig } from '@/pages/YmlPage/components/ConfigurationYmlStorage.mswMocks';
@@ -42,8 +42,6 @@ const MODULAR_ROOT: TreeNode = {
   ],
 };
 
-const ENTITY_INDEX: EntityIndex = { workflows: {}, pipelines: {}, stepBundles: {} };
-
 export default {
   component: UpdateConfigurationDialog,
   args: {
@@ -82,7 +80,7 @@ export const Failed: Story = {
 
 export const Modular: Story = {
   beforeEach: () => {
-    initializeModularConfig({ root: MODULAR_ROOT, entityIndex: ENTITY_INDEX, branch: 'main', commitSha: SHA });
+    initializeModularConfig({ root: MODULAR_ROOT, branch: 'main', commitSha: SHA });
     // Make both module files dirty so they show up as changed modules.
     updateFileDocument('n_pipelines', ({ doc }) => {
       YmlUtils.setIn(doc, ['pipelines', 'pl-1'], {});

--- a/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.stories.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 
-import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { TreeNode } from '@/core/models/Tree';
 import { initializeModularConfig } from '@/core/stores/BitriseYmlStore';
 
 import WorkflowCard from './WorkflowCard';
@@ -66,12 +66,6 @@ const GHOST_ROOT: TreeNode = {
   ],
 };
 
-const GHOST_ENTITY_INDEX: EntityIndex = {
-  workflows: { 'ghost-wf': [{ nodeId: 'n_mod' }] },
-  pipelines: {},
-  stepBundles: {},
-};
-
 export const Ghost: Story = {
   args: {
     id: 'ghost-wf',
@@ -79,7 +73,6 @@ export const Ghost: Story = {
   beforeEach: () => {
     initializeModularConfig({
       root: GHOST_ROOT,
-      entityIndex: GHOST_ENTITY_INDEX,
       branch: 'main',
       commitSha: GHOST_ROOT.commitSha,
     });

--- a/source/javascripts/core/api/BitriseYmlApi.tree.mswMocks.ts
+++ b/source/javascripts/core/api/BitriseYmlApi.tree.mswMocks.ts
@@ -1,6 +1,6 @@
 import { delay, http, HttpResponse } from 'msw';
 
-import BitriseYmlApi, { WireEntityIndex, WireGetConfigResponse, WireTreeNode } from '@/core/api/BitriseYmlApi';
+import BitriseYmlApi, { WireGetConfigResponse, WireTreeNode } from '@/core/api/BitriseYmlApi';
 
 const ROOT_NODE = {
   node_id: 'n_root',
@@ -22,17 +22,10 @@ const ROOT_NODE = {
   ],
 } satisfies WireTreeNode;
 
-const ENTITY_INDEX = {
-  workflows: { build: [{ node_id: 'n_workflows' }] },
-  pipelines: {},
-  step_bundles: {},
-} satisfies WireEntityIndex;
-
 const MERGED_YML = 'format_version: "13"\nworkflows:\n  build:\n    steps:\n      - script@1: {}\n';
 
 const MODULAR_RESPONSE = {
   root: ROOT_NODE,
-  entity_index: ENTITY_INDEX,
   merged_yml: MERGED_YML,
   branch: 'main',
 } satisfies WireGetConfigResponse;
@@ -49,7 +42,6 @@ const SINGLE_NODE_ROOT = {
 
 const SINGLE_NODE_RESPONSE = {
   root: SINGLE_NODE_ROOT,
-  entity_index: { workflows: { build: [{ node_id: 'n_root' }] }, pipelines: {}, step_bundles: {} },
   merged_yml: SINGLE_NODE_ROOT.contents,
   branch: 'main',
 } satisfies WireGetConfigResponse;
@@ -78,4 +70,4 @@ export const postMergeConfig = (error?: string) => {
   });
 };
 
-export const treeMocks = { ROOT_NODE, ENTITY_INDEX, MODULAR_RESPONSE, SINGLE_NODE_RESPONSE };
+export const treeMocks = { ROOT_NODE, MODULAR_RESPONSE, SINGLE_NODE_RESPONSE };

--- a/source/javascripts/core/api/BitriseYmlApi.ts
+++ b/source/javascripts/core/api/BitriseYmlApi.ts
@@ -1,11 +1,4 @@
-import {
-  EntityIndex,
-  EntityIndexEntries,
-  GetConfigResponse,
-  MergedConfigResult,
-  TreeNode,
-  TreeNodeSource,
-} from '@/core/models/Tree';
+import { GetConfigResponse, MergedConfigResult, TreeNode, TreeNodeSource } from '@/core/models/Tree';
 import RuntimeUtils from '@/core/utils/RuntimeUtils';
 
 import Client from './client';
@@ -188,22 +181,6 @@ function toWireTreeNode(node: TreeNode, seen: Set<TreeNode> = new Set()): WireTr
   };
 }
 
-function fromWireEntityEntries(entries: WireEntityEntries = {}): EntityIndexEntries {
-  return Object.fromEntries(
-    Object.entries(entries).map(([id, defs]) => [id, defs.map(({ node_id }) => ({ nodeId: node_id }))]),
-  );
-}
-
-function fromWireEntityIndex(index: WireEntityIndex): EntityIndex {
-  return {
-    workflows: fromWireEntityEntries(index.workflows),
-    pipelines: fromWireEntityEntries(index.pipelines),
-    stepBundles: fromWireEntityEntries(index.step_bundles),
-    containers: fromWireEntityEntries(index.containers),
-    appEnvs: fromWireEntityEntries(index.app_envs),
-  };
-}
-
 function configTreePath({
   projectSlug,
   forceToReadFromRepo,
@@ -244,9 +221,11 @@ async function getConfig({ signal, ...options }: GetConfigOptions): Promise<GetC
   const wire = (await response.json()) as WireGetConfigResponse;
   const headerBranch = response.headers.get(CI_CONFIG_BRANCH_HEADER) || undefined;
 
+  // The BE still ships `entity_index`, but the WFE ignores it and builds the index itself from the
+  // file documents (single source of truth — see EntityIndexService). Left on the wire until the BE
+  // stops emitting it.
   return {
     root: fromWireTreeNode(wire.root),
-    entityIndex: fromWireEntityIndex(wire.entity_index),
     mergedYml: wire.merged_yml,
     branch: wire.branch || headerBranch,
   };

--- a/source/javascripts/core/api/BitriseYmlApi.ts
+++ b/source/javascripts/core/api/BitriseYmlApi.ts
@@ -221,9 +221,6 @@ async function getConfig({ signal, ...options }: GetConfigOptions): Promise<GetC
   const wire = (await response.json()) as WireGetConfigResponse;
   const headerBranch = response.headers.get(CI_CONFIG_BRANCH_HEADER) || undefined;
 
-  // The BE still ships `entity_index`, but the WFE ignores it and builds the index itself from the
-  // file documents (single source of truth — see EntityIndexService). Left on the wire until the BE
-  // stops emitting it.
   return {
     root: fromWireTreeNode(wire.root),
     mergedYml: wire.merged_yml,

--- a/source/javascripts/core/api/BitriseYmlApi.ts
+++ b/source/javascripts/core/api/BitriseYmlApi.ts
@@ -116,20 +116,8 @@ export type WireTreeNode = {
   includes: WireTreeNode[];
 };
 
-export type WireEntityEntries = Record<string, Array<{ node_id: string }>>;
-
-export type WireEntityIndex = {
-  workflows: WireEntityEntries;
-  pipelines: WireEntityEntries;
-  step_bundles: WireEntityEntries;
-  // Optional: absent on older BE responses, defaulted to `{}` on parse.
-  containers?: WireEntityEntries;
-  app_envs?: WireEntityEntries;
-};
-
 export type WireGetConfigResponse = {
   root: WireTreeNode;
-  entity_index: WireEntityIndex;
   merged_yml?: string;
   branch?: string;
 };

--- a/source/javascripts/core/models/Tree.ts
+++ b/source/javascripts/core/models/Tree.ts
@@ -54,7 +54,6 @@ export type EntityKind = keyof EntityIndex;
 /** Bootstrap response (`GET /config/tree`). Always tree-shaped; a non-modular config is a single root node with `includes: []`. */
 export type GetConfigResponse = {
   root: TreeNode;
-  entityIndex: EntityIndex;
   /** Merge of the tree as loaded. Absent if the BE couldn't merge at bootstrap; the FE then fetches it via `POST /config/merge`. */
   mergedYml?: string;
   /** From the `X-Config-Branch` response header (the body carries no branch). */

--- a/source/javascripts/core/services/ContainerService.spec.tsx
+++ b/source/javascripts/core/services/ContainerService.spec.tsx
@@ -1,6 +1,6 @@
 import { ContainerModel, Containers } from '@/core/models/BitriseYml';
 import { ContainerType } from '@/core/models/Container';
-import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { TreeNode } from '@/core/models/Tree';
 import {
   bitriseYmlStore,
   getYmlString,
@@ -11,7 +11,6 @@ import {
 import ContainerService from './ContainerService';
 
 const MODULAR_SHA = 'a1b2c3d4e5f6789012345678901234567890abcd';
-const EMPTY_ENTITY_INDEX: EntityIndex = { workflows: {}, pipelines: {}, stepBundles: {}, containers: {} };
 
 // A modular config whose active file (root) has a workflow but no containers, while an included module
 // defines `from-other-module` — so the entity index knows the container even though the active file
@@ -36,7 +35,7 @@ const initModularConfigWithContainerInModule = (type: 'execution' | 'service') =
       },
     ],
   };
-  initializeModularConfig({ root, entityIndex: EMPTY_ENTITY_INDEX, branch: 'main', commitSha: MODULAR_SHA });
+  initializeModularConfig({ root, branch: 'main', commitSha: MODULAR_SHA });
 };
 
 describe('ContainerService', () => {

--- a/source/javascripts/core/stores/BitriseYmlStore.modular.spec.ts
+++ b/source/javascripts/core/stores/BitriseYmlStore.modular.spec.ts
@@ -51,14 +51,8 @@ function buildRoot(): TreeNode {
   });
 }
 
-const entityIndex = {
-  workflows: { 'child-a': [{ nodeId: 'child-a' }] },
-  pipelines: {},
-  stepBundles: {},
-};
-
 function init() {
-  initializeModularConfig({ root: buildRoot(), entityIndex, branch: 'main', commitSha: 'abc' });
+  initializeModularConfig({ root: buildRoot(), branch: 'main', commitSha: 'abc' });
 }
 
 describe('BitriseYmlStore — modular tree', () => {
@@ -144,7 +138,6 @@ describe('BitriseYmlStore — modular tree', () => {
     it('seeds the merged config (not stale) when the bootstrap response carries mergedYml', () => {
       initializeModularConfig({
         root: buildRoot(),
-        entityIndex,
         mergedYml: 'merged: bootstrap',
         branch: 'main',
         commitSha: 'abc',
@@ -325,7 +318,7 @@ describe('BitriseYmlStore — modular tree', () => {
     it('binds the active document to the merged config when the last tab is closed', () => {
       // Otherwise the views keep rendering the just-closed file, where other files' entities look like ghosts.
       const merged = 'format_version: "13"\nworkflows:\n  child-a: {}\n  defined-elsewhere: {}\n';
-      initializeModularConfig({ root: buildRoot(), entityIndex, mergedYml: merged, branch: 'main' });
+      initializeModularConfig({ root: buildRoot(), mergedYml: merged, branch: 'main' });
 
       closeTab('root');
 
@@ -522,7 +515,7 @@ describe('BitriseYmlStore — modular tree', () => {
     const MERGED = 'format_version: "13"\nworkflows:\n  child-a: {}\n  defined-elsewhere: {}\n';
 
     it('binds the active document to the merged config so every entity resolves locally', () => {
-      initializeModularConfig({ root: buildRoot(), entityIndex, mergedYml: MERGED, branch: 'main' });
+      initializeModularConfig({ root: buildRoot(), mergedYml: MERGED, branch: 'main' });
 
       selectMergedConfig();
 
@@ -532,7 +525,7 @@ describe('BitriseYmlStore — modular tree', () => {
     });
 
     it('is read-only on the merged tab (no file slice backs it → mutations no-op)', () => {
-      initializeModularConfig({ root: buildRoot(), entityIndex, mergedYml: MERGED, branch: 'main' });
+      initializeModularConfig({ root: buildRoot(), mergedYml: MERGED, branch: 'main' });
       selectMergedConfig();
       const before = bitriseYmlStore.getState().ymlDocument;
 
@@ -545,7 +538,7 @@ describe('BitriseYmlStore — modular tree', () => {
     });
 
     it('rebinds the active document when a fresh merge arrives while the merged tab is active', () => {
-      initializeModularConfig({ root: buildRoot(), entityIndex, mergedYml: MERGED, branch: 'main' });
+      initializeModularConfig({ root: buildRoot(), mergedYml: MERGED, branch: 'main' });
       selectMergedConfig();
 
       setMergedConfig('format_version: "13"\nworkflows:\n  only-after-refresh: {}\n');
@@ -594,7 +587,6 @@ describe('BitriseYmlStore — modular tree', () => {
 
       applyModularSaveResult({
         root: refreshed,
-        entityIndex: { workflows: {}, pipelines: {}, stepBundles: {} },
       });
 
       const state = bitriseYmlStore.getState();
@@ -609,7 +601,6 @@ describe('BitriseYmlStore — modular tree', () => {
 
       applyModularSaveResult({
         root: node('root', { path: 'bitrise.yml', includes: [] }),
-        entityIndex: { workflows: {}, pipelines: {}, stepBundles: {} },
       });
 
       const state = bitriseYmlStore.getState();
@@ -623,7 +614,6 @@ describe('BitriseYmlStore — modular tree', () => {
 
       applyModularSaveResult({
         root: buildRoot(),
-        entityIndex: { workflows: {}, pipelines: {}, stepBundles: {} },
         branch: 'feature-x',
         commitSha: 'pushed-sha',
       });

--- a/source/javascripts/core/stores/BitriseYmlStore.ts
+++ b/source/javascripts/core/stores/BitriseYmlStore.ts
@@ -374,18 +374,20 @@ function modularTreePatch(
 
 export function initializeModularConfig({
   root,
-  entityIndex,
+  entityIndex: providedEntityIndex,
   mergedYml,
   branch,
   commitSha,
 }: {
   root: TreeNode;
-  entityIndex: EntityIndex;
+  /** Optional override (stories/tests). Production omits it → the index is built from the files, so the WFE doesn't depend on the BE-served index. */
+  entityIndex?: EntityIndex;
   mergedYml?: string;
   branch?: string;
   commitSha?: string;
 }) {
   const files = buildFileSlices(root);
+  const entityIndex = providedEntityIndex ?? EntityIndexService.buildFromFiles(root, files);
 
   bitriseYmlStore.setState({
     ...modularTreePatch(root, files, entityIndex, files[root.nodeId]),
@@ -407,16 +409,18 @@ export function initializeModularConfig({
  */
 export function applyModularSaveResult({
   root,
-  entityIndex,
+  entityIndex: providedEntityIndex,
   branch,
   commitSha,
 }: {
   root: TreeNode;
-  entityIndex: EntityIndex;
+  /** Optional override (tests). Production omits it → built from the files (see initializeModularConfig). */
+  entityIndex?: EntityIndex;
   branch?: string;
   commitSha?: string;
 }) {
   const files = buildFileSlices(root);
+  const entityIndex = providedEntityIndex ?? EntityIndexService.buildFromFiles(root, files);
   const { openTabs, selectedNodeId } = bitriseYmlStore.getState();
 
   const nextTabs = openTabs.filter((tab) => files[tab.nodeId]);
@@ -639,9 +643,10 @@ bitriseYmlStore.subscribe(
   },
 );
 
-// Keep `entityIndex` live: the BE ships a snapshot at load/save, but unsaved edits to module files
-// must be reflected immediately for cross-file detection + jump-to-definition. Re-derived from the
-// live file documents on every `files` change (at load they equal the BE tree, so the seed is kept).
+// `entityIndex` is derived entirely from the live file documents — the WFE is the single source of
+// truth (the BE-served index is ignored). Built when a tree is bound (initializeModularConfig /
+// applyModularSaveResult) and re-derived here on every `files` change so unsaved edits are reflected
+// immediately for cross-file detection + jump-to-definition.
 bitriseYmlStore.subscribe(
   (s) => s.files,
   (files) => {

--- a/source/javascripts/core/stores/BitriseYmlStore.ts
+++ b/source/javascripts/core/stores/BitriseYmlStore.ts
@@ -374,20 +374,17 @@ function modularTreePatch(
 
 export function initializeModularConfig({
   root,
-  entityIndex: providedEntityIndex,
   mergedYml,
   branch,
   commitSha,
 }: {
   root: TreeNode;
-  /** Optional override (stories/tests). Production omits it → the index is built from the files, so the WFE doesn't depend on the BE-served index. */
-  entityIndex?: EntityIndex;
   mergedYml?: string;
   branch?: string;
   commitSha?: string;
 }) {
   const files = buildFileSlices(root);
-  const entityIndex = providedEntityIndex ?? EntityIndexService.buildFromFiles(root, files);
+  const entityIndex = EntityIndexService.buildFromFiles(root, files);
 
   bitriseYmlStore.setState({
     ...modularTreePatch(root, files, entityIndex, files[root.nodeId]),
@@ -409,18 +406,15 @@ export function initializeModularConfig({
  */
 export function applyModularSaveResult({
   root,
-  entityIndex: providedEntityIndex,
   branch,
   commitSha,
 }: {
   root: TreeNode;
-  /** Optional override (tests). Production omits it → built from the files (see initializeModularConfig). */
-  entityIndex?: EntityIndex;
   branch?: string;
   commitSha?: string;
 }) {
   const files = buildFileSlices(root);
-  const entityIndex = providedEntityIndex ?? EntityIndexService.buildFromFiles(root, files);
+  const entityIndex = EntityIndexService.buildFromFiles(root, files);
   const { openTabs, selectedNodeId } = bitriseYmlStore.getState();
 
   const nextTabs = openTabs.filter((tab) => files[tab.nodeId]);
@@ -643,10 +637,8 @@ bitriseYmlStore.subscribe(
   },
 );
 
-// `entityIndex` is derived entirely from the live file documents — the WFE is the single source of
-// truth (the BE-served index is ignored). Built when a tree is bound (initializeModularConfig /
-// applyModularSaveResult) and re-derived here on every `files` change so unsaved edits are reflected
-// immediately for cross-file detection + jump-to-definition.
+// Re-derive the entity index from the live file documents on every `files` change so unsaved edits
+// are reflected immediately for cross-file detection + jump-to-definition.
 bitriseYmlStore.subscribe(
   (s) => s.files,
   (files) => {

--- a/source/javascripts/hooks/useAIButton.spec.tsx
+++ b/source/javascripts/hooks/useAIButton.spec.tsx
@@ -3,7 +3,7 @@
  */
 import { renderHook } from '@testing-library/react';
 
-import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { TreeNode } from '@/core/models/Tree';
 import { bitriseYmlStore, initializeModularConfig } from '@/core/stores/BitriseYmlStore';
 
 import useAIButton from './useAIButton';
@@ -22,7 +22,6 @@ jest.mock('@/core/utils/PageProps', () => ({
 }));
 
 const SHA = 'a1b2c3d4e5f6789012345678901234567890abcd';
-const EMPTY_INDEX: EntityIndex = { workflows: {}, pipelines: {}, stepBundles: {}, containers: {} };
 const ROOT: TreeNode = {
   nodeId: 'root',
   path: 'bitrise.yml',
@@ -43,7 +42,7 @@ describe('useAIButton', () => {
   });
 
   it('is hidden in a modular config (BIVS-3735)', () => {
-    initializeModularConfig({ root: ROOT, entityIndex: EMPTY_INDEX, branch: 'main', commitSha: SHA });
+    initializeModularConfig({ root: ROOT, branch: 'main', commitSha: SHA });
 
     const { result } = renderHook(() => useAIButton({ action: 'explain_workflow' }));
 

--- a/source/javascripts/hooks/useContainerWorkflowUsage.spec.tsx
+++ b/source/javascripts/hooks/useContainerWorkflowUsage.spec.tsx
@@ -3,13 +3,12 @@
  */
 import { renderHook } from '@testing-library/react';
 
-import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { TreeNode } from '@/core/models/Tree';
 import { initializeModularConfig } from '@/core/stores/BitriseYmlStore';
 
 import useContainerWorkflowUsage, { useContainerUsageByWorkflow } from './useContainerWorkflowUsage';
 
 const SHA = 'a1b2c3d4e5f6789012345678901234567890abcd';
-const EMPTY_INDEX: EntityIndex = { workflows: {}, pipelines: {}, stepBundles: {}, containers: {} };
 
 const leaf = (nodeId: string, path: string, contents: string): TreeNode => ({
   nodeId,
@@ -39,7 +38,7 @@ describe('useContainerWorkflowUsage', () => {
       ],
     };
     // Root is the active file and doesn't use ec1 — the usage lives in the module.
-    initializeModularConfig({ root, entityIndex: EMPTY_INDEX, branch: 'main', commitSha: SHA });
+    initializeModularConfig({ root, branch: 'main', commitSha: SHA });
 
     const { result } = renderHook(() => useContainerWorkflowUsage('ec1'));
 
@@ -64,7 +63,7 @@ describe('useContainerWorkflowUsage', () => {
         ),
       ],
     };
-    initializeModularConfig({ root, entityIndex: EMPTY_INDEX, branch: 'main', commitSha: SHA });
+    initializeModularConfig({ root, branch: 'main', commitSha: SHA });
 
     const { result } = renderHook(() => useContainerWorkflowUsage('ec1'));
 
@@ -92,7 +91,7 @@ describe('useContainerWorkflowUsage', () => {
         ),
       ],
     };
-    initializeModularConfig({ root, entityIndex: EMPTY_INDEX, branch: 'main', commitSha: SHA });
+    initializeModularConfig({ root, branch: 'main', commitSha: SHA });
 
     const { result } = renderHook(() => useContainerWorkflowUsage());
 
@@ -123,7 +122,7 @@ describe('useContainerUsageByWorkflow', () => {
         leaf('n_mod', 'mod.yml', 'workflows:\n  wf-x:\n    steps:\n      - script: {}\n'),
       ],
     };
-    initializeModularConfig({ root, entityIndex: EMPTY_INDEX, branch: 'main', commitSha: SHA });
+    initializeModularConfig({ root, branch: 'main', commitSha: SHA });
 
     const { result } = renderHook(() => useContainerUsageByWorkflow('ec1'));
 

--- a/source/javascripts/hooks/useContainers.spec.tsx
+++ b/source/javascripts/hooks/useContainers.spec.tsx
@@ -4,7 +4,7 @@
 import { act, renderHook } from '@testing-library/react';
 
 import { ContainerType } from '@/core/models/Container';
-import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { TreeNode } from '@/core/models/Tree';
 import { initializeBitriseYmlDocument, initializeModularConfig, selectNode } from '@/core/stores/BitriseYmlStore';
 
 import useContainers, { useModuleContainers } from './useContainers';
@@ -20,8 +20,6 @@ const leaf = (nodeId: string, path: string, contents: string): TreeNode => ({
   editable: true,
   includes: [],
 });
-
-const ENTITY_INDEX: EntityIndex = { workflows: {}, pipelines: {}, stepBundles: {}, containers: {} };
 
 describe('useContainers', () => {
   it('lists containers from the single config document', () => {
@@ -53,7 +51,7 @@ describe('useContainers', () => {
         ),
       ],
     };
-    initializeModularConfig({ root, entityIndex: ENTITY_INDEX, branch: 'main', commitSha: SHA });
+    initializeModularConfig({ root, branch: 'main', commitSha: SHA });
 
     const { result } = renderHook(() => useContainers());
 
@@ -73,7 +71,7 @@ describe('useContainers', () => {
       editable: true,
       includes: [leaf('n_mod', 'mod.yml', 'containers:\n  dup:\n    type: service\n    image: postgres:16\n')],
     };
-    initializeModularConfig({ root, entityIndex: ENTITY_INDEX, branch: 'main', commitSha: SHA });
+    initializeModularConfig({ root, branch: 'main', commitSha: SHA });
 
     const { result } = renderHook(() => useContainers());
 
@@ -113,7 +111,7 @@ describe('useModuleContainers', () => {
       ],
     };
     // initializeModularConfig selects the root file, so the active module is `bitrise.yml`.
-    initializeModularConfig({ root, entityIndex: ENTITY_INDEX, branch: 'main', commitSha: SHA });
+    initializeModularConfig({ root, branch: 'main', commitSha: SHA });
 
     const { result } = renderHook(() => useModuleContainers());
 
@@ -132,7 +130,7 @@ describe('useModuleContainers', () => {
       editable: true,
       includes: [leaf('n_mod', 'mod.yml', 'containers:\n  mod-ctr:\n    type: execution\n    image: node:20\n')],
     };
-    initializeModularConfig({ root, entityIndex: ENTITY_INDEX, branch: 'main', commitSha: SHA });
+    initializeModularConfig({ root, branch: 'main', commitSha: SHA });
 
     const { result } = renderHook(() => useModuleContainers());
 

--- a/source/javascripts/hooks/useMergedConfigSync.spec.tsx
+++ b/source/javascripts/hooks/useMergedConfigSync.spec.tsx
@@ -50,12 +50,10 @@ function buildRoot(): TreeNode {
   };
 }
 
-const entityIndex = { workflows: { 'wf-a': [{ nodeId: 'child-a' }] }, pipelines: {}, stepBundles: {} };
-
 describe('useMergedConfigSync', () => {
   beforeEach(() => {
     jest.spyOn(PageProps, 'appSlug').mockReturnValue('app-1');
-    initializeModularConfig({ root: buildRoot(), entityIndex, branch: 'main', commitSha: 'abc' });
+    initializeModularConfig({ root: buildRoot(), branch: 'main', commitSha: 'abc' });
     selectMergedConfig();
   });
 

--- a/source/javascripts/hooks/usePushBranch.ts
+++ b/source/javascripts/hooks/usePushBranch.ts
@@ -100,7 +100,6 @@ function usePushBranch({ onSuccess, onMergeConflict }: UsePushBranchOptions = {}
         const config = await BitriseYmlApi.getConfig({ projectSlug: appSlug, branch });
         applyModularSaveResult({
           root: config.root,
-          entityIndex: config.entityIndex,
           branch: config.branch,
           commitSha: config.root.commitSha,
         });

--- a/source/javascripts/hooks/useTargetBasedTriggers.spec.tsx
+++ b/source/javascripts/hooks/useTargetBasedTriggers.spec.tsx
@@ -3,13 +3,12 @@
  */
 import { renderHook } from '@testing-library/react';
 
-import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { TreeNode } from '@/core/models/Tree';
 import { initializeModularConfig } from '@/core/stores/BitriseYmlStore';
 
 import { useTriggerDefiningNodeIds } from './useTargetBasedTriggers';
 
 const SHA = 'a1b2c3d4e5f6789012345678901234567890abcd';
-const EMPTY_INDEX: EntityIndex = { workflows: {}, pipelines: {}, stepBundles: {}, containers: {} };
 
 const leaf = (nodeId: string, path: string, contents: string): TreeNode => ({
   nodeId,
@@ -40,7 +39,7 @@ describe('useTriggerDefiningNodeIds', () => {
         leaf('n_mod', 'mod.yml', 'workflows:\n  wf-a:\n    triggers:\n      push:\n        - branch: dev\n'),
       ],
     };
-    initializeModularConfig({ root, entityIndex: EMPTY_INDEX, branch: 'main', commitSha: SHA });
+    initializeModularConfig({ root, branch: 'main', commitSha: SHA });
 
     const { result } = renderHook(() => useTriggerDefiningNodeIds());
 

--- a/source/javascripts/hooks/useTree.spec.tsx
+++ b/source/javascripts/hooks/useTree.spec.tsx
@@ -3,7 +3,7 @@
  */
 import { renderHook } from '@testing-library/react';
 
-import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { TreeNode } from '@/core/models/Tree';
 import { initializeBitriseYmlDocument, initializeModularConfig } from '@/core/stores/BitriseYmlStore';
 
 import { useEntityDefinitionPaths } from './useTree';
@@ -21,8 +21,6 @@ const leaf = (nodeId: string, path: string, contents: string): TreeNode => ({
   editable: true,
   includes: [],
 });
-
-const EMPTY_INDEX: EntityIndex = { workflows: {}, pipelines: {}, stepBundles: {}, containers: {} };
 
 const modularRoot = (rootContents: string, moduleContents: string): TreeNode => ({
   nodeId: 'root',
@@ -48,7 +46,7 @@ describe('useEntityDefinitionPaths', () => {
 
   it('returns a single entry when the container is defined in only one module', () => {
     const root = modularRoot('containers:\n  solo:\n    type: execution\n    image: ubuntu:22.04\n', '');
-    initializeModularConfig({ root, entityIndex: EMPTY_INDEX, branch: 'main', commitSha: SHA });
+    initializeModularConfig({ root, branch: 'main', commitSha: SHA });
 
     const { result } = renderHook(() => useEntityDefinitionPaths('containers', 'solo'));
 
@@ -60,7 +58,7 @@ describe('useEntityDefinitionPaths', () => {
       'containers:\n  dup:\n    type: execution\n    image: ubuntu:22.04\n',
       'containers:\n  dup:\n    type: service\n    image: postgres:16\n',
     );
-    initializeModularConfig({ root, entityIndex: EMPTY_INDEX, branch: 'main', commitSha: SHA });
+    initializeModularConfig({ root, branch: 'main', commitSha: SHA });
 
     const { result } = renderHook(() => useEntityDefinitionPaths('containers', 'dup'));
 

--- a/source/javascripts/main.tsx
+++ b/source/javascripts/main.tsx
@@ -167,7 +167,6 @@ const InitialDataLoader = ({ children }: PropsWithChildren) => {
           } else {
             initializeModularConfig({
               root: config.root,
-              entityIndex: config.entityIndex,
               mergedYml: config.mergedYml,
               branch: config.branch,
               commitSha: config.root.commitSha,

--- a/source/javascripts/pages/YmlPage/components/OpenFileTabs/OpenFileTabs.stories.tsx
+++ b/source/javascripts/pages/YmlPage/components/OpenFileTabs/OpenFileTabs.stories.tsx
@@ -1,7 +1,7 @@
 import { Box } from '@bitrise/bitkit';
 import { Meta, StoryObj } from '@storybook/react-vite';
 
-import { EntityIndex, TreeNode } from '@/core/models/Tree';
+import { TreeNode } from '@/core/models/Tree';
 import { initializeModularConfig, openTab } from '@/core/stores/BitriseYmlStore';
 
 import OpenFileTabs from './OpenFileTabs';
@@ -40,12 +40,10 @@ const ROOT: TreeNode = {
   ],
 };
 
-const ENTITY_INDEX: EntityIndex = { workflows: {}, pipelines: {}, stepBundles: {} };
-
 export default {
   component: OpenFileTabs,
   beforeEach: () => {
-    initializeModularConfig({ root: ROOT, entityIndex: ENTITY_INDEX, branch: 'main', commitSha: ROOT.commitSha });
+    initializeModularConfig({ root: ROOT, branch: 'main', commitSha: ROOT.commitSha });
     openTab('n_local');
     openTab('n_repo');
   },


### PR DESCRIPTION
## What

The WFE now builds the modular **entity index itself** from the loaded file documents and no longer consumes the backend-served `entity_index`. The WFE is the single source of truth for the index.

## Why

Index building is a pure function of the file tree, and the WFE already has all the files. It was previously dual-sourced — the BE shipped an `entity_index` snapshot at load/save *and* the FE re-derived it live from file documents (`EntityIndexService.buildFromFiles`) for unsaved-edit correctness. This removes the BE dependency, so cloud and (upcoming) local behave identically and there's one implementation to reason about. Retiring the BE `EntityIndexBuilder` is a follow-up (BIVS-3728 next step).

## Changes

- `getConfig` no longer parses `wire.entity_index`; `entityIndex` dropped from `GetConfigResponse` (removed `fromWireEntityIndex`/`fromWireEntityEntries`). The BE still emits `entity_index` on the wire — it's simply ignored.
- `initializeModularConfig` / `applyModularSaveResult` build the index from files via `EntityIndexService.buildFromFiles`. `entityIndex` is kept only as an **optional override** for stories/tests; production omits it.
- The existing `files` subscription already re-derives the index on every edit, so this only changes the *seed* (build-from-files instead of BE snapshot).

## Scope

Index only. The tree/files still come from the BE `/config/tree` on cloud; local file-sourcing is a separate ticket (BIVS-3729).

## Testing

`tsc` clean; 77/77 modular tests pass (`BitriseYmlStore.modular`, `EntityIndexService`, `TreeService`); lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)