### PR TITLE
BIVS-3758: Use label tooltips for control buttons across the WFE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@bitrise/bitkit": "^13.359.0",
-        "@bitrise/bitkit-v2": "0.3.306",
+        "@bitrise/bitkit-v2": "^0.3.324",
         "@bitrise/languageserver": "github:bitrise-io/bitrise-yml-language-server#d28eca30c83c37e69ad4093681e0152160a8fbb0",
         "@dagrejs/dagre": "^3.0.0",
         "@datadog/browser-rum": "^7.4.0",
@@ -1087,9 +1087,9 @@
       }
     },
     "node_modules/@bitrise/bitkit-v2": {
-      "version": "0.3.306",
-      "resolved": "https://registry.npmjs.org/@bitrise/bitkit-v2/-/bitkit-v2-0.3.306.tgz",
-      "integrity": "sha512-nqZWZvdCS9SdkPbb9a5T7l7zRwHzFz33oV9iLd+RmMQugNyrgKkBouS54wsu6KlwflbRp83xtsFYcZpNcmA9gw==",
+      "version": "0.3.324",
+      "resolved": "https://registry.npmjs.org/@bitrise/bitkit-v2/-/bitkit-v2-0.3.324.tgz",
+      "integrity": "sha512-wzrRYLTke5g2qbbZFWk7RZKT+VhYxZ+sb/SFwRqTfLqxSFC1nu+9HZj6vCNplVIpDASJGSMZorNVsvy0sNjc/w==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "dependencies": {
     "@bitrise/bitkit": "^13.359.0",
-    "@bitrise/bitkit-v2": "0.3.306",
+    "@bitrise/bitkit-v2": "^0.3.324",
     "@bitrise/languageserver": "github:bitrise-io/bitrise-yml-language-server#d28eca30c83c37e69ad4093681e0152160a8fbb0",
     "@dagrejs/dagre": "^3.0.0",
     "@datadog/browser-rum": "^7.4.0",

--- a/source/javascripts/components/EditableInput/EditableInput.tsx
+++ b/source/javascripts/components/EditableInput/EditableInput.tsx
@@ -1,4 +1,5 @@
-import { ButtonGroup, ControlButton, Input, InputProps } from '@bitrise/bitkit';
+import { ButtonGroup, Input, InputProps } from '@bitrise/bitkit';
+import { BitkitControlButton, IconCheck, IconCross, IconPencil } from '@bitrise/bitkit-v2';
 import { ChangeEventHandler, KeyboardEventHandler, Reducer, useCallback, useEffect, useReducer } from 'react';
 
 type Props = InputProps & {
@@ -109,22 +110,22 @@ const EditableInput = ({ sanitize = defaultSanitizeFn, validate = defaultValidat
       rightAddon={
         editable.isEditing ? (
           <ButtonGroup mx="8" spacing="0">
-            <ControlButton
+            <BitkitControlButton
               size={buttonSize}
-              iconName="Check"
-              aria-label="Change"
-              isDisabled={editable.validationResult !== true}
+              icon={IconCheck}
+              label="Change"
+              state={editable.validationResult !== true ? 'disabled' : undefined}
               onClick={handleCommit}
             />
-            <ControlButton size={buttonSize} aria-label="Cancel" iconName="Cross" onClick={handleCancel} />
+            <BitkitControlButton size={buttonSize} label="Cancel" icon={IconCross} onClick={handleCancel} />
           </ButtonGroup>
         ) : (
-          <ControlButton
-            mx="8"
+          <BitkitControlButton
+            marginInline="8"
             size={buttonSize}
-            aria-label="Edit"
-            iconName="Pencil"
-            isDisabled={isDisabled}
+            label="Edit"
+            icon={IconPencil}
+            state={isDisabled ? 'disabled' : undefined}
             onClick={handleEdit}
           />
         )

--- a/source/javascripts/components/SortableEnvVars/SortableEnvVarItem.tsx
+++ b/source/javascripts/components/SortableEnvVars/SortableEnvVarItem.tsx
@@ -1,4 +1,5 @@
-import { Box, Checkbox, ControlButton, Input, Text } from '@bitrise/bitkit';
+import { Box, Checkbox, Input, Text } from '@bitrise/bitkit';
+import { BitkitControlButton, IconMinusCircle } from '@bitrise/bitkit-v2';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { ReactNode, useState } from 'react';
@@ -117,14 +118,13 @@ const SortableEnvVarItem = ({
               {jumpButton}
             </Box>
           ) : (
-            <ControlButton
+            <BitkitControlButton
               isDanger
-              ml="8"
+              marginInlineStart="8"
               size="md"
-              aria-label="Remove"
-              iconName="MinusCircle"
-              isDisabled={isReadOnlyView}
-              tooltipProps={{ 'aria-label': 'Remove' }}
+              label="Remove"
+              icon={IconMinusCircle}
+              state={isReadOnlyView ? 'disabled' : undefined}
               onClick={() => onRemove?.()}
             />
           )}

--- a/source/javascripts/components/unified-editor/ContainersTab/ContainerCardItem.tsx
+++ b/source/javascripts/components/unified-editor/ContainersTab/ContainerCardItem.tsx
@@ -1,4 +1,5 @@
-import { Box, Checkbox, ControlButton, Td, Text, Tooltip, Tr } from '@bitrise/bitkit';
+import { Box, Checkbox, Td, Text, Tooltip, Tr } from '@bitrise/bitkit';
+import { BitkitControlButton, IconMinusCircle } from '@bitrise/bitkit-v2';
 
 import CrossFileJumpButton from '@/components/JumpToDefinitionLink/CrossFileJumpButton';
 import { segmentTrack } from '@/core/analytics/SegmentBaseTracking';
@@ -70,11 +71,11 @@ const ContainerCardItem = (props: ContainerCardItemProps) => {
           <CrossFileJumpButton kind="containers" id={reference.id} />
           {/* Read-only (merged/ghost) view has no CTAs — the remove button is hidden, not disabled. */}
           {!isReadOnlyView && (
-            <ControlButton
-              aria-label={isDisabled ? 'Edit containers in the Step bundle definition.' : 'Delete container'}
-              iconName="MinusCircle"
-              color="icon/negative"
-              isDisabled={isDisabled}
+            <BitkitControlButton
+              label={isDisabled ? 'Edit containers in the Step bundle definition.' : 'Delete container'}
+              icon={IconMinusCircle}
+              isDanger
+              state={isDisabled ? 'disabled' : undefined}
               onClick={handleRemove}
             />
           )}

--- a/source/javascripts/components/unified-editor/StepSelectorDrawer/components/AlgoliaStepListItem.tsx
+++ b/source/javascripts/components/unified-editor/StepSelectorDrawer/components/AlgoliaStepListItem.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   Card,
   CardProps,
-  ControlButton,
   Icon,
   LinkButton,
   MarkdownContent,
@@ -11,6 +10,7 @@ import {
   Tooltip,
   useDisclosure,
 } from '@bitrise/bitkit';
+import { BitkitControlButton, IconPlus } from '@bitrise/bitkit-v2';
 import { MouseEventHandler, useRef } from 'react';
 import removeMd from 'remove-markdown';
 
@@ -150,7 +150,7 @@ const AlgoliaStepListItem = ({
           />
         )}
 
-        {!isDisabled && isOpen && <ControlButton aria-label="Add to Workflow" iconName="Plus" onClick={onClick} />}
+        {!isDisabled && isOpen && <BitkitControlButton label="Add to Workflow" icon={IconPlus} onClick={onClick} />}
       </Box>
 
       {!isOpen && (

--- a/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
+++ b/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
@@ -115,7 +115,7 @@ const StepBundleCard = (props: StepBundleCardProps) => {
   let cardPadding;
   if (isCollapsable) {
     if (!isPreviewMode) {
-      cardPadding = '6px 8px 6px 0px';
+      cardPadding = '6px 8px 6px 2px';
     }
   } else {
     cardPadding = '4px 8px';

--- a/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
+++ b/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
@@ -1,4 +1,5 @@
-import { Box, Card, CardProps, Collapse, ControlButton, Dot, Icon, Text, useDisclosure } from '@bitrise/bitkit';
+import { Box, Card, CardProps, Collapse, Dot, Icon, Text, useDisclosure } from '@bitrise/bitkit';
+import { BitkitControlButton, IconChevronDown, IconChevronUp } from '@bitrise/bitkit-v2';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { MouseEvent, useMemo, useRef, useState } from 'react';
@@ -224,7 +225,7 @@ const StepBundleCard = (props: StepBundleCardProps) => {
             >
               {/* No expand/collapse for cross-file refs — their nested steps live in another file. */}
               {isCollapsable && !isCrossFile && (
-                <ControlButton
+                <BitkitControlButton
                   size="xs"
                   tabIndex={-1} // NOTE: Without this, the tooltip always appears when closing any drawers on the Workflows page.
                   className="nopan"
@@ -232,11 +233,8 @@ const StepBundleCard = (props: StepBundleCardProps) => {
                     e.stopPropagation();
                     onToggle();
                   }}
-                  iconName={isOpen ? 'ChevronUp' : 'ChevronDown'}
-                  aria-label={`${isOpen ? 'Collapse' : 'Expand'} Step Bundle details`}
-                  tooltipProps={{
-                    'aria-label': `${isOpen ? 'Collapse' : 'Expand'} Step Bundle details`,
-                  }}
+                  icon={isOpen ? IconChevronUp : IconChevronDown}
+                  label={`${isOpen ? 'Collapse' : 'Expand'} Step Bundle details`}
                 />
               )}
               <Box flex="1" minW={0}>

--- a/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
+++ b/source/javascripts/components/unified-editor/StepSelectorDrawer/components/StepBundleCard.tsx
@@ -115,7 +115,7 @@ const StepBundleCard = (props: StepBundleCardProps) => {
   let cardPadding;
   if (isCollapsable) {
     if (!isPreviewMode) {
-      cardPadding = '6px 8px 6px 2px';
+      cardPadding = '6px 8px 6px 4px';
     }
   } else {
     cardPadding = '4px 8px';

--- a/source/javascripts/components/unified-editor/Triggers/ConditionCard.tsx
+++ b/source/javascripts/components/unified-editor/Triggers/ConditionCard.tsx
@@ -1,7 +1,6 @@
 import {
   Button,
   Card,
-  ControlButton,
   Icon,
   Input,
   Select,
@@ -14,6 +13,7 @@ import {
   Toggletip,
   Tr,
 } from '@bitrise/bitkit';
+import { BitkitControlButton, IconTrash } from '@bitrise/bitkit-v2';
 import { Checkbox, Tfoot } from 'chakra-ui-2--react';
 import { useMemo } from 'react';
 import { Controller, FieldArrayWithId, useFormContext } from 'react-hook-form';
@@ -136,13 +136,13 @@ const ConditionCard = ({ triggerType, fields, append, optionsMap, remove }: Prop
                 </Td>
                 {!isTagCondition && (
                   <Td height="auto" paddingBlock="12" verticalAlign="top" paddingLeft="0">
-                    <ControlButton
-                      iconName="Trash"
-                      aria-label="Remove"
-                      isTooltipDisabled={fields.length === 1}
+                    <BitkitControlButton
+                      icon={IconTrash}
+                      label="Remove"
+                      tooltipProps={{ disabled: fields.length === 1 }}
                       size="md"
                       isDanger
-                      isDisabled={fields.length === 1}
+                      state={fields.length === 1 ? 'disabled' : undefined}
                       onClick={() => remove(index)}
                     />
                   </Td>

--- a/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/WorkflowCard.tsx
@@ -1,4 +1,12 @@
-import { Box, Card, CardProps, Collapse, ControlButton, Text, Tooltip, useDisclosure } from '@bitrise/bitkit';
+import { Box, Card, CardProps, Collapse, Text, Tooltip, useDisclosure } from '@bitrise/bitkit';
+import {
+  BitkitControlButton,
+  IconChevronDown,
+  IconChevronUp,
+  IconLink,
+  IconSettings,
+  IconTrash,
+} from '@bitrise/bitkit-v2';
 import { memo, PropsWithChildren, ReactNode, useMemo, useRef, useState } from 'react';
 
 import { otherModulesLabel } from '@/components/EntityModuleProvenance';
@@ -132,16 +140,13 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
         {/* No expand/collapse for cross-file refs — their nested content lives in another file
             and isn't shown here, so the chevron is hidden rather than rendered disabled. */}
         {isCollapsable && !isCrossFile && (
-          <ControlButton
+          <BitkitControlButton
             size="xs"
             tabIndex={-1} // NOTE: Without this, the tooltip always appears when closing any drawers on the Workflows page.
             className="nopan"
             onClick={onToggle}
-            iconName={isOpen ? 'ChevronUp' : 'ChevronDown'}
-            aria-label={`${isOpen ? 'Collapse' : 'Expand'} Workflow details`}
-            tooltipProps={{
-              'aria-label': `${isOpen ? 'Collapse' : 'Expand'} Workflow details`,
-            }}
+            icon={isOpen ? IconChevronUp : IconChevronDown}
+            label={`${isOpen ? 'Collapse' : 'Expand'} Workflow details`}
           />
         )}
 
@@ -156,11 +161,10 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
           <Box display={isJumpPopoverOpen ? 'inline-flex' : 'none'} _groupHover={{ display: 'inline-flex' }}>
             {/* Chaining writes into the definition — hidden for cross-file refs (another file). */}
             {onChainWorkflow && !isCrossFile && (
-              <ControlButton
+              <BitkitControlButton
                 size="xs"
-                iconName="Link"
-                aria-label="Chain Workflows"
-                tooltipProps={{ 'aria-label': 'Chain Workflows' }}
+                icon={IconLink}
+                label="Chain Workflows"
                 onClick={() => {
                   onOpen();
                   onChainWorkflow(id);
@@ -175,21 +179,19 @@ const WorkflowCardContent = memo(function WorkflowCardContent({
               <CrossFileJumpButton kind="workflows" id={workflowId} onOpenChange={setIsJumpPopoverOpen} />
             )}
             {onEditWorkflow && (
-              <ControlButton
+              <BitkitControlButton
                 size="xs"
-                iconName="Settings"
-                aria-label="Edit Workflow"
-                tooltipProps={{ 'aria-label': 'Edit Workflow' }}
+                icon={IconSettings}
+                label="Edit Workflow"
                 onClick={() => onEditWorkflow(id)}
               />
             )}
             {onRemoveWorkflow && (
-              <ControlButton
+              <BitkitControlButton
                 isDanger
                 size="xs"
-                iconName="Trash"
-                aria-label="Remove Workflow"
-                tooltipProps={{ 'aria-label': 'Remove Workflow' }}
+                icon={IconTrash}
+                label="Remove Workflow"
                 onClick={() => onRemoveWorkflow(id)}
               />
             )}

--- a/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
+++ b/source/javascripts/components/unified-editor/WorkflowCard/components/ChainedWorkflowCard.tsx
@@ -1,4 +1,12 @@
-import { Box, ButtonGroup, Card, CardProps, Collapse, ControlButton, Text, useDisclosure } from '@bitrise/bitkit';
+import { Box, ButtonGroup, Card, CardProps, Collapse, Text, useDisclosure } from '@bitrise/bitkit';
+import {
+  BitkitControlButton,
+  IconChevronDown,
+  IconChevronUp,
+  IconLink,
+  IconSettings,
+  IconTrash,
+} from '@bitrise/bitkit-v2';
 import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { memo, useMemo, useRef, useState } from 'react';
@@ -117,11 +125,10 @@ const ChainedWorkflowCard = ({ id, index, uniqueId, placement, isSortable, isDra
     return (
       <ButtonGroup spacing="0" display={isJumpPopoverOpen ? 'flex' : 'none'} _groupHover={{ display: 'flex' }}>
         {onChainChainedWorkflow && !isCrossFile && (
-          <ControlButton
+          <BitkitControlButton
             size="xs"
-            iconName="Link"
-            aria-label="Chain Workflows"
-            tooltipProps={{ 'aria-label': 'Chain Workflows' }}
+            icon={IconLink}
+            label="Chain Workflows"
             onClick={() => {
               onOpen();
               onChainChainedWorkflow(id);
@@ -134,21 +141,19 @@ const ChainedWorkflowCard = ({ id, index, uniqueId, placement, isSortable, isDra
           <CrossFileJumpButton kind="workflows" id={id} onOpenChange={setIsJumpPopoverOpen} />
         )}
         {onEditChainedWorkflow && (
-          <ControlButton
+          <BitkitControlButton
             size="xs"
-            iconName="Settings"
-            aria-label="Edit Workflow"
-            tooltipProps={{ 'aria-label': 'Edit Workflow' }}
+            icon={IconSettings}
+            label="Edit Workflow"
             onClick={() => onEditChainedWorkflow(id, parentWorkflowId)}
           />
         )}
         {onRemoveChainedWorkflow && (
-          <ControlButton
+          <BitkitControlButton
             isDanger
             size="xs"
-            iconName="Trash"
-            aria-label="Remove Workflow"
-            tooltipProps={{ 'aria-label': 'Remove' }}
+            icon={IconTrash}
+            label="Remove Workflow"
             onClick={() => onRemoveChainedWorkflow(parentWorkflowId, placement, id, index)}
           />
         )}
@@ -192,17 +197,15 @@ const ChainedWorkflowCard = ({ id, index, uniqueId, placement, isSortable, isDra
 
             {/* No expand/collapse for cross-file refs — their nested content isn't shown here. */}
             {!isCrossFile && (
-              <ControlButton
+              <BitkitControlButton
                 size="xs"
                 tabIndex={-1} // NOTE: Without this, the tooltip always appears when closing any drawers on the Workflows page.
                 className="nopan"
                 onClick={onToggle}
-                isDisabled={isDragging}
-                iconName={isOpen ? 'ChevronUp' : 'ChevronDown'}
-                aria-label={!isDragging ? `${isOpen ? 'Collapse' : 'Expand'} Workflow details` : ''}
-                tooltipProps={{
-                  'aria-label': `${isOpen ? 'Collapse' : 'Expand'} Workflow details`,
-                }}
+                state={isDragging ? 'disabled' : undefined}
+                icon={isOpen ? IconChevronUp : IconChevronDown}
+                label={`${isOpen ? 'Collapse' : 'Expand'} Workflow details`}
+                tooltipProps={{ disabled: isDragging }}
               />
             )}
 

--- a/source/javascripts/pages/ContainersPage/components/ContainersTable.tsx
+++ b/source/javascripts/pages/ContainersPage/components/ContainersTable.tsx
@@ -1,17 +1,5 @@
-import {
-  Box,
-  ControlButton,
-  Link,
-  Table,
-  Tbody,
-  Td,
-  Text,
-  Th,
-  Thead,
-  Tr,
-  useDisclosure,
-  useResponsive,
-} from '@bitrise/bitkit';
+import { Box, Link, Table, Tbody, Td, Text, Th, Thead, Tr, useDisclosure, useResponsive } from '@bitrise/bitkit';
+import { BitkitControlButton, IconDetails, IconMinusCircle, IconPencil } from '@bitrise/bitkit-v2';
 import { useState } from 'react';
 
 import { segmentTrack } from '@/core/analytics/SegmentBaseTracking';
@@ -111,10 +99,9 @@ const ContainersTable = ({
                 <Td textAlign="right">
                   {isReadOnlyView ? (
                     // Merged/cross-file (read-only) view: edit + delete collapse to a single read-only detail view.
-                    <ControlButton
-                      aria-label="View container details"
-                      iconName="Details"
-                      color="icon/primary"
+                    <BitkitControlButton
+                      label="View container details"
+                      icon={IconDetails}
                       onClick={() => {
                         setEditedContainer(container);
                         openDialog();
@@ -122,20 +109,19 @@ const ContainersTable = ({
                     />
                   ) : (
                     <>
-                      <ControlButton
-                        aria-label="Edit container"
-                        iconName="Pencil"
-                        color="icon/primary"
+                      <BitkitControlButton
+                        label="Edit container"
+                        icon={IconPencil}
                         onClick={() => {
                           setEditedContainer(container);
                           openDialog();
                         }}
-                        mr={['0', '8']}
+                        marginInlineEnd={['0', '8']}
                       />
-                      <ControlButton
-                        aria-label="Delete container"
-                        iconName="MinusCircle"
-                        color="icon/negative"
+                      <BitkitControlButton
+                        label="Delete container"
+                        icon={IconMinusCircle}
+                        isDanger
                         onClick={() => {
                           setSelectedContainerId(container.id);
                           onDeleteContainerDialogOpen();

--- a/source/javascripts/pages/ContainersPage/components/CreateOrEditContainerDialog.tsx
+++ b/source/javascripts/pages/ContainersPage/components/CreateOrEditContainerDialog.tsx
@@ -3,7 +3,6 @@ import {
   Button,
   ButtonGroup,
   Collapse,
-  ControlButton,
   Dialog,
   DialogBody,
   DialogFooter,
@@ -16,6 +15,7 @@ import {
   Textarea,
   useDisclosure,
 } from '@bitrise/bitkit';
+import { BitkitControlButton, IconTrash } from '@bitrise/bitkit-v2';
 import { useEffect } from 'react';
 import { Controller, useFieldArray, useForm } from 'react-hook-form';
 
@@ -334,12 +334,12 @@ const CreateOrEditContainerDialog = (props: CreateOrEditContainerDialogProps) =>
                       onSelect={(envVar) => update(index, { ...fields[index], value: `$${envVar.key}` })}
                       showCreate={false}
                     />
-                    <ControlButton
-                      iconName="Trash"
+                    <BitkitControlButton
+                      icon={IconTrash}
                       isDanger
-                      isDisabled={fields.length === 1}
+                      state={fields.length === 1 ? 'disabled' : undefined}
                       size="lg"
-                      aria-label="Remove environment variable"
+                      label="Remove environment variable"
                       onClick={() => remove(index)}
                     />
                   </ButtonGroup>


### PR DESCRIPTION
## Summary

[BIVS-3758](https://bitrise.atlassian.net/browse/BIVS-3758)

Control buttons across the Workflow Editor now use **label tooltips**. This is achieved by migrating every legacy `ControlButton` (`@bitrise/bitkit`, Chakra v2) to the v2 `BitkitControlButton` (`@bitrise/bitkit-v2`), which wraps itself in `BitkitLabelTooltip` — so the `label` prop drives both the accessible name and the hover tooltip.

Also bumps `@bitrise/bitkit-v2` to `^0.3.324`.

## Changes

Migrated legacy `ControlButton` → `BitkitControlButton` in 10 files:

- `EditableInput.tsx` — Change / Cancel / Edit
- `SortableEnvVarItem.tsx` — Remove
- `ConditionCard.tsx` — Remove
- `ContainerCardItem.tsx` — Delete
- `AlgoliaStepListItem.tsx` — Add to Workflow
- `StepBundleCard.tsx` — Expand/Collapse
- `WorkflowCard.tsx` — Expand / Chain / Edit / Remove
- `ChainedWorkflowCard.tsx` — Expand / Chain / Edit / Remove
- `CreateOrEditContainerDialog.tsx` — Remove env var
- `ContainersTable.tsx` — Details / Edit / Delete

Prop mappings applied:

- `iconName="X"` → `icon={IconX}`
- `aria-label` + redundant `tooltipProps={{ 'aria-label' }}` → single `label`
- `isDisabled` → `state={... ? 'disabled' : undefined}`
- `isTooltipDisabled` / drag-time tooltip suppression → `tooltipProps={{ disabled }}`
- raw `color="icon/negative"` on delete buttons → `isDanger` (v2-idiomatic)
- `mx`/`mr` shorthands → logical `marginInline` / `marginInlineEnd`

Not touched: places already on v2 (JumpToFile/CrossFileJump, ConfigSettingsMenu, UpdateConfigurationDialog, ContainerUsageTable), and the `Regex` `ToggleButton` (not a control button). `Input`/`ButtonGroup`/`Tooltip` v1 components left as-is (out of scope).

Minor copy note: a couple of tooltip strings were unified for consistency — e.g. ChainedWorkflowCard's remove button tooltip changed from "Remove" to "Remove Workflow" (matching its WorkflowCard sibling).

## Test plan

- [x] `tsc --noEmit` passes (exit 0)
- [x] `eslint` clean on changed files (only pre-existing ref warnings remain)
- [x] Visual check: hover each control button and confirm the label tooltip appears as in the ticket screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[BIVS-3758]: https://bitrise.atlassian.net/browse/BIVS-3758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ