### PR TITLE
fix: apply UX-reviewed copy correction to push-branch radio labels

### DIFF
--- a/source/javascripts/components/unified-editor/PushBranchDialog/PushBranchDialog.tsx
+++ b/source/javascripts/components/unified-editor/PushBranchDialog/PushBranchDialog.tsx
@@ -109,8 +109,8 @@ const PushBranchDialog = ({ isOpen, onClose, isPushPending, pushError, onPush, o
           );
         }}
       >
-        <BitkitRadio value="current" labelText="Push to current branch" />
-        <BitkitRadio value="new" labelText="Create a new branch" />
+        <BitkitRadio value="current" labelText="Current branch" />
+        <BitkitRadio value="new" labelText="New branch" />
       </BitkitRadioGroup>
       <Controller
         control={control}


### PR DESCRIPTION
## What

Changes the Push changes dialog's radio labels:
- "Push to current branch" → **"Current branch"**
- "Create a new branch" → **"New branch"**

This **supersedes #1858**, which merged with "Create a new branch" — that fix addressed a real grammar bug (a missing article) but was itself the wrong fix from a UX standpoint.

## Why

#1858 and its companion #20371 sparked a [Slack thread](https://bitfall.slack.com/archives/C0108APMADS/p1784812430665369) with Csaba Sipos ("Sipi") on the UX team. His review established Bitrise's actual UI microcopy convention: terse, headline-register, no articles at all. Applied here:

- **No articles** in UI strings (buttons, headings, dialog titles, labels).
- **Paired/sibling elements must match structure** — since the dialog title already says "Push changes", and the two radio options sit side by side, they shrink to plain, parallel noun-phrase form rather than "Push to X" / "Create a new Y".

This exact "Current branch" / "New branch" wording was confirmed with balazs.wagner in the same thread.

A parallel PR corrects 6 more instances of the same article-based over-fix in `bitrise-website` (companion to #20371). A docs PR will follow once this merges, since [docs#35](https://github.com/bitrise-io/docs/pull/35) quotes these exact radio labels.

## Test plan

- [x] No spec exists for `PushBranchDialog` (confirmed via full local Jest run — 35 suites / 1431 tests, all passing)
- [x] `npx eslint` on the changed file — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)