### PR TITLE
Modular YAML: Workflow Editor modular-config analytics + header subtitle size (BIVS-3743)

### DIFF
--- a/source/javascripts/components/FileTreeViewer/FileTreeViewer.tsx
+++ b/source/javascripts/components/FileTreeViewer/FileTreeViewer.tsx
@@ -1,5 +1,7 @@
 import { BitkitPopover } from '@bitrise/bitkit-v2';
 
+import { trackWorkflowEditorYmlModuleOpened } from '@/core/analytics/ConfigManagementAnalytics';
+import { bitriseYmlStore } from '@/core/stores/BitriseYmlStore';
 import { useFileTabs } from '@/hooks/useFileTabs';
 import { useSelectedNodeId, useTree } from '@/hooks/useTree';
 
@@ -35,6 +37,11 @@ const FileTreeViewer = ({ open, onOpenChange, getAnchor }: Props) => {
         rootNode={tree}
         selectedNodeId={selectedNodeId}
         onSelect={(nodeId) => {
+          // Only a not-yet-open tab counts as opening a module (re-selecting an open tab doesn't).
+          const alreadyOpen = bitriseYmlStore.getState().openTabs.some((tab) => tab.nodeId === nodeId);
+          if (!alreadyOpen) {
+            trackWorkflowEditorYmlModuleOpened({ openMethod: 'file_explorer' });
+          }
           openFile(nodeId);
           onOpenChange(false);
         }}

--- a/source/javascripts/components/Navigation.tsx
+++ b/source/javascripts/components/Navigation.tsx
@@ -13,7 +13,7 @@ import {
 import { PropsWithChildren, useCallback, useEffect, useRef } from 'react';
 
 import { segmentTrack } from '@/core/analytics/SegmentBaseTracking';
-import { getYmlString, updateBitriseYmlDocumentByString } from '@/core/stores/BitriseYmlStore';
+import { bitriseYmlStore, getYmlString, updateBitriseYmlDocumentByString } from '@/core/stores/BitriseYmlStore';
 import { useCiConfigExpertStore } from '@/core/stores/CiConfigExpertStore';
 import PageProps from '@/core/utils/PageProps';
 import RuntimeUtils from '@/core/utils/RuntimeUtils';
@@ -112,6 +112,7 @@ const Navigation = (props: Props) => {
       tab_name: currentPage,
       is_default_tab: isDefaultTabRef.current,
       yml_source: data?.usesRepositoryYml ? 'git' : 'bitrise',
+      is_modular_config: Boolean(bitriseYmlStore.getState().tree),
     });
     isDefaultTabRef.current = false;
   }, [currentPage, data?.usesRepositoryYml]);

--- a/source/javascripts/components/unified-editor/WorkflowConfig/components/WorkflowConfigHeader.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowConfig/components/WorkflowConfigHeader.tsx
@@ -53,15 +53,16 @@ const WorkflowConfigHeader = ({ variant, context, parentWorkflowId }: Props) => 
             {title || id || 'Workflow'}
           </Text>
           {showSubTitle && !isCrossFile && (
-            <Text textStyle="body/sm/regular" color="text/secondary">
+            <Text textStyle="body/md/regular" color="text/secondary">
               {WorkflowService.getUsedByText(dependants)}
             </Text>
           )}
           {showDefinitionLink && (
-            <Text textStyle="body/sm/regular" color="text/secondary">
+            <Text textStyle="body/md/regular" color="text/secondary">
               <EntityModuleProvenance
                 kind="workflows"
                 id={id}
+                pathTextStyle="body/md/semibold"
                 fallback={<JumpToDefinitionLink kind="workflows" id={id} />}
               />
             </Text>

--- a/source/javascripts/core/analytics/ConfigManagementAnalytics.ts
+++ b/source/javascripts/core/analytics/ConfigManagementAnalytics.ts
@@ -1,9 +1,67 @@
+import { EntityKind, TreeNode } from '@/core/models/Tree';
+import { bitriseYmlStore, isFileDirty } from '@/core/stores/BitriseYmlStore';
 import GlobalProps from '@/core/utils/GlobalProps';
 import PageProps from '@/core/utils/PageProps';
 
 import { segmentTrack } from './SegmentBaseTracking';
 
 type YmlSource = 'git' | 'bitrise';
+
+/** How a YAML module tab was opened, for `Workflow Editor Yml Module Opened`. */
+export type ModuleOpenMethod = 'file_explorer' | 'edit_definition';
+
+// The Avo tracking plan uses singular entity_type values; map our internal EntityKind to them.
+const ENTITY_TYPE_BY_KIND: Record<EntityKind, string> = {
+  workflows: 'workflow',
+  pipelines: 'pipeline',
+  stepBundles: 'step_bundle',
+  containers: 'container',
+  appEnvs: 'env_var',
+};
+
+/**
+ * Modular-config properties shared by several events: whether the config is modular (has any
+ * include) and, if so, how many includes it has in total and how many of those are cross-repo.
+ * Derived from the loaded tree; `{ is_modular_config: false }` in single-file mode.
+ */
+function modularConfigProps() {
+  const { tree } = bitriseYmlStore.getState();
+  if (!tree) {
+    return { is_modular_config: false as const };
+  }
+
+  let includes = 0;
+  let crossRepoIncludes = 0;
+  const walk = (node: TreeNode) => {
+    node.includes.forEach((child) => {
+      includes += 1;
+      if (child.source?.repository) {
+        crossRepoIncludes += 1;
+      }
+      walk(child);
+    });
+  };
+  walk(tree);
+
+  return {
+    is_modular_config: true as const,
+    number_of_includes_in_bitrise_yml: includes,
+    number_of_cross_repo_includes_in_bitrise_yml: crossRepoIncludes,
+  };
+}
+
+/**
+ * How many module files changed in the current save/push. In modular mode it's the number of files
+ * with unsaved edits; in single-file mode the one root bitrise.yml counts as the single changed
+ * module (a push only happens when there are changes).
+ */
+function changedModulesCount() {
+  const { tree, files } = bitriseYmlStore.getState();
+  if (!tree) {
+    return 1;
+  }
+  return Object.values(files).filter((file) => isFileDirty(file)).length;
+}
 
 export function trackSaveButtonClicked(
   source: 'save_changes_button' | 'save_changes_keyboard_shortcut_pressed',
@@ -137,6 +195,8 @@ export function trackPushConfigChangesAttempted(currentBranch: string | undefine
     target_branch: targetBranch,
     is_new_target_branch: targetBranch !== currentBranch,
     default_branch: PageProps.app()?.defaultBranch,
+    ...modularConfigProps(),
+    number_of_modules_changed: changedModulesCount(),
   });
 }
 
@@ -149,6 +209,9 @@ export function trackPushConfigChangesSucceeded(currentBranch: string | undefine
     target_branch: targetBranch,
     is_new_target_branch: targetBranch !== currentBranch,
     default_branch: PageProps.app()?.defaultBranch,
+    ...modularConfigProps(),
+    // Tracked before the post-push reload clears the local dirty state, so the count is still accurate.
+    number_of_modules_changed: changedModulesCount(),
   });
 }
 
@@ -166,6 +229,8 @@ export function trackPushConfigChangesFailed(
     is_new_target_branch: targetBranch !== currentBranch,
     default_branch: PageProps.app()?.defaultBranch,
     error_reason: errorReason,
+    ...modularConfigProps(),
+    number_of_modules_changed: changedModulesCount(),
   });
 }
 
@@ -185,6 +250,45 @@ export function trackConfigBranchLoaded(currentBranch: string | undefined) {
     git_provider: PageProps.app()?.gitProvider,
     current_branch: currentBranch,
     default_branch: PageProps.app()?.defaultBranch,
+    ...modularConfigProps(),
+  });
+}
+
+/**
+ * The user opened the file-explorer drawer (the "+" at the end of the module tab bar) to open a
+ * YAML module. — Avo dc-5427
+ */
+export function trackWorkflowEditorFileExplorerOpened() {
+  segmentTrack('Workflow Editor File Explorer Opened', {
+    app_slug: PageProps.appSlug(),
+    workspace_slug: GlobalProps.workspaceSlug(),
+    platform: 'website',
+  });
+}
+
+/**
+ * A YAML module was opened as a tab (next to the read-only Merged Config tab). `openMethod` is the
+ * source that opened it; `entityType` / `numberOfDefinitions` are only sent for `edit_definition`
+ * (the "Edit definition" jump). — Avo dc-5427
+ */
+export function trackWorkflowEditorYmlModuleOpened({
+  openMethod,
+  entityKind,
+  numberOfDefinitions,
+}: {
+  openMethod: ModuleOpenMethod;
+  entityKind?: EntityKind;
+  numberOfDefinitions?: number;
+}) {
+  segmentTrack('Workflow Editor Yml Module Opened', {
+    app_slug: PageProps.appSlug(),
+    workspace_slug: GlobalProps.workspaceSlug(),
+    platform: 'website',
+    open_method: openMethod,
+    ...(openMethod === 'edit_definition' && {
+      entity_type: entityKind ? ENTITY_TYPE_BY_KIND[entityKind] : 'other',
+      number_of_definitions: numberOfDefinitions,
+    }),
   });
 }
 

--- a/source/javascripts/hooks/useJumpToDefinition.ts
+++ b/source/javascripts/hooks/useJumpToDefinition.ts
@@ -1,8 +1,9 @@
 import { useCallback } from 'react';
 
+import { trackWorkflowEditorYmlModuleOpened } from '@/core/analytics/ConfigManagementAnalytics';
 import { EntityKind } from '@/core/models/Tree';
 import EntityIndexService from '@/core/services/EntityIndexService';
-import { openTab, recordActiveTabLocation } from '@/core/stores/BitriseYmlStore';
+import { bitriseYmlStore, openTab, recordActiveTabLocation } from '@/core/stores/BitriseYmlStore';
 import { useEntityIndex } from '@/hooks/useEntityIndex';
 import useNavigation from '@/hooks/useNavigation';
 import useSearchParams from '@/hooks/useSearchParams';
@@ -43,6 +44,18 @@ export default function useJumpToDefinition() {
 
       // Record the current tab's page before switching away, so return restores it.
       recordActiveTabLocation(window.parent.location.hash);
+
+      // Opening the defining file's tab counts as opening a YAML module (edit_definition source);
+      // only a not-yet-open tab is a new open. number_of_definitions is the count that decided
+      // whether a picker was shown (1 = jumped directly, >1 = selection list).
+      const alreadyOpen = bitriseYmlStore.getState().openTabs.some((tab) => tab.nodeId === nodeId);
+      if (!alreadyOpen) {
+        trackWorkflowEditorYmlModuleOpened({
+          openMethod: 'edit_definition',
+          entityKind: kind,
+          numberOfDefinitions: EntityIndexService.definitionsOf(entityIndex, kind, id).length,
+        });
+      }
 
       openTab(nodeId, { preview: false });
 

--- a/source/javascripts/pages/YmlPage/components/OpenFileTabs/OpenFileTabs.tsx
+++ b/source/javascripts/pages/YmlPage/components/OpenFileTabs/OpenFileTabs.tsx
@@ -2,6 +2,7 @@ import { BitkitTabs, IconGroup } from '@bitrise/bitkit-v2';
 import { useRef, useState } from 'react';
 
 import FileTreeViewer from '@/components/FileTreeViewer/FileTreeViewer';
+import { trackWorkflowEditorFileExplorerOpened } from '@/core/analytics/ConfigManagementAnalytics';
 import { FileTabInfo, useFileTabs } from '@/hooks/useFileTabs';
 
 import DiscardFileTabDialog from './DiscardFileTabDialog';
@@ -54,7 +55,19 @@ const OpenFileTabs = () => {
             {tab.name}
           </BitkitTabs.Trigger>
         ))}
-        <BitkitTabs.AddButton ref={addButtonRef} label="Open module" onClick={() => setPickerOpen((open) => !open)} />
+        <BitkitTabs.AddButton
+          ref={addButtonRef}
+          label="Open module"
+          onClick={() =>
+            setPickerOpen((open) => {
+              const next = !open;
+              if (next) {
+                trackWorkflowEditorFileExplorerOpened();
+              }
+              return next;
+            })
+          }
+        />
       </BitkitTabs.List>
 
       <FileTreeViewer open={pickerOpen} onOpenChange={setPickerOpen} getAnchor={() => addButtonRef.current} />

--- a/source/javascripts/pages/YmlPage/components/OpenFileTabs/OpenFileTabs.tsx
+++ b/source/javascripts/pages/YmlPage/components/OpenFileTabs/OpenFileTabs.tsx
@@ -58,15 +58,14 @@ const OpenFileTabs = () => {
         <BitkitTabs.AddButton
           ref={addButtonRef}
           label="Open module"
-          onClick={() =>
-            setPickerOpen((open) => {
-              const next = !open;
-              if (next) {
-                trackWorkflowEditorFileExplorerOpened();
-              }
-              return next;
-            })
-          }
+          onClick={() => {
+            // Keep the analytics side effect out of the state updater (React may call updaters more
+            // than once, e.g. in StrictMode) — fire once here, only when opening.
+            if (!pickerOpen) {
+              trackWorkflowEditorFileExplorerOpened();
+            }
+            setPickerOpen((open) => !open);
+          }}
         />
       </BitkitTabs.List>
 


### PR DESCRIPTION
Modular-YAML follow-up work ([BIVS-3664](https://bitrise.atlassian.net/browse/BIVS-3664)).

## Analytics — [BIVS-3743](https://bitrise.atlassian.net/browse/BIVS-3743)
FE side of the Avo `dc-5427-modular-yaml-wfe` tracking plan ([Avo diff](https://www.avo.app/schemas/Mi3XJPNK9kXZDWP4AHCy/branches/KDZz3Wbh_FG_UDLuVrslr/diff)).

**New events**
- **Workflow Editor File Explorer Opened** — the "+" at the end of the module tab bar (opening the file-explorer drawer).
- **Workflow Editor Yml Module Opened** — a YAML module opened as a tab. `open_method` is `file_explorer` (module picker) or `edit_definition` (jump-to-definition, which also sends `entity_type` + `number_of_definitions`). Fires only on a *new* tab open, not on re-selecting an already-open tab.

**Modular props added to existing events**
- **Push Config Changes Attempted / Succeeded / Failed** — `is_modular_config`, `number_of_modules_changed`.
- **Config Branch Loaded** — `is_modular_config`, `number_of_includes_in_bitrise_yml`, `number_of_cross_repo_includes_in_bitrise_yml`.
- **Workflow Editor Tab Displayed** — `is_modular_config`.

Shared helpers (`modularConfigProps` / `changedModulesCount`) derive the values from the loaded tree + dirty files. Decisions worth a look: include counts are over the whole tree (not just root-level); `number_of_modules_changed` is the dirty-file count (1 in single-file mode); Yml Module Opened fires for any file tab opened via the picker (incl. the root). BE-emitted events (`Workflow Or Pipeline Saved`, `Bitrise Yml Validation Passed/Failed`) are out of scope.

## UI — [BIVS-3706](https://bitrise.atlassian.net/browse/BIVS-3706)
- The Workflow config header subtitle ("Used by …", "Also defined in … • Edit definition") uses `body/md` so it matches the `md` jump link — consistent with the already-`md` step-bundle config header.

## Tests
`tsc` clean, eslint clean, full unit suite green (1415).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[BIVS-3664]: https://bitrise.atlassian.net/browse/BIVS-3664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BIVS-3743]: https://bitrise.atlassian.net/browse/BIVS-3743?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[BIVS-3706]: https://bitrise.atlassian.net/browse/BIVS-3706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ