### PR TITLE
fix: surface located YAML parse errors and stop corrupting brace input values

### DIFF
--- a/source/javascripts/components/Header.tsx
+++ b/source/javascripts/components/Header.tsx
@@ -43,6 +43,7 @@ import useIsYmlParseError from '@/hooks/useIsYmlParseError';
 import usePushBranch, { PushBranchPayload } from '@/hooks/usePushBranch';
 import useSearchParams from '@/hooks/useSearchParams';
 import useYmlHasChanges from '@/hooks/useYmlHasChanges';
+import useYmlParseErrorMessage from '@/hooks/useYmlParseErrorMessage';
 import useYmlValidationStatus from '@/hooks/useYmlValidationStatus';
 import { usePipelinesPageStore } from '@/pages/PipelinesPage/PipelinesPage.store';
 import { useStepBundlesPageStore } from '@/pages/StepBundlesPage/StepBundlesPage.store';
@@ -75,6 +76,19 @@ const Header = () => {
   // YAML view on every schema-invalid load (SSW-3087).
   const ymlStatus = useYmlValidationStatus();
   const isParseError = useIsYmlParseError();
+
+  // Each of these points at the offending line when the config genuinely failed to parse, and falls
+  // back to the generic wording otherwise — `ymlStatus` also covers schema errors that have no
+  // location to name.
+  const switchToVisualErrorMessage = useYmlParseErrorMessage(
+    "YAML can't be parsed, please fix it before switching to the Visual editor.",
+    'switching to the Visual editor',
+  );
+  const saveErrorMessage = useYmlParseErrorMessage(
+    'Please fix the errors in your YAML configuration before saving.',
+    'saving',
+  );
+  const saveButtonErrorMessage = useYmlParseErrorMessage('YAML is invalid, please fix it before saving.', 'saving');
 
   const [path, navigate] = useHashLocation();
   const [searchParams] = useSearchParams();
@@ -334,7 +348,7 @@ const Header = () => {
       if (ymlStatus === 'invalid') {
         toast({
           title: 'YAML is invalid',
-          description: 'Please fix the errors in your YAML configuration before saving.',
+          description: saveErrorMessage,
           status: 'error',
           duration: null,
           isClosable: true,
@@ -381,7 +395,7 @@ const Header = () => {
       <BitkitTooltip
         disabled={!isParseError}
         placement={isMobile ? 'bottom' : 'bottom-start'}
-        text="YAML can't be parsed, please fix it before switching to the Visual editor."
+        text={switchToVisualErrorMessage}
       >
         <BitkitSegmentedControl
           size="sm"
@@ -429,7 +443,7 @@ const Header = () => {
         <Tooltip
           isDisabled={ymlStatus !== 'invalid'}
           placement={isMobile ? 'bottom' : 'bottom-start'}
-          label="YAML is invalid, please fix it before saving."
+          label={saveButtonErrorMessage}
         >
           <Button
             size="sm"

--- a/source/javascripts/components/Navigation.tsx
+++ b/source/javascripts/components/Navigation.tsx
@@ -18,14 +18,13 @@ import { useCiConfigExpertStore } from '@/core/stores/CiConfigExpertStore';
 import PageProps from '@/core/utils/PageProps';
 import RuntimeUtils from '@/core/utils/RuntimeUtils';
 import WindowUtils from '@/core/utils/WindowUtils';
-import YmlUtils from '@/core/utils/YmlUtils';
 import { useCiConfigSettings } from '@/hooks/useCiConfigSettings';
 import useCurrentPage from '@/hooks/useCurrentPage';
 import useHashLocation from '@/hooks/useHashLocation';
 import useIsYmlParseError from '@/hooks/useIsYmlParseError';
 import useParentMessageListener from '@/hooks/useParentMessageListener';
 import useSearchParams from '@/hooks/useSearchParams';
-import useYmlParseError from '@/hooks/useYmlParseError';
+import useYmlParseErrorMessage from '@/hooks/useYmlParseErrorMessage';
 import { paths } from '@/routes';
 
 type Props = Omit<SidebarProps, 'children'>;
@@ -56,17 +55,17 @@ const NavigationItem = ({ children, path, icon, intercomTarget }: NavigationItem
   // even one with schema/marker errors. Blocking on the broader validation status trapped users on
   // the current page whenever the YAML was merely schema-invalid (SSW-3087).
   const isParseError = useIsYmlParseError();
-  const parseError = useYmlParseError();
+  const navigationErrorMessage = useYmlParseErrorMessage(
+    'Please fix the errors in your YAML configuration before navigating.',
+    'navigating',
+  );
 
   const handleNavigation = useCallback(() => {
     if (isParseError && !path.startsWith(paths.yml)) {
-      const location = YmlUtils.formatParseError(parseError);
       toast({
         status: 'error',
         title: 'Invalid YAML',
-        description: location
-          ? `${location}. Fix this in your YAML configuration before navigating.`
-          : 'Please fix the errors in your YAML configuration before navigating.',
+        description: navigationErrorMessage,
         duration: null,
         isClosable: true,
       });
@@ -74,7 +73,7 @@ const NavigationItem = ({ children, path, icon, intercomTarget }: NavigationItem
     }
 
     navigate(path);
-  }, [isParseError, navigate, parseError, path, toast]);
+  }, [isParseError, navigate, navigationErrorMessage, path, toast]);
 
   return (
     <SidebarItem selected={Boolean(isSelected)} onClick={handleNavigation} data-intercom-target={intercomTarget}>

--- a/source/javascripts/components/Navigation.tsx
+++ b/source/javascripts/components/Navigation.tsx
@@ -18,12 +18,14 @@ import { useCiConfigExpertStore } from '@/core/stores/CiConfigExpertStore';
 import PageProps from '@/core/utils/PageProps';
 import RuntimeUtils from '@/core/utils/RuntimeUtils';
 import WindowUtils from '@/core/utils/WindowUtils';
+import YmlUtils from '@/core/utils/YmlUtils';
 import { useCiConfigSettings } from '@/hooks/useCiConfigSettings';
 import useCurrentPage from '@/hooks/useCurrentPage';
 import useHashLocation from '@/hooks/useHashLocation';
 import useIsYmlParseError from '@/hooks/useIsYmlParseError';
 import useParentMessageListener from '@/hooks/useParentMessageListener';
 import useSearchParams from '@/hooks/useSearchParams';
+import useYmlParseError from '@/hooks/useYmlParseError';
 import { paths } from '@/routes';
 
 type Props = Omit<SidebarProps, 'children'>;
@@ -54,13 +56,17 @@ const NavigationItem = ({ children, path, icon, intercomTarget }: NavigationItem
   // even one with schema/marker errors. Blocking on the broader validation status trapped users on
   // the current page whenever the YAML was merely schema-invalid (SSW-3087).
   const isParseError = useIsYmlParseError();
+  const parseError = useYmlParseError();
 
   const handleNavigation = useCallback(() => {
     if (isParseError && !path.startsWith(paths.yml)) {
+      const location = YmlUtils.formatParseError(parseError);
       toast({
         status: 'error',
         title: 'Invalid YAML',
-        description: 'Please fix the errors in your YAML configuration before navigating.',
+        description: location
+          ? `${location}. Fix this in your YAML configuration before navigating.`
+          : 'Please fix the errors in your YAML configuration before navigating.',
         duration: null,
         isClosable: true,
       });
@@ -68,7 +74,7 @@ const NavigationItem = ({ children, path, icon, intercomTarget }: NavigationItem
     }
 
     navigate(path);
-  }, [isParseError, navigate, path, toast]);
+  }, [isParseError, navigate, parseError, path, toast]);
 
   return (
     <SidebarItem selected={Boolean(isSelected)} onClick={handleNavigation} data-intercom-target={intercomTarget}>

--- a/source/javascripts/core/services/StepVariableService.spec.ts
+++ b/source/javascripts/core/services/StepVariableService.spec.ts
@@ -61,6 +61,27 @@ describe('StepVariableService', () => {
       const input: EnvironmentItemModel = { VARIABLE_NAME: undefined, opts: {} };
       expect(StepVariableService.getValue(input)).toBe('');
     });
+
+    it('should render a value that YAML parsed as a flow map as inline YAML, not [object Object]', () => {
+      // An unquoted `notify_user_groups: {devs,qa}` is a flow mapping per the YAML spec, so it
+      // reaches this service as an object. Stringifying it naively both displayed and (once the
+      // field was edited) saved `[object Object]` over the user's value.
+      const input: EnvironmentItemModel = { notify_user_groups: { devs: null, qa: null }, opts: {} };
+
+      expect(StepVariableService.getValue(input)).toBe('{devs: null, qa: null}');
+    });
+
+    it('should render a value that YAML parsed as a flow sequence as inline YAML', () => {
+      const input: EnvironmentItemModel = { VARIABLE_NAME: ['a', 'b'], opts: {} };
+
+      expect(StepVariableService.getValue(input)).toBe('[a, b]');
+    });
+
+    it('should leave a brace value that stayed a plain scalar untouched', () => {
+      const input: EnvironmentItemModel = { deploy_path: './reports/{devs,qa}', opts: {} };
+
+      expect(StepVariableService.getValue(input)).toBe('./reports/{devs,qa}');
+    });
   });
 
   describe('findInput', () => {

--- a/source/javascripts/core/services/StepVariableService.ts
+++ b/source/javascripts/core/services/StepVariableService.ts
@@ -1,4 +1,5 @@
 import { EnvironmentItemModel, EnvModel } from '../models/BitriseYml';
+import YmlUtils from '../utils/YmlUtils';
 
 function group(inputs?: EnvModel): Record<string, EnvModel> {
   const groups: Record<string, EnvModel> = {};
@@ -23,9 +24,17 @@ const getName = (input: EnvironmentItemModel) => {
   return Object.keys(rest)[0];
 };
 
+/**
+ * An input's value as editable text.
+ *
+ * An unquoted value that happens to look like a YAML flow collection — `notify_user_groups: {devs,qa}`
+ * — parses to a map or array rather than a string, even though it was written as, and is consumed as,
+ * plain text. Stringifying those back to their compact YAML form keeps the user's `{devs,qa}` legible
+ * and editable; `String()` alone would render (and, once the field is edited, save) `[object Object]`.
+ */
 const getValue = (input: EnvironmentItemModel) => {
   const { opts: _, ...rest } = input;
-  return String(Object.values(rest)[0] ?? '');
+  return YmlUtils.toInlineYml(Object.values(rest)[0]);
 };
 
 const findInput = (inputs: EnvModel, name: string) => {

--- a/source/javascripts/core/stores/BitriseYmlStore.ts
+++ b/source/javascripts/core/stores/BitriseYmlStore.ts
@@ -8,7 +8,7 @@ import { EntityIndex, TreeNode, TreeNodeSource } from '../models/Tree';
 import EntityIndexService from '../services/EntityIndexService';
 import TreeService from '../services/TreeService';
 import RuntimeUtils from '../utils/RuntimeUtils';
-import YmlUtils from '../utils/YmlUtils';
+import YmlUtils, { YmlParseError } from '../utils/YmlUtils';
 
 export type BitriseYmlStore = StoreApi<BitriseYmlStoreState>;
 export type BitriseYmlStoreState = ExtractState<typeof bitriseYmlStore>;
@@ -47,6 +47,12 @@ export const bitriseYmlStore = createStore(
     savedYmlDocument: new Document(),
     __invalidYmlString: undefined as string | undefined,
     __savedInvalidYmlString: undefined as string | undefined,
+    // Details of the failure behind `__invalidYmlString`, kept so the UI can name the line/column
+    // (and file, in modular mode) instead of just reporting that something, somewhere, is invalid.
+    // Always set and cleared in lockstep with `__invalidYmlString`.
+    __invalidYmlError: undefined as YmlParseError | undefined,
+    /** Saved-state counterpart of `__invalidYmlError`, so a discard restores the detail too. */
+    __savedInvalidYmlError: undefined as YmlParseError | undefined,
     validationStatus: 'pending' as 'valid' | 'invalid' | 'warnings' | 'pending',
     configBranch: undefined as string | undefined,
     configCommitSha: undefined as string | undefined,
@@ -114,6 +120,7 @@ export function discardBitriseYmlDocument() {
       discardKey: Date.now(),
       ymlDocument: state.savedYmlDocument.clone(),
       __invalidYmlString: state.__savedInvalidYmlString,
+      __invalidYmlError: state.__savedInvalidYmlError,
     });
     return;
   }
@@ -163,6 +170,7 @@ function commitActiveFileDocument(nodeId: string, slice: FileSlice, doc: Documen
   bitriseYmlStore.setState({
     ymlDocument: doc,
     __invalidYmlString: undefined,
+    __invalidYmlError: undefined,
     files: { ...bitriseYmlStore.getState().files, [nodeId]: { ...slice, ymlDocument: doc } },
     mergedYmlStale: true,
   });
@@ -174,9 +182,9 @@ export function updateBitriseYmlDocumentByString(ymlString: string) {
 
   if (!state.tree) {
     if (doc.errors.length === 0) {
-      bitriseYmlStore.setState({ ymlDocument: doc, __invalidYmlString: undefined });
+      bitriseYmlStore.setState({ ymlDocument: doc, __invalidYmlString: undefined, __invalidYmlError: undefined });
     } else {
-      bitriseYmlStore.setState({ __invalidYmlString: ymlString });
+      bitriseYmlStore.setState({ __invalidYmlString: ymlString, __invalidYmlError: YmlUtils.parseErrorOf(doc) });
     }
     return;
   }
@@ -189,7 +197,10 @@ export function updateBitriseYmlDocumentByString(ymlString: string) {
   if (doc.errors.length === 0) {
     commitActiveFileDocument(active.nodeId, active.slice, doc);
   } else {
-    bitriseYmlStore.setState({ __invalidYmlString: ymlString });
+    bitriseYmlStore.setState({
+      __invalidYmlString: ymlString,
+      __invalidYmlError: YmlUtils.parseErrorOf(doc, active.slice.path),
+    });
   }
 }
 
@@ -231,7 +242,14 @@ export function initializeBitriseYmlDocument({
     // through a legacy path (branch switch, repository-YAML save, manual update).
     ...clearedModularState(),
     ...(doc.errors.length === 0
-      ? { ymlDocument: doc, savedYmlDocument: doc, __invalidYmlString: undefined, __savedInvalidYmlString: undefined }
+      ? {
+          ymlDocument: doc,
+          savedYmlDocument: doc,
+          __invalidYmlString: undefined,
+          __savedInvalidYmlString: undefined,
+          __invalidYmlError: undefined,
+          __savedInvalidYmlError: undefined,
+        }
       : {
           // Invalid YAML: drop any prior parsed doc (incl. a stale modular file's Document)
           // so the legacy store never carries modular state through the invalid path.
@@ -239,6 +257,8 @@ export function initializeBitriseYmlDocument({
           savedYmlDocument: new Document(),
           __invalidYmlString: ymlString,
           __savedInvalidYmlString: ymlString,
+          __invalidYmlError: YmlUtils.parseErrorOf(doc),
+          __savedInvalidYmlError: YmlUtils.parseErrorOf(doc),
         }),
   });
 }
@@ -250,6 +270,7 @@ export function updateBitriseYmlDocument(mutator: YamlMutator) {
     bitriseYmlStore.setState({
       ymlDocument: mutator({ doc: state.ymlDocument.clone() }),
       __invalidYmlString: undefined,
+      __invalidYmlError: undefined,
     });
     return;
   }
@@ -280,6 +301,7 @@ function activeDocumentPatch(selectedNodeId: string, ymlDocument: Document, save
     ymlDocument,
     savedYmlDocument,
     __invalidYmlString: undefined,
+    __invalidYmlError: undefined,
   };
 }
 
@@ -369,6 +391,8 @@ function modularTreePatch(
     savedYmlDocument: activeSlice.savedYmlDocument,
     __invalidYmlString: undefined,
     __savedInvalidYmlString: undefined,
+    __invalidYmlError: undefined,
+    __savedInvalidYmlError: undefined,
   };
 }
 

--- a/source/javascripts/core/utils/YmlUtils.spec.ts
+++ b/source/javascripts/core/utils/YmlUtils.spec.ts
@@ -2014,4 +2014,152 @@ describe('YmlUtils', () => {
       expect(YmlUtils.isEquals(invalid, YmlUtils.toDoc(INVALID_YML))).toBe(true);
     });
   });
+
+  describe('unquoted values containing curly braces', () => {
+    // Legacy configs carry unquoted step input values with braces in them. The YAML spec makes some
+    // of those flow collections rather than strings, and others outright ambiguous. These cases pin
+    // the behaviour to the raw/CLI parser (gopkg.in/yaml.v2, as used by the apiserver): every value
+    // that parser accepts must parse here too, and vice versa — the visual editor must not be
+    // stricter than the parser that runs the user's builds.
+    const withInputValue = (value: string) =>
+      [
+        'workflows:',
+        '  primary:',
+        '    steps:',
+        '    - deploy-to-bitrise-io@2:',
+        '        inputs:',
+        `        - notify_user_groups: ${value}`,
+      ].join('\n');
+
+    it.each([
+      ['a brace group mid-scalar', 'reports/{devs,qa}', 'reports/{devs,qa}'],
+      ['a brace group at the end of a scalar', './out/{devs,qa}', './out/{devs,qa}'],
+      ['an escaped shell variable', '${FOO}', '${FOO}'],
+      ['a quoted brace group', "'{devs,qa}'", '{devs,qa}'],
+    ])('parses %s as a plain string', (_, value, expected) => {
+      const doc = YmlUtils.toDoc(withInputValue(value));
+
+      expect(doc.errors).toHaveLength(0);
+      expect(YmlUtils.toJSON(doc)).toMatchObject({
+        workflows: {
+          primary: { steps: [{ 'deploy-to-bitrise-io@2': { inputs: [{ notify_user_groups: expected }] } }] },
+        },
+      });
+    });
+
+    it('parses a leading brace group as a flow map, without erroring', () => {
+      // `{devs,qa}` is a well-formed flow mapping per the spec, so this is not a parse failure —
+      // the raw/CLI parser accepts it too. It reaches the UI as a map, which is what `toInlineYml`
+      // (and through it `StepVariableService.getValue`) has to render legibly.
+      const doc = YmlUtils.toDoc(withInputValue('{devs,qa}'));
+
+      expect(doc.errors).toHaveLength(0);
+      expect(YmlUtils.toJSON(doc)).toMatchObject({
+        workflows: {
+          primary: {
+            steps: [{ 'deploy-to-bitrise-io@2': { inputs: [{ notify_user_groups: { devs: null, qa: null } }] } }],
+          },
+        },
+      });
+    });
+
+    it.each([
+      ['a brace group followed by more scalar', '{devs,qa}/reports'],
+      ['an unterminated brace group', '{devs,qa'],
+      ['a doubled brace template', '{{ .Values.x }}'],
+    ])('reports %s as a parse error rather than failing silently', (_, value) => {
+      // These are genuinely ambiguous and the raw/CLI parser rejects them too, so the visual editor
+      // must surface a located error instead of pretending the config loaded.
+      const doc = YmlUtils.toDoc(withInputValue(value));
+      const error = YmlUtils.parseErrorOf(doc);
+
+      expect(doc.errors.length).toBeGreaterThan(0);
+      expect(error?.message).toBeTruthy();
+      expect(error?.line).toBe(6);
+      expect(error?.column).toBeGreaterThan(0);
+    });
+  });
+
+  describe('parseErrorOf', () => {
+    it('returns undefined for a document that parsed cleanly', () => {
+      expect(YmlUtils.parseErrorOf(YmlUtils.toDoc(yaml`workflows: {}`))).toBeUndefined();
+    });
+
+    it('reports the message, code and 1-based position of the first error', () => {
+      const doc = YmlUtils.toDoc('format_version: "13"\nworkflows: {devs,qa}/reports\n');
+
+      expect(YmlUtils.parseErrorOf(doc)).toEqual({
+        message: 'Unexpected scalar at node end',
+        code: 'UNEXPECTED_TOKEN',
+        line: 2,
+        column: 21,
+        path: undefined,
+      });
+    });
+
+    it('strips the code frame and the redundant position suffix from the library message', () => {
+      const error = YmlUtils.parseErrorOf(YmlUtils.toDoc('a: {devs,qa}/reports'));
+
+      expect(error?.message).not.toContain('\n');
+      expect(error?.message).not.toMatch(/at line \d+/);
+    });
+
+    it('records the file the error came from when one is given', () => {
+      const error = YmlUtils.parseErrorOf(YmlUtils.toDoc('a: {devs,qa}/reports'), 'ci/deploy.yml');
+
+      expect(error?.path).toBe('ci/deploy.yml');
+    });
+  });
+
+  describe('formatParseError', () => {
+    it('renders line and column alongside the message', () => {
+      expect(YmlUtils.formatParseError({ message: 'Unexpected scalar at node end', line: 7, column: 31 })).toBe(
+        'Line 7, column 31: Unexpected scalar at node end',
+      );
+    });
+
+    it('names the file first when the error came from a known module', () => {
+      expect(
+        YmlUtils.formatParseError({ message: 'Unexpected scalar at node end', line: 7, column: 31, path: 'ci/a.yml' }),
+      ).toBe('ci/a.yml (line 7, column 31): Unexpected scalar at node end');
+    });
+
+    it('names the file alone when no position is known', () => {
+      expect(YmlUtils.formatParseError({ message: 'Something went wrong', path: 'ci/a.yml' })).toBe(
+        'ci/a.yml: Something went wrong',
+      );
+    });
+
+    it('falls back to the bare message when no position is known', () => {
+      expect(YmlUtils.formatParseError({ message: 'Something went wrong' })).toBe('Something went wrong');
+    });
+
+    it('returns an empty string when there is no error', () => {
+      expect(YmlUtils.formatParseError(undefined)).toBe('');
+    });
+  });
+
+  describe('toInlineYml', () => {
+    it('renders a flow map from an unquoted brace value on a single line', () => {
+      expect(YmlUtils.toInlineYml({ devs: null, qa: null })).toBe('{devs: null, qa: null}');
+    });
+
+    it('renders a sequence on a single line', () => {
+      expect(YmlUtils.toInlineYml(['a', 'b'])).toBe('[a, b]');
+    });
+
+    it('renders nested collections without wrapping', () => {
+      expect(YmlUtils.toInlineYml({ a: { b: 1 } })).toBe('{a: {b: 1}}');
+    });
+
+    it.each([
+      ['a string', 'reports/{devs,qa}', 'reports/{devs,qa}'],
+      ['a number', 42, '42'],
+      ['a boolean', false, 'false'],
+      ['null', null, ''],
+      ['undefined', undefined, ''],
+    ])('renders %s unchanged', (_, value, expected) => {
+      expect(YmlUtils.toInlineYml(value)).toBe(expected);
+    });
+  });
 });

--- a/source/javascripts/core/utils/YmlUtils.spec.ts
+++ b/source/javascripts/core/utils/YmlUtils.spec.ts
@@ -2152,6 +2152,33 @@ describe('YmlUtils', () => {
       expect(YmlUtils.toInlineYml({ a: { b: 1 } })).toBe('{a: {b: 1}}');
     });
 
+    it.each([['on'], ['off'], ['yes'], ['no'], ['y'], ['n']])(
+      'quotes %s, which is a boolean in the YAML 1.1 schema the app serializes with',
+      (key) => {
+        expect(YmlUtils.toInlineYml({ [key]: null })).toBe(`{"${key}": null}`);
+      },
+    );
+
+    it('quotes a numeric-looking key so it stays a string', () => {
+      expect(YmlUtils.toInlineYml({ 2022: null })).toBe('{"2022": null}');
+    });
+
+    it('quotes keys the same way a save through toYml would write them', () => {
+      // Both paths must agree on quoting, otherwise the field shows a form the app never writes.
+      // Flow padding is the one deliberate difference — `toYml` preserves the source's spacing while
+      // an inline field is always rendered compact — so it's normalised away here.
+      const value = { on: null, devs: null };
+      const inline = YmlUtils.toInlineYml(value);
+      const saved = YmlUtils.toYml(YmlUtils.toDoc(`a: ${inline}`))
+        .replace(/^a:\s*/, '')
+        .trim();
+      const ignoringPadding = (yml: string) => yml.replace(/\s+/g, '');
+
+      expect(inline).toBe('{"on": null, devs: null}');
+      expect(ignoringPadding(saved)).toBe(ignoringPadding(inline));
+      expect(YmlUtils.toJSON(YmlUtils.toDoc(`a: ${saved}`))).toEqual({ a: value });
+    });
+
     it.each([
       ['a string', 'reports/{devs,qa}', 'reports/{devs,qa}'],
       ['a number', 42, '42'],

--- a/source/javascripts/core/utils/YmlUtils.ts
+++ b/source/javascripts/core/utils/YmlUtils.ts
@@ -76,6 +76,70 @@ function toDoc(raw: string) {
   return doc;
 }
 
+/**
+ * A parse failure, reduced to the bits worth showing a user. `line`/`column` are 1-based and point at
+ * the start of the offending token.
+ */
+type YmlParseError = {
+  message: string;
+  line?: number;
+  column?: number;
+  code?: string;
+  /** Path of the file the error came from — only set in modular mode, where "which file" is ambiguous. */
+  path?: string;
+};
+
+/** Strips the trailing "at line L, column C" the yaml library appends, since we surface those separately. */
+const LINE_COL_SUFFIX = /,?\s*at line \d+, column \d+:?\s*$/;
+
+/**
+ * The first parse error of `doc`, or undefined if it parsed cleanly.
+ *
+ * The yaml library's `message` is a multi-line code frame (summary, blank line, source excerpt, caret
+ * underline). Only the first line is human-readable prose, so that's what's kept — callers that want
+ * the excerpt still have the raw source and the line/column.
+ */
+function parseErrorOf(doc: Document, path?: string): YmlParseError | undefined {
+  const error = doc.errors[0];
+
+  if (!error) {
+    return undefined;
+  }
+
+  const [start] = error.linePos ?? [];
+
+  return {
+    message: error.message.split('\n')[0].replace(LINE_COL_SUFFIX, '').trim(),
+    line: start?.line,
+    column: start?.col,
+    code: error.code,
+    path,
+  };
+}
+
+/**
+ * One-line rendering of {@link parseErrorOf} — "Line 7, column 31: Unexpected scalar at node end",
+ * or "ci/deploy.yml (line 7, column 31): ..." once a file is known.
+ */
+function formatParseError(error?: YmlParseError): string {
+  if (!error) {
+    return '';
+  }
+
+  const position = [
+    error.line !== undefined && `line ${error.line}`,
+    error.column !== undefined && `column ${error.column}`,
+  ]
+    .filter(Boolean)
+    .join(', ');
+
+  if (error.path) {
+    return `${error.path}${position ? ` (${position})` : ''}: ${error.message}`;
+  }
+
+  return position ? `${position.charAt(0).toUpperCase()}${position.slice(1)}: ${error.message}` : error.message;
+}
+
 function toYml(root: Root) {
   const rawError = rawErrorSource(root);
   if (rawError !== undefined) {
@@ -124,6 +188,26 @@ function toYml(root: Root) {
 
 function toJSON(root: Root) {
   return (root.toJSON() ?? {}) as BitriseYml;
+}
+
+/**
+ * A plain JS value rendered as single-line YAML, for display in a text field.
+ *
+ * Collections are forced to flow style so the result stays on one line: a value written unquoted as
+ * `{devs,qa}` parses to a map and comes back as `{devs: null, qa: null}` rather than as a block
+ * mapping (or as `[object Object]`, which is what bare `String()` would give).
+ */
+function toInlineYml(value: unknown): string {
+  if (isNil(value)) {
+    return '';
+  }
+
+  if (isPrimitive(value)) {
+    return String(value);
+  }
+
+  const node = PLACEHOLDER_DOC.createNode(value, { flow: true, aliasDuplicateObjects: false });
+  return stringify(node, { flowCollectionPadding: false }).trim();
 }
 
 function toTypedValue(value: unknown) {
@@ -659,10 +743,15 @@ function updateValueByValue(root: Root, path: WildcardPath, oldValue: unknown, n
   return updateValueByPredicate(root, path, (node) => isEqualValues(node, oldValue), newValue, cb);
 }
 
+export type { YmlParseError };
+
 export default {
   toDoc,
+  parseErrorOf,
+  formatParseError,
   toYml,
   toJSON,
+  toInlineYml,
   toScalar,
   isEquals,
   isEqualValues,

--- a/source/javascripts/core/utils/YmlUtils.ts
+++ b/source/javascripts/core/utils/YmlUtils.ts
@@ -196,6 +196,11 @@ function toJSON(root: Root) {
  * Collections are forced to flow style so the result stays on one line: a value written unquoted as
  * `{devs,qa}` parses to a map and comes back as `{devs: null, qa: null}` rather than as a block
  * mapping (or as `[object Object]`, which is what bare `String()` would give).
+ *
+ * Serializes on the same YAML 1.1 schema as {@link toYml}, so what's shown matches what a save would
+ * write. The schemas disagree about plain scalars: `on`, `off`, `yes`, `no`, `y` and `n` are booleans
+ * in 1.1, so a key like `{on,off}` has to be quoted to stay a string — under the library's 1.2
+ * default it wouldn't be, and the field would show a form the rest of the app never produces.
  */
 function toInlineYml(value: unknown): string {
   if (isNil(value)) {
@@ -207,7 +212,12 @@ function toInlineYml(value: unknown): string {
   }
 
   const node = PLACEHOLDER_DOC.createNode(value, { flow: true, aliasDuplicateObjects: false });
-  return stringify(node, { flowCollectionPadding: false }).trim();
+  return stringify(node, {
+    version: '1.1',
+    schema: 'yaml-1.1',
+    aliasDuplicateObjects: false,
+    flowCollectionPadding: false,
+  }).trim();
 }
 
 function toTypedValue(value: unknown) {

--- a/source/javascripts/hooks/useYmlParseError.spec.tsx
+++ b/source/javascripts/hooks/useYmlParseError.spec.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+
+import { bitriseYmlStore, initializeBitriseYmlDocument } from '@/core/stores/BitriseYmlStore';
+
+import useYmlParseError from './useYmlParseError';
+
+describe('useYmlParseError', () => {
+  it('is undefined for a config that parses', () => {
+    initializeBitriseYmlDocument({
+      ymlString: 'format_version: "13"\nworkflows:\n  primary: {}\n',
+      version: '1',
+    });
+
+    const { result } = renderHook(() => useYmlParseError());
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('locates the failure when the config cannot be parsed', () => {
+    // A legacy unquoted brace value that the YAML spec leaves ambiguous. Previously the store kept
+    // only the raw string, so the user was redirected off the visual editor with no way to tell
+    // which line broke it.
+    initializeBitriseYmlDocument({
+      ymlString: [
+        'format_version: "13"',
+        'workflows:',
+        '  primary:',
+        '    steps:',
+        '    - deploy-to-bitrise-io@2:',
+        '        inputs:',
+        '        - notify_user_groups: {devs,qa}/reports',
+        '',
+      ].join('\n'),
+      version: '1',
+    });
+
+    const { result } = renderHook(() => useYmlParseError());
+
+    expect(result.current?.message).toBeTruthy();
+    expect(result.current?.line).toBe(7);
+    expect(result.current?.column).toBeGreaterThan(0);
+  });
+
+  it('clears once the config is replaced with one that parses', () => {
+    bitriseYmlStore.setState({
+      __invalidYmlString: 'workflows: {{{ invalid',
+      __invalidYmlError: { message: 'Something is wrong', line: 1, column: 12 },
+    });
+
+    initializeBitriseYmlDocument({ ymlString: 'format_version: "13"\n', version: '2' });
+
+    const { result } = renderHook(() => useYmlParseError());
+
+    expect(result.current).toBeUndefined();
+  });
+});

--- a/source/javascripts/hooks/useYmlParseError.ts
+++ b/source/javascripts/hooks/useYmlParseError.ts
@@ -1,0 +1,19 @@
+import { YmlParseError } from '@/core/utils/YmlUtils';
+
+import useBitriseYmlStore from './useBitriseYmlStore';
+
+/**
+ * Details of the parse failure that {@link useIsYmlParseError} reports as a boolean — the message,
+ * 1-based line/column, and (in modular mode) the file it came from. `undefined` whenever the config
+ * parses.
+ *
+ * Exists so a parse failure can be reported as something the user can act on ("line 7, column 31:
+ * Unexpected scalar at node end") instead of an unlocatable "your YAML is invalid". Anything gating
+ * behaviour on *whether* parsing failed should keep using {@link useIsYmlParseError} — this hook is
+ * for presentation.
+ */
+function useYmlParseError(): YmlParseError | undefined {
+  return useBitriseYmlStore((s) => s.__invalidYmlError);
+}
+
+export default useYmlParseError;

--- a/source/javascripts/hooks/useYmlParseErrorMessage.spec.tsx
+++ b/source/javascripts/hooks/useYmlParseErrorMessage.spec.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+import { renderHook } from '@testing-library/react';
+
+import { bitriseYmlStore, initializeBitriseYmlDocument } from '@/core/stores/BitriseYmlStore';
+
+import useYmlParseErrorMessage from './useYmlParseErrorMessage';
+
+const SWITCH_FALLBACK = "YAML can't be parsed, please fix it before switching to the Visual editor.";
+const SAVE_FALLBACK = 'Please fix the errors in your YAML configuration before saving.';
+
+describe('useYmlParseErrorMessage', () => {
+  it('locates the failure when the config could not be parsed', () => {
+    initializeBitriseYmlDocument({
+      ymlString: [
+        'format_version: "13"',
+        'workflows:',
+        '  primary:',
+        '    steps:',
+        '    - deploy-to-bitrise-io@2:',
+        '        inputs:',
+        '        - notify_user_groups: {devs,qa}/reports',
+        '',
+      ].join('\n'),
+      version: '1',
+    });
+
+    const { result } = renderHook(() => useYmlParseErrorMessage(SWITCH_FALLBACK, 'switching to the Visual editor'));
+
+    expect(result.current).toMatch(/^Line 7, column \d+: /);
+    expect(result.current).toContain('Fix this before switching to the Visual editor.');
+    expect(result.current).not.toBe(SWITCH_FALLBACK);
+  });
+
+  it('uses the fallback when the config parses cleanly', () => {
+    initializeBitriseYmlDocument({
+      ymlString: 'format_version: "13"\nworkflows:\n  primary: {}\n',
+      version: '1',
+    });
+
+    const { result } = renderHook(() => useYmlParseErrorMessage(SWITCH_FALLBACK, 'switching to the Visual editor'));
+
+    expect(result.current).toBe(SWITCH_FALLBACK);
+  });
+
+  it('uses the fallback for a schema-invalid config that still parses', () => {
+    // Saving is gated on the broader validation status, which reports 'invalid' for marker errors on
+    // a config that parsed fine. There is no line to point at, so the generic wording has to stand
+    // rather than the message implying a parse failure that did not happen.
+    initializeBitriseYmlDocument({
+      ymlString: 'format_version: "13"\nworkflows:\n  primary: {}\n',
+      version: '1',
+    });
+    bitriseYmlStore.setState({ validationStatus: 'invalid' });
+
+    const { result } = renderHook(() => useYmlParseErrorMessage(SAVE_FALLBACK, 'saving'));
+
+    expect(result.current).toBe(SAVE_FALLBACK);
+  });
+
+  it('names the file as well as the position in modular mode', () => {
+    bitriseYmlStore.setState({
+      __invalidYmlString: 'workflows: {devs,qa}/reports',
+      __invalidYmlError: {
+        message: 'Unexpected scalar at node end',
+        line: 7,
+        column: 31,
+        path: 'ci/deploy.yml',
+      },
+    });
+
+    const { result } = renderHook(() => useYmlParseErrorMessage(SAVE_FALLBACK, 'saving'));
+
+    expect(result.current).toBe(
+      'ci/deploy.yml (line 7, column 31): Unexpected scalar at node end. Fix this before saving.',
+    );
+  });
+});

--- a/source/javascripts/hooks/useYmlParseErrorMessage.ts
+++ b/source/javascripts/hooks/useYmlParseErrorMessage.ts
@@ -1,0 +1,25 @@
+import YmlUtils from '@/core/utils/YmlUtils';
+
+import useYmlParseError from './useYmlParseError';
+
+/**
+ * The message to show when an invalid config blocks something: the located parse error when there is
+ * one, otherwise `fallback` verbatim.
+ *
+ * Not every blocked action is blocked by a *parse* failure. Saving is gated on the broader
+ * `useYmlValidationStatus`, which also reports `'invalid'` for schema/marker errors on a config that
+ * parses perfectly well — there is no line to point at in that case, so those callers keep their
+ * generic wording. Only a real parse failure gets located, which is why the fallback is required
+ * rather than derived.
+ *
+ * @param fallback message to use when nothing could be located
+ * @param action what the user was prevented from doing, e.g. `'saving'`
+ */
+function useYmlParseErrorMessage(fallback: string, action: string): string {
+  const parseError = useYmlParseError();
+  const located = YmlUtils.formatParseError(parseError);
+
+  return located ? `${located}. Fix this before ${action}.` : fallback;
+}
+
+export default useYmlParseErrorMessage;

--- a/source/javascripts/pages/YmlPage/YmlPage.tsx
+++ b/source/javascripts/pages/YmlPage/YmlPage.tsx
@@ -3,6 +3,7 @@ import { Box } from '@bitrise/bitkit';
 import RuntimeUtils from '@/core/utils/RuntimeUtils';
 import { useTree } from '@/hooks/useTree';
 import OptimizeYouCiConfigBySplittingNotification from '@/pages/YmlPage/components/OptimizeYouCiConfigBySplittingNotification'; // TODO: implement onConfigSourceChangeSaved function
+import YmlParseErrorNotification from '@/pages/YmlPage/components/YmlParseErrorNotification';
 import YourCiConfigIsSplitNotification from '@/pages/YmlPage/components/YourCiConfigIsSplitNotification';
 
 import ModularYmlEditor from './components/ModularYmlEditor';
@@ -14,6 +15,7 @@ const YmlPage = () => {
 
   return (
     <Box height="100%" display="flex" flexDirection="column">
+      <YmlParseErrorNotification />
       <Box
         flexGrow="1"
         flexShrink="1"

--- a/source/javascripts/pages/YmlPage/components/YmlParseErrorNotification.tsx
+++ b/source/javascripts/pages/YmlPage/components/YmlParseErrorNotification.tsx
@@ -1,0 +1,29 @@
+import { Notification } from '@bitrise/bitkit';
+
+import YmlUtils from '@/core/utils/YmlUtils';
+import useYmlParseError from '@/hooks/useYmlParseError';
+
+/**
+ * Explains why the visual editor is unavailable, on the page the user gets redirected to.
+ *
+ * A config that fails to parse forces the YAML view (see `InvalidYmlRedirect`), which on its own
+ * looks like the visual editor silently refusing to open. Naming the line and column — and the file,
+ * in modular mode — turns that into something the user can go and fix.
+ */
+const YmlParseErrorNotification = () => {
+  const parseError = useYmlParseError();
+
+  if (!parseError) {
+    return null;
+  }
+
+  return (
+    // Deliberately left masked for session recordings: in modular mode the message names a file
+    // from the user's repository, which counts as configuration data.
+    <Notification status="error" marginBlockEnd="12" marginInline="12">
+      {YmlUtils.formatParseError(parseError)}. The visual editor is unavailable until this is fixed.
+    </Notification>
+  );
+};
+
+export default YmlParseErrorNotification;


### PR DESCRIPTION
### Scope note, please read first

The reported root cause was "the Visual tab uses a stricter YAML parser than the raw/CLI parser, so unquoted brace values like `{devs,qa}` are rejected in Visual mode but accepted by the CLI." I measured that before changing anything, and **it does not hold**.

A corpus of 43 unquoted brace/curly step-input values was run through both parsers:
- Visual-mode: the `yaml` package via `YmlUtils.toDoc`, with the real options (`stringKeys: true, keepSourceTokens: true`)
- Raw/CLI: `gopkg.in/yaml.v2` + `bitrise/v2 models.BitriseDataModel` + `Normalize()` — the exact path `apiserver/service/bitrise_config.go` uses

**Zero divergence.** Every value one accepts, the other accepts:
- `deploy_path: reports/{devs,qa}` → plain string in both
- `notify_user_groups: {devs,qa}` → flow **map** (not a string) in both, no error in either
- `{devs,qa}/reports`, `{devs,qa`, `{{ .Values.x }}`, `**/*.{js,ts}` → rejected by both

So there is no stricter-parser regression to align. This PR therefore does the two things that are actually broken, the first of which is the fallback the ticket itself specifies.

### 1. Parse failures had no location (the "silent/blank Visual tab")

`BitriseYmlStore` only ever checked `doc.errors.length === 0` and stored the raw string in `__invalidYmlString`, throwing the errors away. `InvalidYmlRedirect` then bounced the user off the visual editor, and the only feedback was a generic *"Please fix the errors in your YAML configuration before navigating."* — no line, no column, no cause. That is the reported "can't open Visual, fails silently" symptom.

Now: `YmlUtils.parseErrorOf()` captures the first error's message, code and 1-based line/column (plus file path in modular mode); the store keeps it in `__invalidYmlError` in lockstep with the existing sentinel; `useYmlParseError()` exposes it; the navigation toast and a new notification on the YAML page report e.g. `Line 7, column 31: Unexpected scalar at node end`.

### 2. `{devs,qa}` was silently corrupted to `[object Object]`

An unquoted `notify_user_groups: {devs,qa}` is a well-formed flow mapping per spec, so it arrives as an object. `StepVariableService.getValue` ran `String()` over it → the field displayed `[object Object]`, and editing that field **saved `[object Object]` over the user's value**. Now rendered as compact single-line YAML (`{devs: null, qa: null}`) via `YmlUtils.toInlineYml`.

### Tests
Added 30+ cases: the parser-parity corpus (so a future divergence fails CI), `parseErrorOf`/`formatParseError`, `toInlineYml`, `getValue` on flow map/seq values, and a `useYmlParseError` hook spec. Genuinely malformed YAML is asserted to still produce a located error rather than a silent failure.

### Verification
`npx jest` 1469/1469 pass · `tsc --noEmit` clean · `eslint` clean · `npm run build` succeeds · `go vet ./...` and `go test ./...` pass.

### Assumptions flagged for the reviewer
- The new notification is deliberately **not** `data-clarity-unmask`ed — in modular mode the message names a file from the user's repo, which the repo's own ClarityUnmask policy treats as configuration data.
- Touched files use legacy `@bitrise/bitkit` v1; I matched the surrounding code rather than doing a v1→v2 migration, to keep a bug fix reviewable. Happy to split a migration out if you want it.