### PR TITLE
fix: modular YAML small fixes — analytics cycle guard + branch kept on merged-config tab

### DIFF
--- a/source/javascripts/core/analytics/ConfigManagementAnalytics.ts
+++ b/source/javascripts/core/analytics/ConfigManagementAnalytics.ts
@@ -32,7 +32,13 @@ function modularConfigProps() {
 
   let includes = 0;
   let crossRepoIncludes = 0;
+  // Cycle-guarded (same as EntityIndexService) so a malformed include graph can't recurse forever.
+  const seen = new Set<string>();
   const walk = (node: TreeNode) => {
+    if (seen.has(node.nodeId)) {
+      return;
+    }
+    seen.add(node.nodeId);
     node.includes.forEach((child) => {
       includes += 1;
       if (child.source?.repository) {

--- a/source/javascripts/hooks/useFileTabs.spec.tsx
+++ b/source/javascripts/hooks/useFileTabs.spec.tsx
@@ -1,0 +1,65 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react';
+
+import { TreeNode } from '@/core/models/Tree';
+import { initializeModularConfig } from '@/core/stores/BitriseYmlStore';
+
+import { useFileTabs } from './useFileTabs';
+
+function node(nodeId: string, overrides: Partial<TreeNode> = {}): TreeNode {
+  return {
+    nodeId,
+    path: `${nodeId}.yml`,
+    contents: `workflows:\n  ${nodeId}: {}\n`,
+    source: null,
+    commitSha: 'sha',
+    editable: true,
+    includes: [],
+    ...overrides,
+  };
+}
+
+function initModularConfig() {
+  initializeModularConfig({
+    root: node('root', {
+      path: 'bitrise.yml',
+      contents: 'format_version: "13"\n',
+      includes: [node('child-a')],
+    }),
+    branch: 'feature-x',
+    commitSha: 'abc',
+  });
+}
+
+describe('useFileTabs', () => {
+  describe('selectMergedConfig', () => {
+    beforeEach(() => {
+      initModularConfig();
+    });
+
+    // Regression: the branch lives in the ?branch= hash query and drives which branch's config is
+    // loaded. A first switch to the (not-yet-visited) merged-config tab lands on the default
+    // workflows page, which must carry the query over — otherwise the branch is dropped and the
+    // editor snaps back to the default branch.
+    it('keeps the ?branch= query when switching to a not-yet-visited merged-config tab', () => {
+      window.parent.location.hash = '#!/workflows?branch=feature-x';
+
+      const { result } = renderHook(() => useFileTabs());
+      act(() => result.current.selectMergedConfig());
+
+      expect(window.parent.location.hash).toContain('workflows');
+      expect(window.parent.location.hash).toContain('branch=feature-x');
+    });
+
+    it('does not append a stray query separator when there is no hash query', () => {
+      window.parent.location.hash = '#!/workflows';
+
+      const { result } = renderHook(() => useFileTabs());
+      act(() => result.current.selectMergedConfig());
+
+      expect(window.parent.location.hash).toBe('#!/workflows');
+    });
+  });
+});

--- a/source/javascripts/hooks/useFileTabs.ts
+++ b/source/javascripts/hooks/useFileTabs.ts
@@ -16,6 +16,7 @@ import {
 } from '@/core/stores/BitriseYmlStore';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
 import useHashLocation from '@/hooks/useHashLocation';
+import { getSearchParamsFromLocationHash } from '@/hooks/useSearchParams';
 import { paths } from '@/routes';
 
 /** A file tab enriched with everything the tab strip needs to render a trigger. */
@@ -31,6 +32,16 @@ export type FileTabInfo = {
 /** The live router location (raw hash) — read directly, not via the lagging snapshot. */
 function currentLocation(): string {
   return window.parent.location.hash;
+}
+
+/**
+ * Append the current hash query (notably `?branch=` in website mode) to a bare path. The active
+ * branch lives in the URL search params and drives which branch's config is loaded, so navigating
+ * to a paramless path would drop it and snap the editor back to the default branch.
+ */
+function withCurrentSearchParams(path: string): string {
+  const search = new URLSearchParams(getSearchParamsFromLocationHash()).toString();
+  return search ? `${path}?${search}` : path;
 }
 
 /**
@@ -82,7 +93,9 @@ export function useFileTabs() {
       const lastLocation = getTabLastLocation(nodeId);
 
       if (nodeId === MERGED_CONFIG_NODE_ID) {
-        navigate(lastLocation ?? paths.workflows);
+        // A recorded lastLocation already carries the branch param; the default landing page doesn't,
+        // so add it explicitly — otherwise a first switch to the merged tab drops the selected branch.
+        navigate(lastLocation ?? withCurrentSearchParams(paths.workflows));
         return;
       }
 


### PR DESCRIPTION
Small modular-YAML fixes collected on this branch.

## 1. Cycle-guard the modular-config analytics tree walk
`ConfigManagementAnalytics.modularConfigProps` recurses over `tree.includes` to derive the analytics props (`number_of_includes_in_bitrise_yml`, `number_of_cross_repo_includes_in_bitrise_yml`) with no cycle guard, so a malformed include graph (e.g. A includes B includes A) could recurse forever and hang/crash analytics tracking. Added a `seen`-set guard, mirroring the existing `EntityIndexService.visit` precedent.

Follow-up to [#1856](https://github.com/bitrise-io/bitrise-workflow-editor/pull/1856) — flagged by the Copilot review there, but that PR merged before the guard landed.

## 2. Keep the selected branch when switching to the merged-config tab
In modular mode on a non-default branch, switching to a **not-yet-visited** merged-config tab navigated to the bare workflows path (`paths.workflows`), which dropped the `?branch=` hash query. The branch lives in the URL search params and drives which branch's config is loaded, so the editor snapped back to the default branch and the branch selector reverted.

`useFileTabs.restoreTabLocation` now carries the current hash query onto the merged tab's default landing path. A recorded `lastLocation` already includes the query (so previously-visited tabs were unaffected); only the paramless default needed fixing.

## Test plan
- [x] `npx eslint` on the changed files — clean
- [x] `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)