### PR TITLE
fix: mirror the parent hash onto this window before nudging Intercom

### DIFF
--- a/source/javascripts/hooks/useHashLocation.ts
+++ b/source/javascripts/hooks/useHashLocation.ts
@@ -21,15 +21,19 @@ const useHashLocation: BaseLocationHook = () => {
 
   useEffect(() => {
     const listener = () => {
-      setPath(`/${window.parent.location.hash.replace(/^#?!?\/?/, '')}`);
+      const parentHash = window.parent.location.hash;
+      setPath(`/${parentHash.replace(/^#?!?\/?/, '')}`);
 
-      // Intercom boots inside this iframe's own document and hooks pushState/replaceState on ITS
-      // window to detect SPA page views. Hash changes on window.parent — whether from our own
-      // navigate() below, an Intercom tour step's own button, or anything else touching the
-      // parent's location — never call this window's History API, so Intercom can't see them and
-      // its "Current page URL contains…" targeting rules are evaluated once, at first load, and
-      // never again. hashchange on window.parent is the one thing every kind of navigation here
-      // has in common, so nudge Intercom from there rather than from navigate() alone.
+      // Intercom boots inside this iframe's own document, so its "Current page URL contains…"
+      // targeting reads THIS window's own location — but the router only ever writes to
+      // window.parent's hash (whether from navigate() below, an Intercom tour step's own button,
+      // or anything else touching the parent's location), so this window's location is otherwise
+      // frozen at whatever it was on the iframe's initial load. Mirror the parent's hash onto our
+      // own location first, so Intercom's page-URL check has something current to see, then nudge
+      // it to re-evaluate. Calling Intercom('update') alone is not enough while this URL is stale.
+      if (window.location.hash !== parentHash) {
+        window.location.hash = parentHash;
+      }
       window.Intercom?.('update');
     };
 


### PR DESCRIPTION
## Follow-up to #1870 (already merged)

Manual test: calling `window.Intercom?.('update')` from the console after navigating in-editor still didn't start the second tour.

## Deeper root cause
Intercom boots inside this iframe's own document, so its "Current page URL contains…" targeting reads **this window's own** `location.href`. The router only ever writes to `window.parent`'s hash (`navigate()`, a tour step's own button, anything else) — this window's own location has been frozen at whatever the iframe's initial `src` was, for the entire session. Calling `Intercom('update')` just re-evaluates against that same stale URL, so it could never match a different page's targeting rule no matter how many times it's called.

## Fix
In the same `hashchange` listener (on `window.parent`) added in #1870, mirror `window.parent.location.hash` onto this window's own `location.hash` first, *then* call `Intercom('update')` — so there's now a current URL for its targeting to actually match against.

Confirmed nothing in the codebase reads or listens to this window's own `location.hash` today, so syncing it is safe.

## Verification
- `tsc --noEmit`: clean.
- `eslint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)