### PR TITLE
fix: add missing article to "Create new branch" label

### DIFF
--- a/source/javascripts/components/unified-editor/PushBranchDialog/PushBranchDialog.tsx
+++ b/source/javascripts/components/unified-editor/PushBranchDialog/PushBranchDialog.tsx
@@ -110,7 +110,7 @@ const PushBranchDialog = ({ isOpen, onClose, isPushPending, pushError, onPush, o
         }}
       >
         <BitkitRadio value="current" labelText="Push to current branch" />
-        <BitkitRadio value="new" labelText="Create new branch" />
+        <BitkitRadio value="new" labelText="Create a new branch" />
       </BitkitRadioGroup>
       <Controller
         control={control}


### PR DESCRIPTION
## What

Changes the Push changes dialog's branch-creation option label from **"Create new branch"** to **"Create a new branch"**.

## Why

This started with [bitrise-io/docs#35](https://github.com/bitrise-io/docs/pull/35) — a docs note explaining that when branch protection blocks **Push to current branch**, users should use **Create a new branch** instead. While reviewing that PR, we noticed the docs already say "Create a new **branch**" correctly, but the live Workflow Editor button drops the article. "Branch" is a singular countable noun and needs a determiner (same reason you'd say "create a file," not "create file") — so the docs were right and the product copy wasn't.

Grepping for the same pattern (verb + "new" + singular noun, missing article) turned up 8 more instances of the identical issue in `bitrise-website`, fixed in a companion PR: [bitrise-io/bitrise-website#20371](https://github.com/bitrise-io/bitrise-website/pull/20371). The same repo also has correctly-formed examples for the identical construction (e.g. "Create a new Workflow" in `ChainableWorkflowList.tsx`), confirming this is a real, unenforced inconsistency rather than a deliberate style choice.

Also flagged (but out of scope here, since it's unrelated and not a code fix): the docs repo has no enforced convention on curly (’) vs. straight (') apostrophes — noted for visibility only.

## Test plan

- [x] No existing spec asserts on the old label text — confirmed via a full local Jest run (33 suites / 1421 tests, all passing)
- [x] `npx eslint` on the changed file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)