### PR TITLE
Replace manual validation with react-hook-form

### DIFF
--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -9,10 +9,15 @@ import {
 } from '@bitrise/bitkit-v2';
 import { Box } from '@chakra-ui/react/box';
 import { Text } from '@chakra-ui/react/text';
-import { FocusEventHandler, useState } from 'react';
+import { useState } from 'react';
+import { useController, useForm } from 'react-hook-form';
 
 import { ToolCatalog, VersionStrategy } from '@/core/models/Tools';
 import ToolsService from '@/core/services/ToolsService';
+
+type ToolRowFormValues = {
+  toolId: string;
+};
 
 const STRATEGY_LABELS: Record<VersionStrategy, string> = {
   'latest-released': 'Latest released version',
@@ -54,7 +59,17 @@ const ToolRow = ({
 }: ToolRowProps) => {
   // Whether the user has explicitly picked "Other" from the dropdown.
   const [manualOther, setManualOther] = useState(false);
-  const [idError, setIdError] = useState<string | undefined>();
+
+  const { control } = useForm<ToolRowFormValues>({
+    mode: 'onChange',
+    values: { toolId },
+  });
+
+  const { field: toolIdField, fieldState: toolIdFieldState } = useController({
+    control,
+    name: 'toolId',
+    rules: { validate: (value) => ToolsService.validateToolId(value.trim(), toolId, existingToolIds, catalog) },
+  });
 
   const isCatalogReady = !!catalog;
   const isToolIdKnown = ToolsService.isKnownToolId(catalog, toolId);
@@ -77,21 +92,18 @@ const ToolRow = ({
       return;
     }
     setManualOther(false);
-    setIdError(undefined);
     if (newValue !== toolId) {
       onIdChange(newValue);
     }
   };
 
-  const handleIdBlur: FocusEventHandler<HTMLInputElement> = (e) => {
-    const newId = e.target.value.trim();
-    const validation = ToolsService.validateToolId(newId, toolId, existingToolIds, catalog);
-    if (validation !== true) {
-      setIdError(validation);
+  const handleIdBlur = () => {
+    toolIdField.onBlur();
+    if (toolIdFieldState.error) {
       return;
     }
-    setIdError(undefined);
     setManualOther(false);
+    const newId = toolIdField.value.trim();
     if (newId !== toolId) {
       onIdChange(newId);
     }
@@ -120,8 +132,12 @@ const ToolRow = ({
             <BitkitTextInput
               size="lg"
               placeholder="Tool ID (e.g. deno)"
-              errorText={idError}
-              inputProps={{ defaultValue: toolId, autoFocus, onBlur: handleIdBlur }}
+              errorText={toolIdFieldState.error?.message}
+              inputProps={{
+                ...toolIdField,
+                autoFocus,
+                onBlur: handleIdBlur,
+              }}
             />
           )}
         </Box>

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -35,7 +35,6 @@ type ToolRowProps = {
   existingToolIds: string[];
   catalog: ToolCatalog | undefined;
   allowUnset?: boolean;
-  autoFocus?: boolean;
   isCatalogLoading: boolean;
   onIdChange: (newId: string) => void;
   onStrategyChange: (strategy: VersionStrategy, version: string) => void;
@@ -50,7 +49,6 @@ const ToolRow = ({
   existingToolIds,
   catalog,
   allowUnset,
-  autoFocus,
   isCatalogLoading,
   onIdChange,
   onStrategyChange,
@@ -126,7 +124,6 @@ const ToolRow = ({
             items={dropdownItems}
             value={showCustomInput ? OTHER_VALUE : toolId}
             onValueChange={handleDropdownChange}
-            triggerProps={showCustomInput ? undefined : { autoFocus }}
           />
           {showCustomInput && (
             <BitkitTextInput
@@ -135,7 +132,6 @@ const ToolRow = ({
               errorText={toolIdFieldState.error?.message}
               inputProps={{
                 ...toolIdField,
-                autoFocus,
                 onBlur: handleIdBlur,
               }}
             />

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -69,7 +69,6 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
             existingToolIds={existingToolIds}
             catalog={catalog}
             allowUnset={allowUnset}
-            autoFocus
             isCatalogLoading={isCatalogLoading}
             onIdChange={(newId) => {
               ToolsService.setTool(newId, pendingStrategy, pendingVersion, scope);


### PR DESCRIPTION
Current tool setup input validation is hand-rolled, and before https://github.com/bitrise-io/bitrise-workflow-editor/pull/1842 adds even more complexity to it, I think it would make sense to use `react-hook-form`, just like in other parts of the codebase.

### Changes:
- Replace manual validation and state handling with RHF
- [Separate commit] The above change caused a weird bug around the `manualOther` state, and form validation flipping the state back to `false` when selecting `Other` from the dropdown. I'm not 100% sure of the root cause, but this made me realize that the whole autofocus logic is largely irrelevant now that a new pending row doesn't render a text input as its initial state. So I decided to clean up autofocus logic completely, and it resolved the original bug.