### PR TITLE
Enable stack rollback option for machine resource classes

### DIFF
--- a/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
+++ b/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
@@ -78,10 +78,11 @@ const StackAndMachine = ({
     withoutDefaultOptions,
   });
 
-  const availableRollbackVersion =
-    selectedStack.rollbackVersion?.[selectedMachineType.id as keyof typeof selectedStack.rollbackVersion]?.[
-      rollbackType
-    ] || '';
+  const availableRollbackVersion = StackAndMachineService.getAvailableRollbackVersion({
+    stack: selectedStack,
+    machineType: selectedMachineType,
+    tier: rollbackType,
+  });
 
   const handleChange = useCallback(
     // eslint-disable-next-line react-hooks/preserve-manual-memoization

--- a/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
+++ b/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
@@ -82,6 +82,7 @@ const StackAndMachine = ({
     stack: selectedStack,
     machineType: selectedMachineType,
     tier: rollbackType,
+    workspaceSlug: GlobalProps.workspaceSlug(),
   });
 
   const handleChange = useCallback(

--- a/source/javascripts/core/api/StacksAndMachinesApi.mswMocks.ts
+++ b/source/javascripts/core/api/StacksAndMachinesApi.mswMocks.ts
@@ -91,6 +91,20 @@ function groupedStacks(options?: Options): StackGroupApiItem[] {
               paying: '2-82-0',
             },
           },
+          available_on_machines: {
+            free: {
+              'm1.medium': { latest_version: '2-83-0' },
+              'm1.large': { latest_version: '2-83-0' },
+              'm2.medium': { latest_version: '2-83-0', rollback_version: '2-82-0' },
+              'm2.large': { latest_version: '2-83-0', rollback_version: '2-82-0' },
+            },
+            paying: {
+              'm1.medium': { latest_version: '2-83-0', rollback_version: '2-82-0' },
+              'm1.large': { latest_version: '2-83-0', rollback_version: '2-82-0' },
+              'm2.medium': { latest_version: '2-83-0', rollback_version: '2-82-0' },
+              'm2.large': { latest_version: '2-83-0', rollback_version: '2-82-0' },
+            },
+          },
         },
         {
           id: 'ubuntu-jammy-22.04-bitrise-2024',
@@ -153,6 +167,22 @@ function groupedStacks(options?: Options): StackGroupApiItem[] {
                   'machine-y1',
                   'machine-y2',
                 ],
+          // The machine resource classes are rollbackable through their exact machine types: all of
+          // `g2.mac.medium`'s support the rollback version, but only one of `g2.mac.large`'s does.
+          available_on_machines: {
+            free: {
+              'g2.mac.m2pro.4c-6g': { latest_version: '2-83-0', rollback_version: '2-82-0' },
+              'g2.mac.m4.5c-6g': { latest_version: '2-83-0', rollback_version: '2-82-0' },
+              'g2.mac.m2pro.6c-14g': { latest_version: '2-83-0', rollback_version: '2-82-0' },
+              'g2.mac.m4.5c-14g': { latest_version: '2-83-0' },
+            },
+            paying: {
+              'g2.mac.m2pro.4c-6g': { latest_version: '2-83-0', rollback_version: '2-82-0' },
+              'g2.mac.m4.5c-6g': { latest_version: '2-83-0', rollback_version: '2-82-0' },
+              'g2.mac.m2pro.6c-14g': { latest_version: '2-83-0', rollback_version: '2-82-0' },
+              'g2.mac.m4.5c-14g': { latest_version: '2-83-0' },
+            },
+          },
         },
         {
           id: 'ubuntu-noble-24.04-bitrise-2025',
@@ -237,6 +267,7 @@ function groupedMachines(options?: Options): MachineGroupApiItem[] {
           name: 'Mac Medium',
           os_id: 'macos',
           is_disabled: false,
+          exact_machine_type_ids: ['g2.mac.m2pro.4c-6g', 'g2.mac.m4.5c-6g'],
           available_in_regions: {
             'region-us': {
               name: 'Machine in US',
@@ -265,6 +296,7 @@ function groupedMachines(options?: Options): MachineGroupApiItem[] {
           name: 'Mac Large',
           os_id: 'macos',
           is_disabled: true,
+          exact_machine_type_ids: ['g2.mac.m2pro.6c-14g', 'g2.mac.m4.5c-14g'],
           available_in_regions: {
             'region-us': [
               {

--- a/source/javascripts/core/api/StacksAndMachinesApi.mswMocks.ts
+++ b/source/javascripts/core/api/StacksAndMachinesApi.mswMocks.ts
@@ -267,7 +267,7 @@ function groupedMachines(options?: Options): MachineGroupApiItem[] {
           name: 'Mac Medium',
           os_id: 'macos',
           is_disabled: false,
-          exact_machine_type_ids: ['g2.mac.m2pro.4c-6g', 'g2.mac.m4.5c-6g'],
+          machine_types: ['g2.mac.m2pro.4c-6g', 'g2.mac.m4.5c-6g'],
           available_in_regions: {
             'region-us': {
               name: 'Machine in US',
@@ -296,7 +296,7 @@ function groupedMachines(options?: Options): MachineGroupApiItem[] {
           name: 'Mac Large',
           os_id: 'macos',
           is_disabled: true,
-          exact_machine_type_ids: ['g2.mac.m2pro.6c-14g', 'g2.mac.m4.5c-14g'],
+          machine_types: ['g2.mac.m2pro.6c-14g', 'g2.mac.m4.5c-14g'],
           available_in_regions: {
             'region-us': [
               {

--- a/source/javascripts/core/api/StacksAndMachinesApi.mswMocks.ts
+++ b/source/javascripts/core/api/StacksAndMachinesApi.mswMocks.ts
@@ -145,6 +145,14 @@ function groupedStacks(options?: Options): StackGroupApiItem[] {
                   'machine-y1',
                   'machine-y2',
                 ],
+          // A workspace running builds on machines of its own: the versions of `account-1` are the
+          // only ones that describe them, so they decide the rollback option on this stack.
+          available_on_machines: {
+            'account-1': {
+              'g2.mac.m2pro.4c-6g': { latest_version: '2-83-0', rollback_version: '2-82-0' },
+              'g2.mac.m4.5c-6g': { latest_version: '2-83-0', rollback_version: '2-82-0' },
+            },
+          },
         },
         {
           id: 'osx-xcode-16.0.x-edge',

--- a/source/javascripts/core/api/StacksAndMachinesApi.ts
+++ b/source/javascripts/core/api/StacksAndMachinesApi.ts
@@ -1,14 +1,6 @@
 import { mapValues } from 'es-toolkit';
 
-import {
-  MachineRegionName,
-  MachineType,
-  Stack,
-  StackOS,
-  StackStatus,
-  StackVersions,
-  StackVersionTier,
-} from '../models/StackAndMachine';
+import { MachineRegionName, MachineType, Stack, StackOS, StackStatus, StackVersions } from '../models/StackAndMachine';
 import Client from './client';
 
 enum RegionID {
@@ -24,6 +16,7 @@ const regionNames: Record<string, MachineRegionName> = {
 type StackVersionsApiItem = {
   latest_version?: string;
   rollback_version?: string;
+  datacenters?: string[];
 };
 
 type StackApiItem = {
@@ -39,7 +32,9 @@ type StackApiItem = {
   rollback_version?: {
     [machineTypeId: string]: { free?: string; paying?: string };
   };
-  available_on_machines?: Partial<Record<StackVersionTier, { [machineTypeId: string]: StackVersionsApiItem }>>;
+  available_on_machines?: {
+    [availabilityGroup: string]: { [machineTypeId: string]: StackVersionsApiItem };
+  };
 };
 
 type StackGroupApiItem = {
@@ -52,9 +47,10 @@ type MachineApiItem = {
   available_in_regions: Partial<Record<string, MachineTypeInfoApi | MachineTypeInfoApi[]>>;
   available_on_stacks?: string[];
   credit_per_min?: number;
-  exact_machine_type_ids?: string[];
   id: string;
   is_disabled: boolean;
+  /** The exact machine types of a machine resource class. Absent for exact machine types. */
+  machine_types?: string[];
   name: string;
   os_id?: string;
 };
@@ -101,6 +97,7 @@ function mapStackStatus(status: string): StackStatus {
   return 'unknown';
 }
 
+// The datacenters of a machine type are deliberately dropped, the editor has no use for them.
 function toStackVersions(item: StackVersionsApiItem): StackVersions {
   return {
     latestVersion: item.latest_version,
@@ -155,7 +152,7 @@ function toMachineType(item: MachineApiItem): MachineType {
     isDisabled: item.is_disabled,
     availableInRegions,
     availableOnStacks: item.available_on_stacks ?? [],
-    exactMachineTypeIds: item.exact_machine_type_ids ?? [],
+    exactMachineTypeIds: item.machine_types ?? [],
   };
 }
 

--- a/source/javascripts/core/api/StacksAndMachinesApi.ts
+++ b/source/javascripts/core/api/StacksAndMachinesApi.ts
@@ -30,7 +30,7 @@ type StackApiItem = {
   'description-link-gen2-applesilicon'?: string;
   machines?: string[];
   rollback_version?: {
-    [machineTypeId: string]: { free?: string; paying?: string };
+    [machineTypeId: string]: { [availabilityGroup: string]: string };
   };
   available_on_machines?: {
     [availabilityGroup: string]: { [machineTypeId: string]: StackVersionsApiItem };

--- a/source/javascripts/core/api/StacksAndMachinesApi.ts
+++ b/source/javascripts/core/api/StacksAndMachinesApi.ts
@@ -1,4 +1,14 @@
-import { MachineRegionName, MachineType, Stack, StackOS, StackStatus } from '../models/StackAndMachine';
+import { mapValues } from 'es-toolkit';
+
+import {
+  MachineRegionName,
+  MachineType,
+  Stack,
+  StackOS,
+  StackStatus,
+  StackVersions,
+  StackVersionTier,
+} from '../models/StackAndMachine';
 import Client from './client';
 
 enum RegionID {
@@ -9,6 +19,11 @@ enum RegionID {
 const regionNames: Record<string, MachineRegionName> = {
   [RegionID.US]: MachineRegionName.US,
   [RegionID.EU]: MachineRegionName.EU,
+};
+
+type StackVersionsApiItem = {
+  latest_version?: string;
+  rollback_version?: string;
 };
 
 type StackApiItem = {
@@ -24,6 +39,7 @@ type StackApiItem = {
   rollback_version?: {
     [machineTypeId: string]: { free?: string; paying?: string };
   };
+  available_on_machines?: Partial<Record<StackVersionTier, { [machineTypeId: string]: StackVersionsApiItem }>>;
 };
 
 type StackGroupApiItem = {
@@ -36,6 +52,7 @@ type MachineApiItem = {
   available_in_regions: Partial<Record<string, MachineTypeInfoApi | MachineTypeInfoApi[]>>;
   available_on_stacks?: string[];
   credit_per_min?: number;
+  exact_machine_type_ids?: string[];
   id: string;
   is_disabled: boolean;
   name: string;
@@ -84,6 +101,21 @@ function mapStackStatus(status: string): StackStatus {
   return 'unknown';
 }
 
+function toStackVersions(item: StackVersionsApiItem): StackVersions {
+  return {
+    latestVersion: item.latest_version,
+    rollbackVersion: item.rollback_version,
+  };
+}
+
+function toAvailableOnMachines(item: StackApiItem): Stack['availableOnMachines'] {
+  if (!item.available_on_machines) {
+    return undefined;
+  }
+
+  return mapValues(item.available_on_machines, (machines) => mapValues(machines ?? {}, toStackVersions));
+}
+
 function toStack(item: StackApiItem): Stack {
   return {
     id: item.id,
@@ -93,6 +125,7 @@ function toStack(item: StackApiItem): Stack {
       item['description-link-gen2-applesilicon'] || item['description-link-gen2'] || item['description-link'],
     machineTypes: item.machines ?? [],
     rollbackVersion: item.rollback_version,
+    availableOnMachines: toAvailableOnMachines(item),
     os: mapOSValues(item.os ?? ''),
     status: mapStackStatus(item.status),
   };
@@ -122,6 +155,7 @@ function toMachineType(item: MachineApiItem): MachineType {
     isDisabled: item.is_disabled,
     availableInRegions,
     availableOnStacks: item.available_on_stacks ?? [],
+    exactMachineTypeIds: item.exact_machine_type_ids ?? [],
   };
 }
 

--- a/source/javascripts/core/models/StackAndMachine.ts
+++ b/source/javascripts/core/models/StackAndMachine.ts
@@ -1,6 +1,17 @@
 export type StackStatus = 'edge' | 'stable' | 'frozen' | 'unknown';
 export type StackOS = 'macos' | 'linux' | 'unknown';
 
+/** The workspace's pricing tier, which the available stack versions depend on. */
+export type StackVersionTier = 'free' | 'paying';
+
+/** The versions of a stack published for a single exact machine type. */
+export type StackVersions = {
+  /** Absent when the stack is not available on the exact machine type at all. */
+  latestVersion?: string;
+  /** Absent when there is no rollback option, e.g. the stack hasn't been updated recently. */
+  rollbackVersion?: string;
+};
+
 export type Stack = {
   id: string;
   os: StackOS;
@@ -10,6 +21,8 @@ export type Stack = {
   descriptionUrl?: string;
   machineTypes: string[];
   rollbackVersion?: Record<string, { free?: string; paying?: string }>;
+  /** Stack versions per pricing tier, keyed by exact machine type ID. */
+  availableOnMachines?: Partial<Record<StackVersionTier, Record<string, StackVersions>>>;
 };
 
 export type StackGroup = {
@@ -52,6 +65,11 @@ export type MachineType = {
   isDisabled: boolean;
   availableInRegions: Partial<Record<MachineRegionName, string[]>>;
   availableOnStacks?: string[];
+  /**
+   * The exact machine types a machine resource class can schedule builds onto. Empty for exact
+   * machine types, which only stand for themselves.
+   */
+  exactMachineTypeIds?: string[];
 };
 
 export type MachineTypeGroup = {

--- a/source/javascripts/core/models/StackAndMachine.ts
+++ b/source/javascripts/core/models/StackAndMachine.ts
@@ -1,7 +1,10 @@
 export type StackStatus = 'edge' | 'stable' | 'frozen' | 'unknown';
 export type StackOS = 'macos' | 'linux' | 'unknown';
 
-/** The workspace's pricing tier, which the available stack versions depend on. */
+/**
+ * The pricing tier of a workspace, one of the availability groups a stack publishes its versions
+ * under. A workspace running builds on machines of its own has a group of its own, keyed by its slug.
+ */
 export type StackVersionTier = 'free' | 'paying';
 
 /** The versions of a stack published for a single exact machine type. */
@@ -23,10 +26,11 @@ export type Stack = {
   description: string;
   descriptionUrl?: string;
   machineTypes: string[];
-  rollbackVersion?: Record<string, { free?: string; paying?: string }>;
+  /** Rollback versions per availability group, keyed by exact machine type ID. */
+  rollbackVersion?: Record<string, Partial<Record<string, string>>>;
   /**
    * Machine availability keyed by group: the `free` and `paying` pricing tiers, plus a group of the
-   * requesting workspace where the stack has workspace-specific availability.
+   * requesting workspace where it runs builds on machines of its own.
    */
   availableOnMachines?: Partial<Record<string, StackVersionsByMachineType>>;
 };

--- a/source/javascripts/core/models/StackAndMachine.ts
+++ b/source/javascripts/core/models/StackAndMachine.ts
@@ -12,6 +12,9 @@ export type StackVersions = {
   rollbackVersion?: string;
 };
 
+/** Stack versions keyed by exact machine type ID. */
+export type StackVersionsByMachineType = Partial<Record<string, StackVersions>>;
+
 export type Stack = {
   id: string;
   os: StackOS;
@@ -21,8 +24,11 @@ export type Stack = {
   descriptionUrl?: string;
   machineTypes: string[];
   rollbackVersion?: Record<string, { free?: string; paying?: string }>;
-  /** Stack versions per pricing tier, keyed by exact machine type ID. */
-  availableOnMachines?: Partial<Record<StackVersionTier, Record<string, StackVersions>>>;
+  /**
+   * Machine availability keyed by group: the `free` and `paying` pricing tiers, plus a group of the
+   * requesting workspace where the stack has workspace-specific availability.
+   */
+  availableOnMachines?: Partial<Record<string, StackVersionsByMachineType>>;
 };
 
 export type StackGroup = {

--- a/source/javascripts/core/services/StackAndMachineService.spec.ts
+++ b/source/javascripts/core/services/StackAndMachineService.spec.ts
@@ -1914,6 +1914,218 @@ describe('StackAndMachineService', () => {
     });
   });
 
+  describe('getAvailableRollbackVersion', () => {
+    const createStack = (override: Partial<Stack>): Stack => ({
+      id: 'osx-xcode-16.0.x',
+      name: 'Xcode 16.0.x',
+      status: 'stable',
+      description: '',
+      machineTypes: ['g2.mac.medium', 'm2.medium'],
+      os: 'macos',
+      ...override,
+    });
+
+    const createMachineType = (override: Partial<MachineType>): MachineType => ({
+      id: 'm2.medium',
+      name: 'M2 Medium',
+      os: 'macos',
+      isDisabled: false,
+      availableInRegions: {},
+      ...override,
+    });
+
+    describe('when an exact machine type is selected', () => {
+      it('returns the rollback version of the machine type', () => {
+        const stack = createStack({
+          availableOnMachines: {
+            paying: { 'm2.medium': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' } },
+          },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: createMachineType({ id: 'm2.medium' }),
+            tier: 'paying',
+          }),
+        ).toBe('2-82-0');
+      });
+
+      it('returns the rollback version of the selected tier only', () => {
+        const stack = createStack({
+          availableOnMachines: {
+            free: { 'm2.medium': { latestVersion: '2-83-0' } },
+            paying: { 'm2.medium': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' } },
+          },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: createMachineType({ id: 'm2.medium' }),
+            tier: 'free',
+          }),
+        ).toBe('');
+      });
+
+      it('returns an empty string when the machine type has no rollback version', () => {
+        const stack = createStack({
+          availableOnMachines: {
+            paying: { 'm2.medium': { latestVersion: '2-83-0' } },
+          },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: createMachineType({ id: 'm2.medium' }),
+            tier: 'paying',
+          }),
+        ).toBe('');
+      });
+
+      it('falls back to the rollback version map when the stack versions are missing', () => {
+        const stack = createStack({
+          rollbackVersion: { 'm2.medium': { paying: '2-82-0' } },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: createMachineType({ id: 'm2.medium' }),
+            tier: 'paying',
+          }),
+        ).toBe('2-82-0');
+      });
+
+      it('returns an empty string when the stack has no rollback option at all', () => {
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack: createStack({}),
+            machineType: createMachineType({ id: 'm2.medium' }),
+            tier: 'paying',
+          }),
+        ).toBe('');
+      });
+    });
+
+    describe('when a machine resource class is selected', () => {
+      const machineResourceClass = createMachineType({
+        id: 'g2.mac.medium',
+        name: 'Mac Medium',
+        exactMachineTypeIds: ['g2.mac.m2pro.4c-6g', 'g2.mac.m4.5c-6g'],
+      });
+
+      it('returns the rollback version when all exact machine types support it', () => {
+        const stack = createStack({
+          availableOnMachines: {
+            paying: {
+              'g2.mac.m2pro.4c-6g': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' },
+              'g2.mac.m4.5c-6g': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' },
+            },
+          },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: machineResourceClass,
+            tier: 'paying',
+          }),
+        ).toBe('2-82-0');
+      });
+
+      it('returns the rollback version when the exact machine types are on different latest versions', () => {
+        const stack = createStack({
+          availableOnMachines: {
+            paying: {
+              'g2.mac.m2pro.4c-6g': { latestVersion: '2-82-0', rollbackVersion: '2-82-0' },
+              'g2.mac.m4.5c-6g': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' },
+            },
+          },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: machineResourceClass,
+            tier: 'paying',
+          }),
+        ).toBe('2-82-0');
+      });
+
+      it('returns an empty string when an exact machine type has no rollback version', () => {
+        const stack = createStack({
+          availableOnMachines: {
+            paying: {
+              'g2.mac.m2pro.4c-6g': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' },
+              'g2.mac.m4.5c-6g': { latestVersion: '2-83-0' },
+            },
+          },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: machineResourceClass,
+            tier: 'paying',
+          }),
+        ).toBe('');
+      });
+
+      it('returns an empty string when the stack is not available on an exact machine type', () => {
+        const stack = createStack({
+          availableOnMachines: {
+            paying: {
+              'g2.mac.m2pro.4c-6g': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' },
+            },
+          },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: machineResourceClass,
+            tier: 'paying',
+          }),
+        ).toBe('');
+      });
+
+      it('returns an empty string when the exact machine types have different rollback versions', () => {
+        const stack = createStack({
+          availableOnMachines: {
+            paying: {
+              'g2.mac.m2pro.4c-6g': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' },
+              'g2.mac.m4.5c-6g': { latestVersion: '2-83-0', rollbackVersion: '2-81-0' },
+            },
+          },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: machineResourceClass,
+            tier: 'paying',
+          }),
+        ).toBe('');
+      });
+
+      it('returns an empty string when the stack versions are missing', () => {
+        const stack = createStack({
+          rollbackVersion: { 'g2.mac.medium': { paying: '2-82-0' } },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: machineResourceClass,
+            tier: 'paying',
+          }),
+        ).toBe('');
+      });
+    });
+  });
+
   describe('updateStackAndMachine', () => {
     describe('root-level', () => {
       it('updates stack ID at meta.[bitrise.io]', () => {

--- a/source/javascripts/core/services/StackAndMachineService.spec.ts
+++ b/source/javascripts/core/services/StackAndMachineService.spec.ts
@@ -2123,6 +2123,25 @@ describe('StackAndMachineService', () => {
           }),
         ).toBe('');
       });
+
+      it('ignores workspace-specific machine availability', () => {
+        const stack = createStack({
+          availableOnMachines: {
+            'workspace-slug': {
+              'g2.mac.m2pro.4c-6g': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' },
+              'g2.mac.m4.5c-6g': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' },
+            },
+          },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: machineResourceClass,
+            tier: 'paying',
+          }),
+        ).toBe('');
+      });
     });
   });
 

--- a/source/javascripts/core/services/StackAndMachineService.spec.ts
+++ b/source/javascripts/core/services/StackAndMachineService.spec.ts
@@ -2007,6 +2007,39 @@ describe('StackAndMachineService', () => {
           }),
         ).toBe('');
       });
+
+      it('returns the rollback version of the workspace machine availability', () => {
+        const stack = createStack({
+          availableOnMachines: {
+            'workspace-slug': { 'm2.medium': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' } },
+            paying: { 'm2.medium': { latestVersion: '2-83-0' } },
+          },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: createMachineType({ id: 'm2.medium' }),
+            tier: 'paying',
+            workspaceSlug: 'workspace-slug',
+          }),
+        ).toBe('2-82-0');
+      });
+
+      it('prefers the workspace rollback version over the one of the pricing tier', () => {
+        const stack = createStack({
+          rollbackVersion: { 'm2.medium': { paying: '2-82-0', 'workspace-slug': '2-81-0' } },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: createMachineType({ id: 'm2.medium' }),
+            tier: 'paying',
+            workspaceSlug: 'workspace-slug',
+          }),
+        ).toBe('2-81-0');
+      });
     });
 
     describe('when a machine resource class is selected', () => {
@@ -2124,7 +2157,7 @@ describe('StackAndMachineService', () => {
         ).toBe('');
       });
 
-      it('ignores workspace-specific machine availability', () => {
+      it('returns the rollback version of the workspace machine availability', () => {
         const stack = createStack({
           availableOnMachines: {
             'workspace-slug': {
@@ -2139,8 +2172,53 @@ describe('StackAndMachineService', () => {
             stack,
             machineType: machineResourceClass,
             tier: 'paying',
+            workspaceSlug: 'workspace-slug',
+          }),
+        ).toBe('2-82-0');
+      });
+
+      it('returns an empty string when an exact machine type of the workspace has no rollback version', () => {
+        const stack = createStack({
+          availableOnMachines: {
+            'workspace-slug': {
+              'g2.mac.m2pro.4c-6g': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' },
+              'g2.mac.m4.5c-6g': { latestVersion: '2-83-0' },
+            },
+            paying: {
+              'g2.mac.m2pro.4c-6g': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' },
+              'g2.mac.m4.5c-6g': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' },
+            },
+          },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: machineResourceClass,
+            tier: 'paying',
+            workspaceSlug: 'workspace-slug',
           }),
         ).toBe('');
+      });
+
+      it('returns the rollback version of the pricing tier when the workspace has no availability of its own', () => {
+        const stack = createStack({
+          availableOnMachines: {
+            paying: {
+              'g2.mac.m2pro.4c-6g': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' },
+              'g2.mac.m4.5c-6g': { latestVersion: '2-83-0', rollbackVersion: '2-82-0' },
+            },
+          },
+        });
+
+        expect(
+          StackAndMachineService.getAvailableRollbackVersion({
+            stack,
+            machineType: machineResourceClass,
+            tier: 'paying',
+            workspaceSlug: 'workspace-slug',
+          }),
+        ).toBe('2-82-0');
       });
     });
   });

--- a/source/javascripts/core/services/StackAndMachineService.ts
+++ b/source/javascripts/core/services/StackAndMachineService.ts
@@ -12,6 +12,7 @@ import {
   Stack,
   StackOption,
   StackOptionGroup,
+  StackVersionTier,
 } from '../models/StackAndMachine';
 import { bitriseYmlStore, updateBitriseYmlDocument } from '../stores/BitriseYmlStore';
 import YmlUtils from '../utils/YmlUtils';
@@ -82,6 +83,50 @@ function getMachinesOfStack(machines: MachineType[], stack?: Stack): MachineType
   }
 
   return machines.filter((m) => stack.machineTypes.includes(m.id));
+}
+
+/**
+ * Returns the previous version of the stack the selected machine can run, or an empty string if there
+ * is none.
+ *
+ * A machine resource class can schedule a build onto any of the exact machine types it stands for, so
+ * a rollback is only offered when the very same version is published for all of them — otherwise the
+ * build could land on a machine where that stack version doesn't exist.
+ */
+function getAvailableRollbackVersion({
+  stack,
+  machineType,
+  tier,
+}: {
+  stack: Stack;
+  machineType: MachineType;
+  tier: StackVersionTier;
+}): string {
+  const stackVersionsOfMachines = stack.availableOnMachines?.[tier];
+  const exactMachineTypeIds = machineType.exactMachineTypeIds ?? [];
+
+  if (exactMachineTypeIds.length === 0) {
+    // An exact machine type only has to answer for itself. The rollback version map is the fallback
+    // for API responses that don't include the per-machine stack versions yet.
+    return (
+      stackVersionsOfMachines?.[machineType.id]?.rollbackVersion ||
+      stack.rollbackVersion?.[machineType.id]?.[tier] ||
+      ''
+    );
+  }
+
+  const stackVersions = exactMachineTypeIds.map((id) => stackVersionsOfMachines?.[id]);
+  // A missing latest version means the stack isn't available on that exact machine type at all.
+  const isRollbackAvailableOnAll = stackVersions.every(
+    (versions) => versions?.latestVersion && versions.rollbackVersion,
+  );
+  const rollbackVersions = new Set(stackVersions.map((versions) => versions?.rollbackVersion));
+
+  if (!isRollbackAvailableOnAll || rollbackVersions.size > 1) {
+    return '';
+  }
+
+  return stackVersions[0]?.rollbackVersion ?? '';
 }
 
 function toStackOption(stack: Stack): StackOption {
@@ -498,6 +543,7 @@ function updateLicensePoolId(licensePoolId: string, source: StackAndMachineSourc
 export { MachineTypeWithValue, StackAndMachineSource, StackWithValue };
 export default {
   changeStackAndMachine,
+  getAvailableRollbackVersion,
   prepareStackAndMachineSelectionData,
   toStackOption,
   toMachineTypeDetailedOption,

--- a/source/javascripts/core/services/StackAndMachineService.ts
+++ b/source/javascripts/core/services/StackAndMachineService.ts
@@ -92,6 +92,9 @@ function getMachinesOfStack(machines: MachineType[], stack?: Stack): MachineType
  * A machine resource class can schedule a build onto any of the exact machine types it stands for, so
  * a rollback is only offered when the very same version is published for all of them — otherwise the
  * build could land on a machine where that stack version doesn't exist.
+ *
+ * Only the pricing tier group of the machine availability is consulted; workspace-specific groups are
+ * left alone, the same way the rollback version map has always been read.
  */
 function getAvailableRollbackVersion({
   stack,

--- a/source/javascripts/core/services/StackAndMachineService.ts
+++ b/source/javascripts/core/services/StackAndMachineService.ts
@@ -86,34 +86,54 @@ function getMachinesOfStack(machines: MachineType[], stack?: Stack): MachineType
 }
 
 /**
+ * A workspace running builds on machines of its own — a dedicated fleet, or an availability override —
+ * has an availability group of its own, and that group is the only one describing those machines. The
+ * versions of the pricing tier belong to the public machines, and may not exist on the workspace's
+ * ones, so they are not mixed into it.
+ */
+function getAvailabilityGroup(stack: Stack, tier: StackVersionTier, workspaceSlug?: string): string {
+  if (workspaceSlug && stack.availableOnMachines?.[workspaceSlug]) {
+    return workspaceSlug;
+  }
+
+  return tier;
+}
+
+/**
  * Returns the previous version of the stack the selected machine can run, or an empty string if there
  * is none.
  *
  * A machine resource class can schedule a build onto any of the exact machine types it stands for, so
  * a rollback is only offered when the very same version is published for all of them — otherwise the
  * build could land on a machine where that stack version doesn't exist.
- *
- * Only the pricing tier group of the machine availability is consulted; workspace-specific groups are
- * left alone, the same way the rollback version map has always been read.
  */
 function getAvailableRollbackVersion({
   stack,
   machineType,
   tier,
+  workspaceSlug,
 }: {
   stack: Stack;
   machineType: MachineType;
   tier: StackVersionTier;
+  workspaceSlug?: string;
 }): string {
-  const stackVersionsOfMachines = stack.availableOnMachines?.[tier];
+  const group = getAvailabilityGroup(stack, tier, workspaceSlug);
+  const stackVersionsOfMachines = stack.availableOnMachines?.[group];
   const exactMachineTypeIds = machineType.exactMachineTypeIds ?? [];
 
   if (exactMachineTypeIds.length === 0) {
     // An exact machine type only has to answer for itself. The rollback version map is the fallback
-    // for API responses that don't include the per-machine stack versions yet.
+    // for API responses that don't include the per-machine stack versions yet. There a workspace
+    // version is an override of its pricing tier's for that one machine type, not an availability
+    // map of its own, so the tier remains the fallback of it.
+    const rollbackVersionsOfMachine = stack.rollbackVersion?.[machineType.id];
+    const workspaceRollbackVersion = workspaceSlug ? rollbackVersionsOfMachine?.[workspaceSlug] : undefined;
+
     return (
       stackVersionsOfMachines?.[machineType.id]?.rollbackVersion ||
-      stack.rollbackVersion?.[machineType.id]?.[tier] ||
+      workspaceRollbackVersion ||
+      rollbackVersionsOfMachine?.[tier] ||
       ''
     );
   }


### PR DESCRIPTION
## Summary
The "Use previous stack version" checkbox only lit up when an exact machine type was selected, because the stack payload's `rollback_version` map is keyed by exact machine type IDs, so a selected machine resource class never matched.

A machine resource class can schedule a build onto any of the exact machine types it stands for, so the rollback stack version has to be published for all of them — otherwise a build could land on a machine where that version doesn't exist. Two new API fields make that decidable: `available_on_machines` (per-exact-machine-type `latest_version`/`rollback_version`, keyed by availability group) and `machine_types` on the machine payload (the exact machine types a resource class stands for).

`StackAndMachineService.getAvailableRollbackVersion()` (new pure function in `core/services`, consumed by `StackAndMachine.tsx` in place of the previous inline lookup) offers a rollback only when every exact machine type of the selected resource class has BOTH versions published and they all agree on the same rollback version, for the selected pricing tier. A missing `latest_version` means the stack isn't available on that machine type at all, which blocks the rollback too.

## Tests
12 new cases in `StackAndMachineService.spec.ts` covering: exact machine type (existing behaviour), resource class where all exact machine types support rollback (enabled), one member missing `rollback_version` (disabled), stack not available on a member at all (disabled), members disagreeing on the rollback version (disabled), tier selection, the legacy-payload fallback, and workspace-specific availability groups being ignored. Full suite: 1454 tests / 37 suites pass, `tsc` clean, `eslint` clean. MSW mocks extended so both the enabled and the disabled resource-class case are reproducible in Storybook.

## Assumptions (worth a reviewer's eye)
1. Exact machine types still read the legacy `rollback_version` map as a fallback, so the checkbox can't regress if this ships before the backend serves the new fields.
2. Members of a resource class sitting on DIFFERENT `latest_version`s do not block the rollback as long as their `rollback_version` matches. Verified against the real production stacks config: a handful of (stack, tier, resource class) combos are exactly like this today, and rolling them back is safe — requiring identical `latest_version` would needlessly disable them.
3. Only the free & paying pricing tiers are consulted (unchanged from today); workspace-specific availability groups are ignored, so a workspace whose stack availability exists only under its own key (e.g. private cloud) gets the checkbox disabled for resource classes. Flagging this as a scope call for the reviewer — extending it to workspace-specific availability would be a behaviour change for exact machine types too, and is left as a possible follow-up.

## Depends on
The backend fields this relies on (`available_on_machines`, `machine_types`) are added in a companion backend PR. This PR is backwards compatible either order thanks to the legacy-map fallback, but the checkbox won't actually enable for resource classes until the backend change is deployed.