### PR TITLE
feat(local-modular): modular YML editing in the local (CLI) Workflow Editor [BIVS-3729]

### DIFF
--- a/apiserver/routes.go
+++ b/apiserver/routes.go
@@ -27,6 +27,12 @@ func SetupRoutes(isServeFilesThroughMiddlemanServer bool) (*mux.Router, error) {
 	r.HandleFunc("/api/bitrise-yml.json", wrapHandlerFunc(service.GetBitriseYMLAsJSONHandler)).Methods("GET")
 	r.HandleFunc("/api/bitrise-yml.json", wrapHandlerFunc(service.PostBitriseYMLFromJSONHandler)).Methods("POST")
 
+	// Modular config (include tree): resolve the tree from disk, save changed module files, and
+	// merge the live tree. The FE drives these in local mode exactly like the hosted /config/tree.
+	r.HandleFunc("/api/bitrise-yml/tree", wrapHandlerFunc(service.GetBitriseYMLTreeHandler)).Methods("GET")
+	r.HandleFunc("/api/bitrise-yml/tree", wrapHandlerFunc(service.PostBitriseYMLTreeHandler)).Methods("POST")
+	r.HandleFunc("/api/bitrise-yml/tree/merge", wrapHandlerFunc(service.PostBitriseYMLTreeMergeHandler)).Methods("POST")
+
 	r.HandleFunc("/api/secrets", wrapHandlerFunc(service.GetSecretsAsJSONHandler)).Methods("GET")
 	r.HandleFunc("/api/secrets", wrapHandlerFunc(service.PostSecretsYMLFromJSONHandler)).Methods("POST")
 

--- a/apiserver/service/bitrise_config_tree.go
+++ b/apiserver/service/bitrise_config_tree.go
@@ -1,0 +1,283 @@
+package service
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bitrise-io/bitrise-workflow-editor/apiserver/config"
+	"github.com/bitrise-io/bitrise-workflow-editor/apiserver/utility"
+	"github.com/bitrise-io/bitrise/v2/configmerge"
+	bitriselog "github.com/bitrise-io/bitrise/v2/log"
+	"github.com/bitrise-io/bitrise/v2/models"
+	"github.com/bitrise-io/go-utils/fileutil"
+	"github.com/bitrise-io/go-utils/log"
+)
+
+// The config tree wire shape mirrors what the Workflow Editor frontend expects from the
+// hosted `/config/tree` endpoint (see BitriseYmlApi.ts `WireTreeNode`), so the same FE
+// code drives cloud and local. The frontend builds the entity index itself from these
+// files, so no index is sent here.
+
+type wireTreeNodeSource struct {
+	Path       string  `json:"path"`
+	Repository *string `json:"repository"`
+	Branch     *string `json:"branch"`
+	Tag        *string `json:"tag"`
+	Commit     *string `json:"commit"`
+}
+
+type wireTreeNode struct {
+	NodeID    string              `json:"node_id"`
+	Path      string              `json:"path"`
+	Contents  string              `json:"contents"`
+	Source    *wireTreeNodeSource `json:"source"`
+	CommitSha string              `json:"commit_sha"`
+	Editable  bool                `json:"editable"`
+	Modified  bool                `json:"modified,omitempty"`
+	Includes  []wireTreeNode      `json:"includes"`
+}
+
+type getConfigTreeResponse struct {
+	Root      wireTreeNode `json:"root"`
+	MergedYML string       `json:"merged_yml"`
+	Branch    string       `json:"branch"`
+}
+
+func configMergeLogger() bitriselog.Logger {
+	return bitriselog.NewLogger(bitriselog.LoggerOpts{LoggerType: bitriselog.ConsoleLogger, Writer: io.Discard})
+}
+
+// nodeID is a stable id derived from the node's merge key (unique within a tree — the key
+// already encodes path + repo + ref), so the FE keeps tab/selection identity across reloads.
+func nodeID(key string) string {
+	sum := sha256.Sum256([]byte(key))
+	return "n_" + hex.EncodeToString(sum[:])[:12]
+}
+
+func strPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// parseNodeKey splits a configmerge tree key back into its parts. Local same-branch keys are
+// a bare path; cross-ref keys look like `repo:NAME,path@branch:B` / `…@tag:T` / `…@commit:C`.
+// A node is editable only when it lives in the working repo on the current branch (no repo, no
+// pinned ref) — matching the cloud read-only rule.
+func parseNodeKey(key string) (path string, source wireTreeNodeSource, editable bool) {
+	rest := key
+	var repo string
+	if strings.HasPrefix(rest, "repo:") {
+		rest = strings.TrimPrefix(rest, "repo:")
+		if comma := strings.Index(rest, ","); comma >= 0 {
+			repo = rest[:comma]
+			rest = rest[comma+1:]
+		}
+	}
+
+	var branch, tag, commit string
+	if i := strings.Index(rest, "@commit:"); i >= 0 {
+		path, commit = rest[:i], rest[i+len("@commit:"):]
+	} else if i := strings.Index(rest, "@tag:"); i >= 0 {
+		path, tag = rest[:i], rest[i+len("@tag:"):]
+	} else if i := strings.Index(rest, "@branch:"); i >= 0 {
+		path, branch = rest[:i], rest[i+len("@branch:"):]
+	} else {
+		path = rest
+	}
+
+	editable = repo == "" && branch == "" && tag == "" && commit == ""
+	source = wireTreeNodeSource{Path: path, Repository: strPtr(repo), Branch: strPtr(branch), Tag: strPtr(tag), Commit: strPtr(commit)}
+	return path, source, editable
+}
+
+func toWireTreeNode(node models.ConfigFileTreeModel, rootPath string, isRoot bool) wireTreeNode {
+	includes := make([]wireTreeNode, 0, len(node.Includes))
+	for _, child := range node.Includes {
+		includes = append(includes, toWireTreeNode(child, rootPath, false))
+	}
+
+	wire := wireTreeNode{
+		NodeID:   nodeID(node.Path),
+		Contents: node.Contents,
+		Editable: true,
+		Includes: includes,
+	}
+
+	if isRoot {
+		// The root is loaded directly (not via an include), so it has no source; normalize its
+		// path to the repo-relative bitrise.yml regardless of how the CLI addressed it.
+		wire.Path = rootPath
+		wire.Source = nil
+	} else {
+		path, source, editable := parseNodeKey(node.Path)
+		wire.Path = path
+		wire.Source = &source
+		wire.Editable = editable
+	}
+	return wire
+}
+
+// GetBitriseYMLTreeHandler resolves the modular include tree from disk (via the bitrise CLI's
+// configmerge) and returns it in the FE wire shape, plus the merged config. A non-modular config
+// comes back as a single root node, so the FE consumes one shape either way.
+func GetBitriseYMLTreeHandler(w http.ResponseWriter, r *http.Request) {
+	rootPath := filepath.Base(config.BitriseYMLPath)
+
+	isModular, err := configmerge.IsModularConfig(config.BitriseYMLPath)
+	if err != nil {
+		log.Errorf("Failed to detect modular config (%s), error: %s", config.BitriseYMLPath, err)
+		RespondWithJSONBadRequestErrorMessage(w, "Failed to read bitrise.yml, error: %s", err)
+		return
+	}
+
+	if !isModular {
+		contStr, err := fileutil.ReadStringFromFile(config.BitriseYMLPath)
+		if err != nil {
+			log.Errorf("Failed to read bitrise.yml (%s), error: %s", config.BitriseYMLPath, err)
+			RespondWithJSONBadRequestErrorMessage(w, "Failed to read bitrise.yml, error: %s", err)
+			return
+		}
+		RespondWithJSON(w, http.StatusOK, getConfigTreeResponse{
+			Root:      wireTreeNode{NodeID: nodeID(rootPath), Path: rootPath, Contents: contStr, Editable: true, Includes: []wireTreeNode{}},
+			MergedYML: contStr,
+		})
+		return
+	}
+
+	reader, err := configmerge.NewConfigReader(configMergeLogger())
+	if err != nil {
+		log.Errorf("Failed to init config reader, error: %s", err)
+		RespondWithJSONBadRequestErrorMessage(w, "Failed to resolve config tree, error: %s", err)
+		return
+	}
+	merger := configmerge.NewMerger(reader, configMergeLogger())
+
+	mergedYML, tree, err := merger.MergeConfig(config.BitriseYMLPath)
+	if err != nil {
+		log.Errorf("Failed to merge modular config (%s), error: %s", config.BitriseYMLPath, err)
+		RespondWithJSONBadRequestErrorMessage(w, "Failed to resolve config tree, error: %s", err)
+		return
+	}
+
+	RespondWithJSON(w, http.StatusOK, getConfigTreeResponse{
+		Root:      toWireTreeNode(*tree, rootPath, true),
+		MergedYML: mergedYML,
+	})
+}
+
+func toConfigFileTree(node wireTreeNode) models.ConfigFileTreeModel {
+	includes := make([]models.ConfigFileTreeModel, 0, len(node.Includes))
+	for _, child := range node.Includes {
+		includes = append(includes, toConfigFileTree(child))
+	}
+	return models.ConfigFileTreeModel{Path: node.Path, Contents: node.Contents, Includes: includes}
+}
+
+func collectEditableModified(node wireTreeNode, out *[]wireTreeNode) {
+	if node.Editable && node.Modified {
+		*out = append(*out, node)
+	}
+	for _, child := range node.Includes {
+		collectEditableModified(child, out)
+	}
+}
+
+// PostBitriseYMLTreeHandler validates the merged tree, then writes each changed, editable module
+// file back to disk. Read-only (cross-ref) files are never written; unmodified files are skipped.
+func PostBitriseYMLTreeHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Body == nil {
+		RespondWithJSONBadRequestErrorMessage(w, "Empty request body")
+		return
+	}
+	defer func() {
+		if err := r.Body.Close(); err != nil {
+			log.Errorf("Failed to close request body, error: %s", err)
+		}
+	}()
+
+	var reqObj struct {
+		Root wireTreeNode `json:"root"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqObj); err != nil {
+		log.Errorf("Failed to read JSON input, error: %s", err)
+		RespondWithJSONBadRequestErrorMessage(w, "Failed to read JSON input, error: %s", err)
+		return
+	}
+
+	// Validation is merged-only (a single module isn't a complete config), mirroring cloud.
+	tree := toConfigFileTree(reqObj.Root)
+	mergedYML, err := tree.Merge()
+	if err != nil {
+		log.Errorf("Failed to merge config tree, error: %s", err)
+		RespondWithJSONBadRequestErrorMessage(w, "Failed to merge config tree, error: %s", err)
+		return
+	}
+	warnings, validationErr := utility.ValidateBitriseConfigAndSecret(mergedYML, config.MinimalValidSecrets)
+	if validationErr != nil {
+		log.Errorf("Validation error: %s", validationErr)
+		RespondWithJSON(w, http.StatusBadRequest, NewErrorResponseWithConfig(mergedYML, "%s", validationErr.Error()))
+		return
+	}
+
+	repoRoot := filepath.Dir(config.BitriseYMLPath)
+	var toWrite []wireTreeNode
+	collectEditableModified(reqObj.Root, &toWrite)
+	for _, node := range toWrite {
+		target := node.Path
+		if !filepath.IsAbs(target) {
+			target = filepath.Join(repoRoot, node.Path)
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			log.Errorf("Failed to create module dir (%s), error: %s", filepath.Dir(target), err)
+			RespondWithJSONBadRequestErrorMessage(w, "Failed to write module file (%s), error: %s", node.Path, err)
+			return
+		}
+		if err := fileutil.WriteStringToFile(target, node.Contents); err != nil {
+			log.Errorf("Failed to write module file (%s), error: %s", target, err)
+			RespondWithJSONBadRequestErrorMessage(w, "Failed to write module file (%s), error: %s", node.Path, err)
+			return
+		}
+	}
+
+	RespondWithJSON(w, http.StatusOK, utility.ValidationResponse{Warnings: warnings})
+}
+
+// PostBitriseYMLTreeMergeHandler flattens the posted (possibly-edited) tree so the merged-config
+// view reflects in-memory edits without a reload.
+func PostBitriseYMLTreeMergeHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Body == nil {
+		RespondWithJSONBadRequestErrorMessage(w, "Empty request body")
+		return
+	}
+	defer func() {
+		if err := r.Body.Close(); err != nil {
+			log.Errorf("Failed to close request body, error: %s", err)
+		}
+	}()
+
+	var reqObj struct {
+		Root wireTreeNode `json:"root"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&reqObj); err != nil {
+		RespondWithJSONBadRequestErrorMessage(w, "Failed to read JSON input, error: %s", err)
+		return
+	}
+
+	tree := toConfigFileTree(reqObj.Root)
+	mergedYML, err := tree.Merge()
+	if err != nil {
+		log.Errorf("Failed to merge config tree, error: %s", err)
+		RespondWithJSONBadRequestErrorMessage(w, "Failed to merge config tree, error: %s", err)
+		return
+	}
+
+	RespondWithJSON(w, http.StatusOK, map[string]string{"merged_yml": mergedYML})
+}

--- a/apiserver/service/bitrise_config_tree_test.go
+++ b/apiserver/service/bitrise_config_tree_test.go
@@ -59,7 +59,7 @@ func TestGetBitriseYMLTreeHandler_nonModular(t *testing.T) {
 	config.BitriseYMLPath = "bitrise.yml"
 
 	rr := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/api/bitrise-yml/tree", nil)
+	req := httptest.NewRequest("GET", "/api/bitrise-yml/tree", nil)
 	http.HandlerFunc(GetBitriseYMLTreeHandler).ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
@@ -87,7 +87,7 @@ func TestGetBitriseYMLTreeHandler_modular(t *testing.T) {
 	config.BitriseYMLPath = "bitrise.yml"
 
 	rr := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/api/bitrise-yml/tree", nil)
+	req := httptest.NewRequest("GET", "/api/bitrise-yml/tree", nil)
 	http.HandlerFunc(GetBitriseYMLTreeHandler).ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
@@ -135,10 +135,11 @@ func TestPostBitriseYMLTreeHandler_writesEditableModified(t *testing.T) {
 			}},
 		},
 	}
-	body, _ := json.Marshal(payload)
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/api/bitrise-yml/tree", bytes.NewReader(body))
+	req := httptest.NewRequest("POST", "/api/bitrise-yml/tree", bytes.NewReader(body))
 	http.HandlerFunc(PostBitriseYMLTreeHandler).ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
@@ -159,10 +160,11 @@ func TestPostBitriseYMLTreeMergeHandler(t *testing.T) {
 			}},
 		},
 	}
-	body, _ := json.Marshal(payload)
+	body, err := json.Marshal(payload)
+	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
-	req, _ := http.NewRequest("POST", "/api/bitrise-yml/tree/merge", bytes.NewReader(body))
+	req := httptest.NewRequest("POST", "/api/bitrise-yml/tree/merge", bytes.NewReader(body))
 	http.HandlerFunc(PostBitriseYMLTreeMergeHandler).ServeHTTP(rr, req)
 
 	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())

--- a/apiserver/service/bitrise_config_tree_test.go
+++ b/apiserver/service/bitrise_config_tree_test.go
@@ -1,0 +1,173 @@
+package service
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/bitrise-io/bitrise-workflow-editor/apiserver/config"
+	"github.com/bitrise-io/go-utils/fileutil"
+	"github.com/stretchr/testify/require"
+)
+
+// configmerge resolves local include paths relative to the process working directory (the CLI
+// runs from the repo root), so tests chdir into the fixture dir.
+func withWorkdir(t *testing.T, dir string) {
+	t.Helper()
+	prev, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(dir))
+	t.Cleanup(func() { require.NoError(t, os.Chdir(prev)) })
+}
+
+func TestParseNodeKey(t *testing.T) {
+	t.Run("local same-branch is editable, no ref", func(t *testing.T) {
+		path, src, editable := parseNodeKey("modules/wf.yml")
+		require.Equal(t, "modules/wf.yml", path)
+		require.True(t, editable)
+		require.Equal(t, "modules/wf.yml", src.Path)
+		require.Nil(t, src.Repository)
+		require.Nil(t, src.Branch)
+	})
+
+	t.Run("cross-repo branch is read-only", func(t *testing.T) {
+		path, src, editable := parseNodeKey("repo:shared-modules,shared/build.yml@branch:main")
+		require.Equal(t, "shared/build.yml", path)
+		require.False(t, editable)
+		require.Equal(t, "shared-modules", *src.Repository)
+		require.Equal(t, "main", *src.Branch)
+	})
+
+	t.Run("pinned tag is read-only", func(t *testing.T) {
+		path, src, editable := parseNodeKey("pinned/release.yml@tag:v1.4.0")
+		require.Equal(t, "pinned/release.yml", path)
+		require.False(t, editable)
+		require.Equal(t, "v1.4.0", *src.Tag)
+		require.Nil(t, src.Repository)
+	})
+}
+
+func TestGetBitriseYMLTreeHandler_nonModular(t *testing.T) {
+	dir := t.TempDir()
+	withWorkdir(t, dir)
+	contents := "format_version: \"13\"\nworkflows:\n  build: {}\n"
+	require.NoError(t, fileutil.WriteStringToFile(filepath.Join(dir, "bitrise.yml"), contents))
+	config.BitriseYMLPath = "bitrise.yml"
+
+	rr := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/bitrise-yml/tree", nil)
+	http.HandlerFunc(GetBitriseYMLTreeHandler).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var resp getConfigTreeResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Equal(t, "bitrise.yml", resp.Root.Path)
+	require.True(t, resp.Root.Editable)
+	require.Nil(t, resp.Root.Source)
+	require.Empty(t, resp.Root.Includes)
+	require.Equal(t, contents, resp.MergedYML)
+}
+
+func TestGetBitriseYMLTreeHandler_modular(t *testing.T) {
+	dir := t.TempDir()
+	withWorkdir(t, dir)
+	require.NoError(t, fileutil.WriteStringToFile(
+		filepath.Join(dir, "bitrise.yml"),
+		"format_version: \"13\"\ninclude:\n  - path: modules/wf.yml\npipelines:\n  release:\n    workflows:\n      build: {}\n",
+	))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "modules"), 0o755))
+	require.NoError(t, fileutil.WriteStringToFile(
+		filepath.Join(dir, "modules", "wf.yml"),
+		"workflows:\n  build: {}\n",
+	))
+	config.BitriseYMLPath = "bitrise.yml"
+
+	rr := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/bitrise-yml/tree", nil)
+	http.HandlerFunc(GetBitriseYMLTreeHandler).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var resp getConfigTreeResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+
+	require.Equal(t, "bitrise.yml", resp.Root.Path)
+	require.Nil(t, resp.Root.Source)
+	require.Len(t, resp.Root.Includes, 1)
+
+	child := resp.Root.Includes[0]
+	require.Equal(t, "modules/wf.yml", child.Path)
+	require.True(t, child.Editable)
+	require.Equal(t, "modules/wf.yml", child.Source.Path)
+	require.NotEqual(t, resp.Root.NodeID, child.NodeID)
+
+	// Merged config stitches both files together.
+	require.Contains(t, resp.MergedYML, "build")
+	require.Contains(t, resp.MergedYML, "release")
+}
+
+func TestPostBitriseYMLTreeHandler_writesEditableModified(t *testing.T) {
+	dir := t.TempDir()
+	withWorkdir(t, dir)
+	require.NoError(t, fileutil.WriteStringToFile(filepath.Join(dir, "bitrise.yml"), "format_version: \"13\"\ninclude:\n  - path: modules/wf.yml\n"))
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "modules"), 0o755))
+	require.NoError(t, fileutil.WriteStringToFile(filepath.Join(dir, "modules", "wf.yml"), "workflows:\n  build: {}\n"))
+	config.BitriseYMLPath = "bitrise.yml"
+
+	payload := map[string]any{
+		"root": wireTreeNode{
+			NodeID:   "n_root",
+			Path:     "bitrise.yml",
+			Contents: "format_version: \"13\"\ninclude:\n  - path: modules/wf.yml\n",
+			Editable: true,
+			Modified: false,
+			Includes: []wireTreeNode{{
+				NodeID:   "n_wf",
+				Path:     "modules/wf.yml",
+				Contents: "workflows:\n  build: {}\n  deploy: {}\n",
+				Source:   &wireTreeNodeSource{Path: "modules/wf.yml"},
+				Editable: true,
+				Modified: true,
+				Includes: []wireTreeNode{},
+			}},
+		},
+	}
+	body, _ := json.Marshal(payload)
+
+	rr := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/bitrise-yml/tree", bytes.NewReader(body))
+	http.HandlerFunc(PostBitriseYMLTreeHandler).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	written, err := fileutil.ReadStringFromFile(filepath.Join(dir, "modules", "wf.yml"))
+	require.NoError(t, err)
+	require.Contains(t, written, "deploy")
+}
+
+func TestPostBitriseYMLTreeMergeHandler(t *testing.T) {
+	payload := map[string]any{
+		"root": wireTreeNode{
+			Path:     "bitrise.yml",
+			Contents: "format_version: \"13\"\ninclude:\n  - path: modules/wf.yml\npipelines:\n  release: {}\n",
+			Includes: []wireTreeNode{{
+				Path:     "modules/wf.yml",
+				Contents: "workflows:\n  build: {}\n",
+				Includes: []wireTreeNode{},
+			}},
+		},
+	}
+	body, _ := json.Marshal(payload)
+
+	rr := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/api/bitrise-yml/tree/merge", bytes.NewReader(body))
+	http.HandlerFunc(PostBitriseYMLTreeMergeHandler).ServeHTTP(rr, req)
+
+	require.Equal(t, http.StatusOK, rr.Code, rr.Body.String())
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &resp))
+	require.Contains(t, resp["merged_yml"], "build")
+	require.Contains(t, resp["merged_yml"], "release")
+}

--- a/source/javascripts/components/Header.tsx
+++ b/source/javascripts/components/Header.tsx
@@ -191,11 +191,14 @@ const Header = () => {
   // Local modular save: write changed module files to disk + reload the tree (no branch/PR locally).
   const { isPending: isSavingTree, mutate: saveConfigTree } = useSaveConfigTree({
     onSuccess: (config) => applyModularSaveResult({ root: config.root }),
-    onError: (error: ClientError) => {
+    onError: (error: Error) => {
       segmentTrack('Workflow Editor Invalid Yml Popup Shown', { source: 'save', tab_name: currentPage });
       toast({
         title: 'Failed to save changes',
-        description: error.getResponseErrorMessage() || error.message || 'Something went wrong',
+        description:
+          (error instanceof ClientError ? error.getResponseErrorMessage() : undefined) ||
+          error.message ||
+          'Something went wrong',
         status: 'error',
         duration: null,
         isClosable: true,

--- a/source/javascripts/components/Header.tsx
+++ b/source/javascripts/components/Header.tsx
@@ -21,6 +21,7 @@ import { segmentTrack } from '@/core/analytics/SegmentBaseTracking';
 import { PushBranchConflict } from '@/core/api/BranchesApi';
 import { ClientError } from '@/core/api/client';
 import {
+  applyModularSaveResult,
   bitriseYmlStore,
   discardBitriseYmlDocument,
   getTabLastLocation,
@@ -32,7 +33,7 @@ import { useCiConfigExpertStore } from '@/core/stores/CiConfigExpertStore';
 import PageProps from '@/core/utils/PageProps';
 import RuntimeUtils from '@/core/utils/RuntimeUtils';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
-import { useSaveCiConfig } from '@/hooks/useCiConfig';
+import { useSaveCiConfig, useSaveConfigTree } from '@/hooks/useCiConfig';
 import { useCiConfigSettings } from '@/hooks/useCiConfigSettings';
 import { closeAIDrawer } from '@/hooks/useCloseAIDrawer';
 import useCurrentPage from '@/hooks/useCurrentPage';
@@ -187,6 +188,23 @@ const Header = () => {
     onSuccess: initializeBitriseYmlDocument,
   });
 
+  // Local modular save: write changed module files to disk + reload the tree (no branch/PR locally).
+  const { isPending: isSavingTree, mutate: saveConfigTree } = useSaveConfigTree({
+    onSuccess: (config) => applyModularSaveResult({ root: config.root }),
+    onError: (error: ClientError) => {
+      segmentTrack('Workflow Editor Invalid Yml Popup Shown', { source: 'save', tab_name: currentPage });
+      toast({
+        title: 'Failed to save changes',
+        description: error.getResponseErrorMessage() || error.message || 'Something went wrong',
+        status: 'error',
+        duration: null,
+        isClosable: true,
+      });
+    },
+  });
+
+  const isSavingConfig = isSaving || isSavingTree;
+
   const { isPushPending, pushBranch, pushError, clearPushError } = usePushBranch({
     onSuccess: () => {
       closePushBranchDialog();
@@ -222,6 +240,12 @@ const Header = () => {
   const saveCIConfig = useCallback(
     (source: 'save_changes_button' | 'save_changes_keyboard_shortcut_pressed') => {
       trackSaveButtonClicked(source, currentPage, bitriseYmlStore.getState().configBranch, conversationId, turnCount);
+
+      // Local modular config: save straight to disk (there's no branch/PR locally).
+      if (isModular && !isWebsiteMode) {
+        saveConfigTree();
+        return;
+      }
 
       if (ciConfigSettings?.usesRepositoryYml) {
         if (enableBranchSwitching) {
@@ -267,6 +291,9 @@ const Header = () => {
       turnCount,
       ciConfigSettings?.usesRepositoryYml,
       save,
+      isModular,
+      isWebsiteMode,
+      saveConfigTree,
       appSlug,
       enableBranchSwitching,
       openPushBranchDialog,
@@ -292,7 +319,7 @@ const Header = () => {
   };
 
   useEventListener('keydown', (e: KeyboardEvent) => {
-    if ((e.ctrlKey || e.metaKey) && e.key === 's' && hasChanges && !isSaving) {
+    if ((e.ctrlKey || e.metaKey) && e.key === 's' && hasChanges && !isSavingConfig) {
       e.preventDefault();
 
       if (ymlStatus === 'invalid') {
@@ -364,7 +391,7 @@ const Header = () => {
           className="diff"
           variant="secondary"
           onClick={openDiffViewer}
-          isDisabled={!hasChanges || isSaving}
+          isDisabled={!hasChanges || isSavingConfig}
         >
           Show diff
         </Button>
@@ -374,7 +401,7 @@ const Header = () => {
           className="discard"
           variant="secondary"
           onClick={onDiscard}
-          isDisabled={!hasChanges || isSaving}
+          isDisabled={!hasChanges || isSavingConfig}
         >
           Discard
         </Button>
@@ -387,7 +414,7 @@ const Header = () => {
             size="sm"
             className="save"
             variant="primary"
-            isLoading={isSaving}
+            isLoading={isSavingConfig}
             isDisabled={!hasChanges || ymlStatus === 'invalid'}
             onClick={() => saveCIConfig('save_changes_button')}
           >

--- a/source/javascripts/core/api/BitriseYmlApi.spec.ts
+++ b/source/javascripts/core/api/BitriseYmlApi.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * @jest-environment jsdom
+ */
+import BitriseYmlApi from './BitriseYmlApi';
+
+// RuntimeUtils.isWebsiteMode() reads window.env.MODE === 'WEBSITE'.
+function setMode(mode?: string) {
+  (window as unknown as { env: { MODE?: string } }).env = { MODE: mode };
+}
+
+describe('BitriseYmlApi config-tree endpoints by mode', () => {
+  afterEach(() => setMode(undefined));
+
+  it('targets the local CLI apiserver endpoints outside website mode', () => {
+    setMode('LOCAL');
+    expect(BitriseYmlApi.configTreePath({ projectSlug: 'app-1' })).toBe('/api/bitrise-yml/tree');
+    expect(BitriseYmlApi.mergeConfigPath('app-1')).toBe('/api/bitrise-yml/tree/merge');
+  });
+
+  it('targets the app-scoped endpoints in website mode', () => {
+    setMode('WEBSITE');
+    expect(BitriseYmlApi.configTreePath({ projectSlug: 'app-1' })).toBe('/api/app/app-1/config/tree');
+    expect(BitriseYmlApi.mergeConfigPath('app-1')).toBe('/api/app/app-1/config/merge');
+  });
+});

--- a/source/javascripts/core/api/BitriseYmlApi.ts
+++ b/source/javascripts/core/api/BitriseYmlApi.ts
@@ -95,6 +95,9 @@ async function saveCiConfig({ data, version, tabOpenDuringSave, projectSlug, con
 
 const CONFIG_TREE_PATH = `/api/app/:projectSlug/config/tree`;
 const CONFIG_MERGE_PATH = `/api/app/:projectSlug/config/merge`;
+// Local (CLI apiserver) has no app slug; the same wire shape is served off the working repo.
+const LOCAL_CONFIG_TREE_PATH = `/api/bitrise-yml/tree`;
+const LOCAL_CONFIG_MERGE_PATH = `/api/bitrise-yml/tree/merge`;
 
 // Wire types are exported so MSW mock fixtures can `satisfies`-check against them.
 export type WireTreeNodeSource = {
@@ -178,7 +181,9 @@ function configTreePath({
   forceToReadFromRepo?: boolean;
   branch?: string;
 }) {
-  const basePath = CONFIG_TREE_PATH.replace(':projectSlug', projectSlug);
+  const basePath = RuntimeUtils.isWebsiteMode()
+    ? CONFIG_TREE_PATH.replace(':projectSlug', projectSlug)
+    : LOCAL_CONFIG_TREE_PATH;
 
   const queryParams = new URLSearchParams();
   if (forceToReadFromRepo) {
@@ -192,7 +197,9 @@ function configTreePath({
 }
 
 function mergeConfigPath(projectSlug: string) {
-  return CONFIG_MERGE_PATH.replace(':projectSlug', projectSlug);
+  return RuntimeUtils.isWebsiteMode()
+    ? CONFIG_MERGE_PATH.replace(':projectSlug', projectSlug)
+    : LOCAL_CONFIG_MERGE_PATH;
 }
 
 type GetConfigOptions = {
@@ -238,6 +245,17 @@ async function getMergedConfig({
   return { mergedYml: response?.merged_yml ?? '' };
 }
 
+/**
+ * Local (CLI) tree save: posts the full tree; the apiserver validates the merged config and writes
+ * each editable+modified module file to disk. There's no branch/PR locally — cloud saves via
+ * push-to-branch instead.
+ */
+async function saveConfigTree({ tree }: { tree: TreeNode }) {
+  return Client.post(LOCAL_CONFIG_TREE_PATH, {
+    body: JSON.stringify({ root: toWireTreeNode(tree) }),
+  });
+}
+
 export type { GetCiConfigResult };
 
 export default {
@@ -248,6 +266,7 @@ export default {
   configTreePath,
   mergeConfigPath,
   getMergedConfig,
+  saveConfigTree,
   // Exposed so push-to-branch (`BranchesApi.pushBranch`, the canonical tree-save
   // path) can serialize a full tree to the wire shape. Deliberate cross-client
   // import: both clients speak the same wire shape, and one owner beats a copy.

--- a/source/javascripts/hooks/useCiConfig.ts
+++ b/source/javascripts/hooks/useCiConfig.ts
@@ -2,6 +2,8 @@ import { UndefinedInitialDataOptions, useMutation, UseMutationOptions, useQuery 
 
 import BitriseYmlApi, { GetCiConfigResult } from '@/core/api/BitriseYmlApi';
 import { ClientError } from '@/core/api/client';
+import { GetConfigResponse } from '@/core/models/Tree';
+import { getModularConfigTree } from '@/core/stores/BitriseYmlStore';
 import PageProps from '@/core/utils/PageProps';
 import { getSearchParamsFromLocationHash, setSearchParamsInLocationHash } from '@/hooks/useSearchParams';
 
@@ -24,6 +26,7 @@ type UseSaveCiConfigProps = {
 
 type UseGetCiConfigOptions<T> = Omit<UndefinedInitialDataOptions<T, ClientError>, 'queryKey' | 'queryFn'>;
 type UseSaveCiConfigOptions = UseMutationOptions<GetCiConfigResult, ClientError, UseSaveCiConfigProps>;
+type UseSaveConfigTreeOptions = UseMutationOptions<GetConfigResponse, ClientError, void>;
 
 export function useGetCiConfig(props: UseGetCiConfigProps, options?: UseGetCiConfigOptions<GetCiConfigResult>) {
   return useQuery({
@@ -65,6 +68,26 @@ export function useSaveCiConfig(options?: UseSaveCiConfigOptions) {
       return BitriseYmlApi.getCiConfig({
         projectSlug: PageProps.appSlug(),
       });
+    },
+    ...options,
+  });
+}
+
+/**
+ * Local (CLI) modular save: writes every changed module file to disk via the apiserver, then
+ * reloads the tree so the merged view + per-file baselines refresh. Cloud saves via push-to-branch
+ * instead (`usePushBranch`). The reloaded tree is returned; the caller rebinds it via
+ * `applyModularSaveResult` in `onSuccess`.
+ */
+export function useSaveConfigTree(options?: UseSaveConfigTreeOptions) {
+  return useMutation({
+    mutationFn: async () => {
+      const tree = getModularConfigTree();
+      if (!tree) {
+        throw new Error('No modular config tree to save');
+      }
+      await BitriseYmlApi.saveConfigTree({ tree });
+      return BitriseYmlApi.getConfig({ projectSlug: PageProps.appSlug() });
     },
     ...options,
   });

--- a/source/javascripts/hooks/useCiConfig.ts
+++ b/source/javascripts/hooks/useCiConfig.ts
@@ -26,7 +26,9 @@ type UseSaveCiConfigProps = {
 
 type UseGetCiConfigOptions<T> = Omit<UndefinedInitialDataOptions<T, ClientError>, 'queryKey' | 'queryFn'>;
 type UseSaveCiConfigOptions = UseMutationOptions<GetCiConfigResult, ClientError, UseSaveCiConfigProps>;
-type UseSaveConfigTreeOptions = UseMutationOptions<GetConfigResponse, ClientError, void>;
+// Error (not ClientError): most failures are ClientError from the API, but the guard below can
+// throw a plain Error, so consumers must handle both.
+type UseSaveConfigTreeOptions = UseMutationOptions<GetConfigResponse, Error, void>;
 
 export function useGetCiConfig(props: UseGetCiConfigProps, options?: UseGetCiConfigOptions<GetCiConfigResult>) {
   return useQuery({

--- a/source/javascripts/main.tsx
+++ b/source/javascripts/main.tsx
@@ -104,13 +104,14 @@ const InitialDataLoader = ({ children }: PropsWithChildren) => {
   useYmlLanguageServices();
   useCloseAIDrawer();
 
-  // Modular editing only makes sense for repo-stored configs (where includes/modules can
-  // exist). A Bitrise-stored config can't have modules, so even with the flag on it must
-  // use the legacy single-file flow — otherwise we'd build a tree (and show file tabs) for
-  // a config that has none. CLI mode has no Bitrise storage, so the flag alone decides there.
+  // Modular editing only makes sense for repo-stored configs (where includes/modules can exist);
+  // a Bitrise-stored config can't have modules, so it stays on the legacy single-file flow even
+  // with the flag on. In website mode it's ramped behind the LD flag. CLI mode has no LaunchDarkly
+  // (and no Bitrise storage), so it's simply on — a non-modular config resolves to a single-node
+  // tree, which the editor drives exactly like the single-file flow.
   const isModularFlagEnabled = useFeatureFlag('enable-wfe-modular-yaml-editing');
   const canBeModular = !isWebsiteMode || ymlSettings?.usesRepositoryYml === true;
-  const isModularEnabled = isModularFlagEnabled && canBeModular;
+  const isModularEnabled = canBeModular && (isWebsiteMode ? isModularFlagEnabled : true);
 
   // In website mode with the flag on, the storage type decides which endpoint to hit, so
   // wait for the settings to resolve before fetching (don't fire the tree query then switch


### PR DESCRIPTION
## What

Brings modular (`include:`) YML editing to the **local** Workflow Editor (the CLI apiserver), with the same experience as cloud — tree of module tabs, per-file editing, merged view, and save. The frontend is unchanged in shape; only the endpoints differ by mode.

## Backend (CLI apiserver, Go)

New handlers in `apiserver/service/bitrise_config_tree.go` (+ routes):

- `GET /api/bitrise-yml/tree` — resolves the include tree from disk via the bitrise CLI's `configmerge`, returns the same wire shape as the hosted `/config/tree` plus the merged YAML. A non-modular config comes back as a single root node, so the FE consumes one shape. `node_id` / `source` / `editable` are derived from the configmerge tree key (cross-ref nodes — other repo/branch/tag/commit — load **read-only**, matching cloud). No entity index is sent; the FE builds it.
- `POST /api/bitrise-yml/tree` — validates the **merged** tree (merged-only, like cloud), then writes each **editable + modified** module file to disk. Read-only files are never written; unmodified files are skipped.
- `POST /api/bitrise-yml/tree/merge` — flattens the posted (possibly-edited) tree so the merged view reflects in-memory edits.

## Frontend

Same code as cloud, mode-aware endpoints:

- `BitriseYmlApi`: `configTreePath` / `mergeConfigPath` branch on `isWebsiteMode` (local → `/api/bitrise-yml/tree[/merge]`, no app slug); new `saveConfigTree` for the local disk save.
- `useSaveConfigTree`: write the tree to disk, then reload it.
- `Header`: local modular save writes to disk + reloads (there's no branch/PR locally — cloud still saves via push-to-branch); Save button pending state includes it.
- `main.tsx`: the modular LD flag gates **website only**. Local has no LaunchDarkly, so modular is simply on — a non-modular config resolves to a single-node tree and is driven exactly like the single-file flow.

## Testing

- Go: `parseNodeKey` (local / x-repo / x-tag), tree GET (non-modular + modular), tree save (writes editable+modified), tree merge — all green. `go build` / `go vet` clean.
- FE: `tsc` clean, eslint clean; jest green for the API path-branching spec, the modular store, and merged-config sync.

## Notes / follow-ups

- Cross-ref (x-repo / branch / tag / commit) files load read-only locally, same as cloud; `configmerge` fetches x-repo modules via local git for the merged view.
- Not yet exercised end-to-end inside the packaged CLI plugin against a real modular repo — worth a manual smoke test before GA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)