### PR TITLE
fix: don't crash the editor on a parse-invalid YAML module

### DIFF
--- a/source/javascripts/core/utils/YmlUtils.spec.ts
+++ b/source/javascripts/core/utils/YmlUtils.spec.ts
@@ -1984,4 +1984,34 @@ describe('YmlUtils', () => {
       ).toThrow('Node at path "workflows.wf1.steps" is not a YAML Node');
     });
   });
+
+  describe('parse-error documents', () => {
+    // Malformed YAML: yaml's Document.toString()/stringify() would otherwise throw
+    // "Document with errors cannot be stringified".
+    const INVALID_YML = 'workflows:\n  a:\n    steps:\n  - : : :\n\tbad_tab\n';
+
+    it('toDoc parses malformed YAML into a document with errors (does not throw)', () => {
+      const doc = YmlUtils.toDoc(INVALID_YML);
+      expect(doc.errors.length).toBeGreaterThan(0);
+    });
+
+    it('toYml returns the raw source verbatim for a parse-error document instead of throwing', () => {
+      const doc = YmlUtils.toDoc(INVALID_YML);
+      expect(() => YmlUtils.toYml(doc)).not.toThrow();
+      expect(YmlUtils.toYml(doc)).toBe(INVALID_YML);
+    });
+
+    it('toYml still serializes valid documents normally', () => {
+      const doc = YmlUtils.toDoc(yaml`workflows: {}`);
+      expect(YmlUtils.toYml(doc)).toBe(yaml`workflows: {}`);
+    });
+
+    it('isEquals does not throw when comparing against a parse-error document', () => {
+      const invalid = YmlUtils.toDoc(INVALID_YML);
+      const valid = YmlUtils.toDoc(yaml`workflows: {}`);
+      expect(() => YmlUtils.isEquals(invalid, valid)).not.toThrow();
+      expect(YmlUtils.isEquals(invalid, valid)).toBe(false);
+      expect(YmlUtils.isEquals(invalid, YmlUtils.toDoc(INVALID_YML))).toBe(true);
+    });
+  });
 });

--- a/source/javascripts/core/utils/YmlUtils.ts
+++ b/source/javascripts/core/utils/YmlUtils.ts
@@ -51,14 +51,37 @@ type Callback = (node: Node, path: Path) => void;
 
 const PLACEHOLDER_DOC = new Document('', { stringKeys: true, keepSourceTokens: true });
 
+// yaml's `Document.toString()` (and therefore `stringify()` and our `toYml`) throws
+// "Document with errors cannot be stringified" once a document has parse errors, and node
+// `.toString()` in `isEquals` throws the same way. A malformed module would then crash every
+// serialization/equality path that touches it (e.g. the multi-file language service serializing
+// every include file on load). Documents can only be parse-invalid at load time — edits route
+// invalid YAML to `__invalidYmlString`, never into a stored document — so the raw source stashed
+// here at parse time is a lossless, throw-free fallback for that exact document.
+const rawSourceByErrorDoc = new WeakMap<Document, string>();
+
+/** The raw source for a parse-error document (stashed in `toDoc`), or undefined for a valid one. */
+function rawErrorSource(root: Root): string | undefined {
+  return isDocument(root) && root.errors.length > 0 ? rawSourceByErrorDoc.get(root) : undefined;
+}
+
 function toDoc(raw: string) {
-  return parseDocument(raw, {
+  const doc = parseDocument(raw, {
     stringKeys: true,
     keepSourceTokens: true,
   });
+  if (doc.errors.length > 0) {
+    rawSourceByErrorDoc.set(doc, raw);
+  }
+  return doc;
 }
 
 function toYml(root: Root) {
+  const rawError = rawErrorSource(root);
+  if (rawError !== undefined) {
+    return rawError;
+  }
+
   let indents = 0;
   let paddings = 0;
 
@@ -391,7 +414,10 @@ function isEquals(a: Root, b: Root) {
 
   // NOTE: Using toString() for equality check instead of toYml() as it's faster
   // and sufficient for our use case since it preserves all node structure and formatting.
-  aCache.set(b, a.toString() === b.toString());
+  // A parse-error document can't be stringified (yaml throws), so fall back to its raw source.
+  const aStr = rawErrorSource(a) ?? a.toString();
+  const bStr = rawErrorSource(b) ?? b.toString();
+  aCache.set(b, aStr === bStr);
 
   return aCache.get(b)!;
 }


### PR DESCRIPTION
## What
Makes `YmlUtils.toYml` and `YmlUtils.isEquals` throw-free for parse-invalid YAML documents by falling back to the raw source.

## Why
yaml's `Document.toString()` / `stringify()` throw **"Document with errors cannot be stringified"** once a document has parse errors, and node `.toString()` in `isEquals` throws the same way.

In modular mode the multi-file language service serializes **every** include file's document on load (`useYmlLanguageServices.desiredModels` → `YmlUtils.toYml`). So a single malformed include module threw an uncaught error and **blocked the whole editor from loading**:

```
Error: Document with errors cannot be stringified
  at e.toString (useBitriseYmlStore…)
  at Gr → Object.ai [as toYml]
  at ie (toYmlCached) → flatMap (desiredModels) → …
```

Introduced by #1854 (multi-file Bitrise language service).

## Fix
A document can only be parse-invalid at **load time** (`buildFileSlices` → `YmlUtils.toDoc(node.contents)`); edits route invalid YAML to `__invalidYmlString` and never store an error document. So `toDoc` stashes the raw source for error documents in a `WeakMap`, and `toYml` / `isEquals` return it **verbatim** — a lossless, throw-free fallback for that exact document. Valid documents are unaffected.

## Test plan
- [x] New `YmlUtils.spec.ts` cases: `toYml` returns raw source for an error doc (no throw), still serializes valid docs; `isEquals` doesn't throw against an error doc
- [x] `YmlUtils` + `BitriseYmlStore` suites green (299 tests)
- [x] `tsc --noEmit` + `eslint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)