### PR TITLE
Modular YAML manual-review fixes 7: jump-to-def lists all defining modules, read-only Env Vars empty state (BIVS-3664)

### DIFF
--- a/source/javascripts/components/EntityModuleProvenance.tsx
+++ b/source/javascripts/components/EntityModuleProvenance.tsx
@@ -54,7 +54,9 @@ const EntityModuleProvenance = ({
       {withJumpLink && (
         <>
           {' • '}
-          <JumpToDefinitionLink kind={kind} id={id} nodeIds={nodeIds} />
+          {/* The jump picker lists *every* defining module (incl. the current one) so both occurrences
+              are reachable; only the text above excludes the current module. */}
+          <JumpToDefinitionLink kind={kind} id={id} />
         </>
       )}
     </>

--- a/source/javascripts/components/SortableEnvVars/SortableEnvVars.tsx
+++ b/source/javascripts/components/SortableEnvVars/SortableEnvVars.tsx
@@ -1,4 +1,4 @@
-import { Box, BoxProps, Button } from '@bitrise/bitkit';
+import { Box, BoxProps, Button, Text } from '@bitrise/bitkit';
 import { DndContext, DragOverlay } from '@dnd-kit/core';
 import { restrictToParentElement, restrictToVerticalAxis } from '@dnd-kit/modifiers';
 import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable';
@@ -21,6 +21,8 @@ export type SortableEnvVarsProps = {
   initialEnvs?: EnvVar[];
   /** Read-only views: render a jump-to-definition arrow per row in place of the remove button. */
   renderJumpButton?: (env: SortableEnvVar) => ReactNode;
+  /** Placeholder shown on read-only views when there are no env vars (and thus no "Add new" button). */
+  emptyText?: string;
 };
 
 const SortableEnvVars = ({
@@ -32,6 +34,7 @@ const SortableEnvVars = ({
   onValidationErrorsChange,
   initialEnvs,
   renderJumpButton,
+  emptyText,
 }: SortableEnvVarsProps) => {
   const isReadOnlyView = useIsReadOnlyView();
   const {
@@ -78,6 +81,13 @@ const SortableEnvVars = ({
         </SortableContext>
         <DragOverlay>{activeItem && <SortableEnvVarItem env={activeItem} isDragging />}</DragOverlay>
       </DndContext>
+
+      {/* Read-only view with nothing to show (no rows, no "Add new") would leave an empty box. */}
+      {isReadOnlyView && envs.length === 0 && emptyText && (
+        <Text paddingInline="24" paddingBlock="16" textStyle="body/md/regular" color="text/secondary">
+          {emptyText}
+        </Text>
+      )}
 
       {/* Read-only views (merged config, cross-repo/ref files) can't add — show no action. */}
       {!hideAddButton && !isReadOnlyView && (

--- a/source/javascripts/components/unified-editor/StepBundleConfig/StepBundleConfigHeader.tsx
+++ b/source/javascripts/components/unified-editor/StepBundleConfig/StepBundleConfigHeader.tsx
@@ -30,11 +30,8 @@ const StepBundleConfigHeader = ({ variant }: HeaderProps) => {
   const otherModules = useOtherDefiningModules('stepBundles', stepBundleId);
   const shouldJumpToDefinition = otherModules.nodeIds.length > 0 || (isMergedView && hasDefinition);
   const editDefinitionLink = shouldJumpToDefinition ? (
-    <JumpToDefinitionLink
-      kind="stepBundles"
-      id={stepBundleId}
-      nodeIds={otherModules.nodeIds.length > 0 ? otherModules.nodeIds : undefined}
-    />
+    // Lists every defining module (incl. the current one) so both occurrences are reachable.
+    <JumpToDefinitionLink kind="stepBundles" id={stepBundleId} />
   ) : (
     <BitkitLinkButton onClick={() => replace('/step_bundles', { step_bundle_id: stepBundleId })}>
       Edit definition

--- a/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
+++ b/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
@@ -260,12 +260,8 @@ const StepBundleCard = (props: StepBundleCardProps) => {
               </Box>
               {showJumpButton && (
                 <Box display={isJumpPopoverOpen ? 'flex' : 'none'} _groupHover={{ display: 'flex' }}>
-                  <CrossFileJumpButton
-                    kind="stepBundles"
-                    id={bundleId}
-                    nodeIds={otherModules.nodeIds.length > 0 ? otherModules.nodeIds : undefined}
-                    onOpenChange={setIsJumpPopoverOpen}
-                  />
+                  {/* Lists every defining module (incl. the current one) so both occurrences are reachable. */}
+                  <CrossFileJumpButton kind="stepBundles" id={bundleId} onOpenChange={setIsJumpPopoverOpen} />
                 </Box>
               )}
               {buttonGroup}

--- a/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
@@ -170,12 +170,9 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
             {/* Jump takes the leading "primary action" slot for ghosts (where Chain is hidden),
                 matching the design's referenced-WF actions: jump → settings → remove. */}
             {showJumpButton && (
-              <CrossFileJumpButton
-                kind="workflows"
-                id={workflowId}
-                nodeIds={otherModules.nodeIds.length > 0 ? otherModules.nodeIds : undefined}
-                onOpenChange={setIsJumpPopoverOpen}
-              />
+              // The picker lists every defining module (incl. the current one) so both occurrences of
+              // a workflow defined here and elsewhere are reachable.
+              <CrossFileJumpButton kind="workflows" id={workflowId} onOpenChange={setIsJumpPopoverOpen} />
             )}
             {onEditWorkflow && (
               <ControlButton

--- a/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
@@ -130,12 +130,8 @@ const ChainedWorkflowCard = ({ id, index, uniqueId, placement, isSortable, isDra
         )}
         {/* Jump leads the action group for ghosts (Chain is hidden there): jump → settings → remove. */}
         {showJumpButton && (
-          <CrossFileJumpButton
-            kind="workflows"
-            id={id}
-            nodeIds={otherModules.nodeIds.length > 0 ? otherModules.nodeIds : undefined}
-            onOpenChange={setIsJumpPopoverOpen}
-          />
+          // Lists every defining module (incl. the current one) so both occurrences are reachable.
+          <CrossFileJumpButton kind="workflows" id={id} onOpenChange={setIsJumpPopoverOpen} />
         )}
         {onEditChainedWorkflow && (
           <ControlButton

--- a/source/javascripts/components/unified-editor/WorkflowConfig/components/EnvVarsCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowConfig/components/EnvVarsCard.tsx
@@ -35,6 +35,7 @@ const EnvVarsCard = () => {
           sourceId={sourceId}
           listenForExternalChanges
           onValidationErrorsChange={setErrorCount}
+          emptyText="No Env Vars defined."
         />
       </Box>
     </ExpandableCard>


### PR DESCRIPTION
Modular-YAML manual-review follow-up fixes ([BIVS-3664](https://bitrise.atlassian.net/browse/BIVS-3664)). **Draft** — more fixes may land on this branch.

## Changes
- **[BIVS-3706](https://bitrise.atlassian.net/browse/BIVS-3706)** — the "Also defined in" jump-to-definition picker now lists **every** defining module (including the current one), so an entity defined in the current module *and* another (e.g. a workflow added to a pipeline) exposes both occurrences. Previously the jump reused `useOtherDefiningModules` and excluded the current module — that exclusion is only meant for the provenance *text*, not the navigation picker. Dropped the `otherModules` node-id scoping from the jump in the workflow/step-bundle cards, the step-bundle config header and the shared `EntityModuleProvenance`; the text and the show-jump gating still exclude the current module. Usage/trigger-scoped jumps (BIVS-3708 / triggers) are intentionally left scoped. Also sized the default "Edit definition" link to `sm` (`body/sm`) so it matches the provenance subtitle instead of rendering at the larger default.
- **[BIVS-3712](https://bitrise.atlassian.net/browse/BIVS-3712)** (drawer) — the workflow config drawer's Env Vars card showed an empty box on the merged/read-only view (no env vars, no "Add new" button). Added an optional `emptyText` to `SortableEnvVars`, shown only when read-only with no env vars, and pass "No Env Vars defined." from `EnvVarsCard`. The prop is optional, so other `SortableEnvVars` consumers are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[BIVS-3664]: https://bitrise.atlassian.net/browse/BIVS-3664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BIVS-3706]: https://bitrise.atlassian.net/browse/BIVS-3706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BIVS-3712]: https://bitrise.atlassian.net/browse/BIVS-3712?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
