### PR TITLE
fix(tool setup): honour read-only views in tool setup, guard non-string versions

### DIFF
--- a/source/javascripts/components/StacksAndMachine/StackAndMachine.stories.tsx
+++ b/source/javascripts/components/StacksAndMachine/StackAndMachine.stories.tsx
@@ -1,0 +1,166 @@
+import { Box } from '@chakra-ui/react/box';
+import { Meta, StoryObj } from '@storybook/react-vite';
+import { set } from 'es-toolkit/compat';
+
+import JumpToFileButton from '@/components/JumpToDefinitionLink/JumpToFileButton';
+import { getStacksAndMachines } from '@/core/api/StacksAndMachinesApi.mswMocks';
+import ToolCatalogApiMocks from '@/core/api/ToolCatalogApi.mswMocks';
+import { TreeNode } from '@/core/models/Tree';
+import { FileSlice, MERGED_CONFIG_NODE_ID } from '@/core/stores/BitriseYmlStore';
+import YmlUtils from '@/core/utils/YmlUtils';
+
+import StackAndMachine from './StackAndMachine';
+
+const SHA = 'a1b2c3d4e5f6789012345678901234567890abcd';
+
+const TOOLS_YML = ['tools:', '  go: 1.23.0', '  nodejs: 22:latest', '  python: 3.13.4'].join('\n');
+
+const ROOT_YML = [
+  'meta:',
+  '  bitrise.io:',
+  '    stack: osx-xcode-16.0.x',
+  '    machine_type_id: m2.medium',
+  TOOLS_YML,
+  'workflows:',
+  '  primary:',
+  '    steps: []',
+  '',
+].join('\n');
+
+const MODULE_YML = [TOOLS_YML, 'workflows:', '  deploy:', '    steps: []', ''].join('\n');
+
+const slice = (nodeId: string, path: string, contents: string, editable: boolean, source: FileSlice['source']) => {
+  const doc = YmlUtils.toDoc(contents);
+  return { nodeId, path, source, commitSha: SHA, editable, ymlDocument: doc, savedYmlDocument: doc };
+};
+
+const tree = (moduleEditable: boolean): TreeNode => ({
+  nodeId: 'root',
+  path: 'bitrise.yml',
+  contents: ROOT_YML,
+  source: null,
+  commitSha: SHA,
+  editable: true,
+  includes: [
+    {
+      nodeId: 'n_mod',
+      path: 'ci/deploy.yml',
+      contents: MODULE_YML,
+      source: moduleEditable
+        ? { path: 'ci/deploy.yml', repository: null, branch: null, tag: null, commit: null }
+        : { path: 'ci/deploy.yml', repository: 'bitrise-io/shared-ci', branch: 'main', tag: null, commit: null },
+      commitSha: SHA,
+      editable: moduleEditable,
+      includes: [],
+    },
+  ],
+});
+
+/** Store state for a modular tree with `selectedNodeId` as the active view. */
+const modularStore = ({
+  selectedNodeId,
+  moduleEditable = true,
+}: {
+  selectedNodeId: string;
+  moduleEditable?: boolean;
+}) => {
+  const activeContents = selectedNodeId === 'n_mod' ? MODULE_YML : ROOT_YML;
+  const activeDoc = YmlUtils.toDoc(activeContents);
+  const treeNode = tree(moduleEditable);
+
+  return {
+    tree: treeNode,
+    files: {
+      root: slice('root', 'bitrise.yml', ROOT_YML, true, null),
+      n_mod: slice('n_mod', 'ci/deploy.yml', MODULE_YML, moduleEditable, treeNode.includes[0].source),
+    },
+    selectedNodeId,
+    mergedYml: ROOT_YML,
+    ymlDocument: activeDoc,
+    savedYmlDocument: activeDoc,
+    yml: YmlUtils.toJSON(activeDoc),
+  };
+};
+
+/** Single-file (non-modular) store, so the view is editable unless `forceReadOnly` is set. */
+const singleFileStore = (() => {
+  const doc = YmlUtils.toDoc(ROOT_YML);
+  return {
+    tree: undefined,
+    files: {},
+    selectedNodeId: undefined,
+    ymlDocument: doc,
+    savedYmlDocument: doc,
+    yml: YmlUtils.toJSON(doc),
+  };
+})();
+
+const meta: Meta<typeof StackAndMachine> = {
+  component: StackAndMachine,
+  args: {
+    stackId: 'osx-xcode-16.0.x',
+    machineTypeId: 'm2.medium',
+  },
+  decorators: [
+    (Story) => (
+      <Box padding="24">
+        <Story />
+      </Box>
+    ),
+  ],
+  parameters: {
+    bitriseYmlStore: singleFileStore,
+    msw: {
+      handlers: [getStacksAndMachines(), ToolCatalogApiMocks.getToolCatalog(), ToolCatalogApiMocks.getToolVersions()],
+    },
+  },
+  beforeEach: () => {
+    // Tool versions is the part of the card that renders differently in read-only mode.
+    set(window, 'localFeatureFlags.enable-wfe-tool-versions', true);
+    return () => set(window, 'localFeatureFlags.enable-wfe-tool-versions', false);
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StackAndMachine>;
+
+export const Editable: Story = {};
+
+/** Editable despite the modular tree, so read-only detection must not fire here. */
+export const ModularEditableFileView: Story = {
+  parameters: {
+    bitriseYmlStore: modularStore({ selectedNodeId: 'n_mod' }),
+  },
+};
+
+/** Read-only because the caller says so (e.g. an inherited default rendered in a module). */
+export const ForceReadOnly: Story = {
+  args: {
+    forceReadOnly: true,
+    selectsTrailing: <JumpToFileButton nodeId="root" />,
+  },
+  parameters: {
+    bitriseYmlStore: modularStore({ selectedNodeId: 'n_mod' }),
+  },
+};
+
+/** Read-only because the merged config preview is active. */
+export const MergedConfigView: Story = {
+  parameters: {
+    bitriseYmlStore: modularStore({ selectedNodeId: MERGED_CONFIG_NODE_ID }),
+  },
+};
+
+/** Read-only because the selected file comes from another repo. */
+export const CrossRepoFileView: Story = {
+  parameters: {
+    bitriseYmlStore: modularStore({ selectedNodeId: 'n_mod', moduleEditable: false }),
+  },
+};
+
+/** Read-only, collapsed variant used by the workflow cards. */
+export const ReadOnlyExpandable: Story = {
+  ...MergedConfigView,
+  args: { isExpandable: true },
+};

--- a/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
+++ b/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
@@ -184,7 +184,7 @@ const StackAndMachine = ({
         </Notification>
       )}
       <DeprecatedMachineNotification machineTypeId={selectedMachineType.id} />
-      {isToolVersionsEnabled && <ToolVersions workflowId={workflowId} />}
+      {isToolVersionsEnabled && <ToolVersions workflowId={workflowId} isReadOnly={isReadOnlyView} />}
     </StackAndMachineWrapper>
   );
 };

--- a/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
+++ b/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
@@ -127,7 +127,7 @@ const StackAndMachine = ({
     >
       <Box display="flex" flexDir={orientation === 'horizontal' ? 'row' : 'column'} gap="24">
         {/* Tooltip wraps only the selectors — not selectsTrailing, whose jump button has its own tooltip. */}
-        <Tooltip label="Read-only here — edit it in the module file that defines it." isDisabled={!isReadOnlyView}>
+        <Tooltip label="To edit, switch to the module file that defines them." isDisabled={!isReadOnlyView}>
           <Box
             ref={ref}
             display="flex"

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -5,6 +5,7 @@ import {
   BitkitLink,
   BitkitSelect,
   BitkitTextInput,
+  BitkitTooltip,
   IconMinusCircle,
   IconOpenInNew,
   rem,
@@ -30,6 +31,8 @@ const STRATEGY_LABELS: Record<VersionStrategy, string> = {
 };
 
 const OTHER_VALUE = '__other__';
+
+const READ_ONLY_TOOLTIP_TEXT = 'To edit, switch to the module file that defines it.';
 
 const TOOL_ID_COLUMN_WIDTH = rem(160);
 const VERSION_COLUMN_WIDTH = rem(240);
@@ -161,80 +164,86 @@ const ToolRow = ({
   return (
     <Box display="flex" flexDirection="column" gap="8">
       <Box display="flex" alignItems="flex-start" gap="12">
-        <Box display="flex" flexDirection="column" gap="8" width={TOOL_ID_COLUMN_WIDTH} flexShrink="0">
-          <BitkitSelect
-            size="lg"
-            placeholder="Select one"
-            isLoading={isCatalogLoading}
-            items={dropdownItems}
-            state={isReadOnly ? 'readOnly' : undefined}
-            value={showCustomInput ? OTHER_VALUE : toolId}
-            onValueChange={handleDropdownChange}
-          />
-          {showCustomInput && (
-            <BitkitTextInput
+        <BitkitTooltip text={READ_ONLY_TOOLTIP_TEXT} disabled={!isReadOnly}>
+          <Box display="flex" flexDirection="column" gap="8" width={TOOL_ID_COLUMN_WIDTH} flexShrink="0">
+            <BitkitSelect
               size="lg"
-              placeholder="Tool ID (e.g. deno)"
-              errorText={toolIdFieldState.error?.message}
+              placeholder="Select one"
+              isLoading={isCatalogLoading}
+              items={dropdownItems}
               state={isReadOnly ? 'readOnly' : undefined}
-              inputProps={{
-                ...toolIdField,
-                onBlur: handleIdBlur,
-              }}
+              value={showCustomInput ? OTHER_VALUE : toolId}
+              onValueChange={handleDropdownChange}
             />
-          )}
-        </Box>
-
-        <BitkitSelect
-          flex="1"
-          size="lg"
-          items={Object.entries(STRATEGY_LABELS)
-            .filter(([value]) => allowUnset || value !== 'unset')
-            .map(([value, label]) => ({ value, label }))}
-          value={strategy}
-          state={isReadOnly ? 'readOnly' : undefined}
-          onValueChange={(v) => handleStrategyChange(v as VersionStrategy)}
-        />
-
-        {strategy !== 'unset' && (
-          <Box display="flex" flexDirection="column" gap="8" width={VERSION_COLUMN_WIDTH} flexShrink="0">
-            {/* A catalog-known tool always has at least one version to offer, so the dropdown
-                applies whenever one is possible at all. */}
-            {isExactKnownTool ? (
-              <BitkitCombobox
-                size="lg"
-                placeholder="Select"
-                emptyLabel="No matches"
-                items={versionOptions}
-                isLoading={isVersionsLoading}
-                // With no version list there is nothing to pick from. Read-only rather than
-                // disabled, so the configured version stays legible and reachable by keyboard
-                // and screen readers; the alert below points to the YAML editor instead.
-                state={isVersionsError || isReadOnly ? 'readOnly' : undefined}
-                // Closing the menu without picking counts as visiting and leaving the field.
-                comboboxProps={{
-                  onOpenChange: (details) => !details.open && setVersionTouched(true),
-                  onBlur: () => setVersionTouched(true),
-                }}
-                errorText={displayedVersionError}
-                warningText={catalogMismatchWarning}
-                value={version || undefined}
-                onValueChange={(newVersion) => onVersionChange(newVersion ?? '')}
-              />
-            ) : (
+            {showCustomInput && (
               <BitkitTextInput
                 size="lg"
-                placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
-                errorText={displayedVersionError}
+                placeholder="Tool ID (e.g. deno)"
+                errorText={toolIdFieldState.error?.message}
                 state={isReadOnly ? 'readOnly' : undefined}
                 inputProps={{
-                  value: version,
-                  onChange: (e) => onVersionChange(e.target.value),
-                  onBlur: () => setVersionTouched(true),
+                  ...toolIdField,
+                  onBlur: handleIdBlur,
                 }}
               />
             )}
           </Box>
+        </BitkitTooltip>
+
+        <BitkitTooltip text={READ_ONLY_TOOLTIP_TEXT} disabled={!isReadOnly}>
+          <BitkitSelect
+            flex="1"
+            size="lg"
+            items={Object.entries(STRATEGY_LABELS)
+              .filter(([value]) => allowUnset || value !== 'unset')
+              .map(([value, label]) => ({ value, label }))}
+            value={strategy}
+            state={isReadOnly ? 'readOnly' : undefined}
+            onValueChange={(v) => handleStrategyChange(v as VersionStrategy)}
+          />
+        </BitkitTooltip>
+
+        {strategy !== 'unset' && (
+          <BitkitTooltip text={READ_ONLY_TOOLTIP_TEXT} disabled={!isReadOnly}>
+            <Box display="flex" flexDirection="column" gap="8" width={VERSION_COLUMN_WIDTH} flexShrink="0">
+              {/* A catalog-known tool always has at least one version to offer, so the dropdown
+                  applies whenever one is possible at all. */}
+              {isExactKnownTool ? (
+                <BitkitCombobox
+                  size="lg"
+                  placeholder="Select"
+                  emptyLabel="No matches"
+                  items={versionOptions}
+                  isLoading={isVersionsLoading}
+                  // With no version list there is nothing to pick from. Read-only rather than
+                  // disabled, so the configured version stays legible and reachable by keyboard
+                  // and screen readers; the alert below points to the YAML editor instead.
+                  state={isVersionsError || isReadOnly ? 'readOnly' : undefined}
+                  // Closing the menu without picking counts as visiting and leaving the field.
+                  comboboxProps={{
+                    onOpenChange: (details) => !details.open && setVersionTouched(true),
+                    onBlur: () => setVersionTouched(true),
+                  }}
+                  errorText={displayedVersionError}
+                  warningText={catalogMismatchWarning}
+                  value={version || undefined}
+                  onValueChange={(newVersion) => onVersionChange(newVersion ?? '')}
+                />
+              ) : (
+                <BitkitTextInput
+                  size="lg"
+                  placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
+                  errorText={displayedVersionError}
+                  state={isReadOnly ? 'readOnly' : undefined}
+                  inputProps={{
+                    value: version,
+                    onChange: (e) => onVersionChange(e.target.value),
+                    onBlur: () => setVersionTouched(true),
+                  }}
+                />
+              )}
+            </Box>
+          </BitkitTooltip>
         )}
 
         <BitkitIconButton

--- a/source/javascripts/components/ToolVersions/ToolRow.tsx
+++ b/source/javascripts/components/ToolVersions/ToolRow.tsx
@@ -42,6 +42,7 @@ type ToolRowProps = {
   catalog: ToolCatalog | undefined;
   allowUnset?: boolean;
   isCatalogLoading: boolean;
+  isReadOnly?: boolean;
   onIdChange: (newId: string) => void;
   onStrategyChange: (strategy: VersionStrategy, version: string) => void;
   onVersionChange: (version: string) => void;
@@ -56,6 +57,7 @@ const ToolRow = ({
   catalog,
   allowUnset,
   isCatalogLoading,
+  isReadOnly,
   onIdChange,
   onStrategyChange,
   onVersionChange,
@@ -165,6 +167,7 @@ const ToolRow = ({
             placeholder="Select one"
             isLoading={isCatalogLoading}
             items={dropdownItems}
+            state={isReadOnly ? 'readOnly' : undefined}
             value={showCustomInput ? OTHER_VALUE : toolId}
             onValueChange={handleDropdownChange}
           />
@@ -173,6 +176,7 @@ const ToolRow = ({
               size="lg"
               placeholder="Tool ID (e.g. deno)"
               errorText={toolIdFieldState.error?.message}
+              state={isReadOnly ? 'readOnly' : undefined}
               inputProps={{
                 ...toolIdField,
                 onBlur: handleIdBlur,
@@ -188,6 +192,7 @@ const ToolRow = ({
             .filter(([value]) => allowUnset || value !== 'unset')
             .map(([value, label]) => ({ value, label }))}
           value={strategy}
+          state={isReadOnly ? 'readOnly' : undefined}
           onValueChange={(v) => handleStrategyChange(v as VersionStrategy)}
         />
 
@@ -205,7 +210,7 @@ const ToolRow = ({
                 // With no version list there is nothing to pick from. Read-only rather than
                 // disabled, so the configured version stays legible and reachable by keyboard
                 // and screen readers; the alert below points to the YAML editor instead.
-                state={isVersionsError ? 'readOnly' : undefined}
+                state={isVersionsError || isReadOnly ? 'readOnly' : undefined}
                 // Closing the menu without picking counts as visiting and leaving the field.
                 comboboxProps={{
                   onOpenChange: (details) => !details.open && setVersionTouched(true),
@@ -221,6 +226,7 @@ const ToolRow = ({
                 size="lg"
                 placeholder={strategy === 'exact' ? 'e.g. 24.7.0' : 'prefix, e.g. 22'}
                 errorText={displayedVersionError}
+                state={isReadOnly ? 'readOnly' : undefined}
                 inputProps={{
                   value: version,
                   onChange: (e) => onVersionChange(e.target.value),
@@ -231,7 +237,13 @@ const ToolRow = ({
           </Box>
         )}
 
-        <BitkitIconButton variant="tertiary" icon={IconMinusCircle} label="Remove tool" onClick={onRemove} />
+        <BitkitIconButton
+          variant="tertiary"
+          icon={IconMinusCircle}
+          label="Remove tool"
+          state={isReadOnly ? 'disabled' : undefined}
+          onClick={onRemove}
+        />
       </Box>
 
       {isExactKnownTool && isVersionsError && (

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -24,7 +24,13 @@ import { paths } from '@/routes';
 
 import ToolRow from './ToolRow';
 
-const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
+type Props = {
+  workflowId?: string;
+  /** The store drops mutations here, so the rows must not pretend to accept edits. */
+  isReadOnly?: boolean;
+};
+
+const ToolVersions = ({ workflowId, isReadOnly }: Props) => {
   const scope: ToolScope = workflowId ? { type: 'workflow', workflowId } : { type: 'root' };
   const tools = useToolsForScope(scope);
   const { replace } = useNavigation();
@@ -80,82 +86,93 @@ const ToolVersions = ({ workflowId }: { workflowId?: string }) => {
         )}
       </Stack>
 
-      <Stack gap="16">
-        {Object.entries(tools).map(([toolId, versionString]) => {
-          const parsed = ToolsService.parseToolVersion(versionString);
-          const versionValue =
-            parsed.strategy === 'exact' ? parsed.version : parsed.strategy === 'unset' ? '' : (parsed.prefix ?? '');
-          return (
+      <BitkitTooltip text="Read-only here — edit it in the module file that defines it." disabled={!isReadOnly}>
+        <Stack gap="16">
+          {Object.entries(tools).map(([toolId, versionString]) => {
+            const parsed = ToolsService.parseToolVersion(versionString);
+            const versionValue =
+              parsed.strategy === 'exact' ? parsed.version : parsed.strategy === 'unset' ? '' : (parsed.prefix ?? '');
+            return (
+              <ToolRow
+                key={toolId}
+                toolId={toolId}
+                strategy={parsed.strategy}
+                version={versionValue}
+                existingToolIds={existingToolIds}
+                catalog={catalog}
+                allowUnset={allowUnset}
+                isCatalogLoading={isCatalogLoading}
+                isReadOnly={isReadOnly}
+                onIdChange={(newId) => ToolsService.renameTool(toolId, newId, scope)}
+                onStrategyChange={(strategy, ver) => ToolsService.setTool(toolId, strategy, ver, scope)}
+                onVersionChange={(ver) => ToolsService.setTool(toolId, parsed.strategy, ver, scope)}
+                onRemove={() => ToolsService.deleteTool(toolId, scope)}
+              />
+            );
+          })}
+          {hasPendingRow && (
             <ToolRow
-              key={toolId}
-              toolId={toolId}
-              strategy={parsed.strategy}
-              version={versionValue}
+              toolId=""
+              strategy={pendingStrategy}
+              version={pendingVersion}
               existingToolIds={existingToolIds}
               catalog={catalog}
               allowUnset={allowUnset}
               isCatalogLoading={isCatalogLoading}
-              onIdChange={(newId) => ToolsService.renameTool(toolId, newId, scope)}
-              onStrategyChange={(strategy, ver) => ToolsService.setTool(toolId, strategy, ver, scope)}
-              onVersionChange={(ver) => ToolsService.setTool(toolId, parsed.strategy, ver, scope)}
-              onRemove={() => ToolsService.deleteTool(toolId, scope)}
+              onIdChange={(newId) => {
+                ToolsService.setTool(newId, pendingStrategy, pendingVersion, scope);
+                setHasPendingRow(false);
+              }}
+              onStrategyChange={(strategy, ver) => {
+                setPendingStrategy(strategy);
+                setPendingVersion(ver);
+              }}
+              onVersionChange={(ver) => setPendingVersion(ver)}
+              onRemove={() => setHasPendingRow(false)}
             />
-          );
-        })}
-        {hasPendingRow && (
-          <ToolRow
-            toolId=""
-            strategy={pendingStrategy}
-            version={pendingVersion}
-            existingToolIds={existingToolIds}
-            catalog={catalog}
-            allowUnset={allowUnset}
-            isCatalogLoading={isCatalogLoading}
-            onIdChange={(newId) => {
-              ToolsService.setTool(newId, pendingStrategy, pendingVersion, scope);
-              setHasPendingRow(false);
-            }}
-            onStrategyChange={(strategy, ver) => {
-              setPendingStrategy(strategy);
-              setPendingVersion(ver);
-            }}
-            onVersionChange={(ver) => setPendingVersion(ver)}
-            onRemove={() => setHasPendingRow(false)}
-          />
-        )}
-        {existingToolIds.length === 0 && !hasPendingRow && (
-          <Box display="flex" alignItems="center" minHeight="48">
-            <Text textStyle="body/md/regular" color="text/primary">
-              Set up the first tool. Supports{' '}
-              <BitkitTooltip text="Ruby">
-                <IconRuby size="16" aria-label="Ruby" />
-              </BitkitTooltip>{' '}
-              <BitkitTooltip text="Flutter">
-                <IconFlutter size="16" aria-label="Flutter" />
-              </BitkitTooltip>{' '}
-              <BitkitTooltip text="Node.js">
-                <IconNodejs size="16" aria-label="Node.js" />
-              </BitkitTooltip>{' '}
-              <BitkitTooltip text="Python">
-                <IconPython size="16" aria-label="Python" />
-              </BitkitTooltip>{' '}
-              and many more.
-            </Text>
-          </Box>
-        )}
-      </Stack>
+          )}
+          {existingToolIds.length === 0 && !hasPendingRow && (
+            <Box display="flex" alignItems="center" minHeight="48">
+              <Text textStyle="body/md/regular" color="text/primary">
+                {isReadOnly ? (
+                  'No tools are set up here.'
+                ) : (
+                  <>
+                    Set up the first tool. Supports{' '}
+                    <BitkitTooltip text="Ruby">
+                      <IconRuby size="16" aria-label="Ruby" />
+                    </BitkitTooltip>{' '}
+                    <BitkitTooltip text="Flutter">
+                      <IconFlutter size="16" aria-label="Flutter" />
+                    </BitkitTooltip>{' '}
+                    <BitkitTooltip text="Node.js">
+                      <IconNodejs size="16" aria-label="Node.js" />
+                    </BitkitTooltip>{' '}
+                    <BitkitTooltip text="Python">
+                      <IconPython size="16" aria-label="Python" />
+                    </BitkitTooltip>{' '}
+                    and many more.
+                  </>
+                )}
+              </Text>
+            </Box>
+          )}
+        </Stack>
+      </BitkitTooltip>
 
       {isCatalogError && <BitkitAlert variant="warning" messageText="Couldn't load tool suggestions." />}
 
-      <BitkitButton
-        variant="secondary"
-        size="md"
-        alignSelf="flex-start"
-        state={hasPendingRow ? 'disabled' : undefined}
-        onClick={handleAddNew}
-      >
-        Add new
-      </BitkitButton>
+      {!isReadOnly && (
+        <BitkitButton
+          variant="secondary"
+          size="md"
+          alignSelf="flex-start"
+          state={hasPendingRow ? 'disabled' : undefined}
+          onClick={handleAddNew}
+        >
+          Add new
+        </BitkitButton>
+      )}
     </Stack>
   );
 };

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -119,6 +119,7 @@ const ToolVersions = ({ workflowId, isReadOnly }: Props) => {
               catalog={catalog}
               allowUnset={allowUnset}
               isCatalogLoading={isCatalogLoading}
+              isReadOnly={isReadOnly}
               onIdChange={(newId) => {
                 ToolsService.setTool(newId, pendingStrategy, pendingVersion, scope);
                 setHasPendingRow(false);

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -86,80 +86,78 @@ const ToolVersions = ({ workflowId, isReadOnly }: Props) => {
         )}
       </Stack>
 
-      <BitkitTooltip text="Read-only here — edit it in the module file that defines it." disabled={!isReadOnly}>
-        <Stack gap="16">
-          {Object.entries(tools).map(([toolId, versionString]) => {
-            const parsed = ToolsService.parseToolVersion(versionString);
-            const versionValue =
-              parsed.strategy === 'exact' ? parsed.version : parsed.strategy === 'unset' ? '' : (parsed.prefix ?? '');
-            return (
-              <ToolRow
-                key={toolId}
-                toolId={toolId}
-                strategy={parsed.strategy}
-                version={versionValue}
-                existingToolIds={existingToolIds}
-                catalog={catalog}
-                allowUnset={allowUnset}
-                isCatalogLoading={isCatalogLoading}
-                isReadOnly={isReadOnly}
-                onIdChange={(newId) => ToolsService.renameTool(toolId, newId, scope)}
-                onStrategyChange={(strategy, ver) => ToolsService.setTool(toolId, strategy, ver, scope)}
-                onVersionChange={(ver) => ToolsService.setTool(toolId, parsed.strategy, ver, scope)}
-                onRemove={() => ToolsService.deleteTool(toolId, scope)}
-              />
-            );
-          })}
-          {hasPendingRow && (
+      <Stack gap="16">
+        {Object.entries(tools).map(([toolId, versionString]) => {
+          const parsed = ToolsService.parseToolVersion(versionString);
+          const versionValue =
+            parsed.strategy === 'exact' ? parsed.version : parsed.strategy === 'unset' ? '' : (parsed.prefix ?? '');
+          return (
             <ToolRow
-              toolId=""
-              strategy={pendingStrategy}
-              version={pendingVersion}
+              key={toolId}
+              toolId={toolId}
+              strategy={parsed.strategy}
+              version={versionValue}
               existingToolIds={existingToolIds}
               catalog={catalog}
               allowUnset={allowUnset}
               isCatalogLoading={isCatalogLoading}
               isReadOnly={isReadOnly}
-              onIdChange={(newId) => {
-                ToolsService.setTool(newId, pendingStrategy, pendingVersion, scope);
-                setHasPendingRow(false);
-              }}
-              onStrategyChange={(strategy, ver) => {
-                setPendingStrategy(strategy);
-                setPendingVersion(ver);
-              }}
-              onVersionChange={(ver) => setPendingVersion(ver)}
-              onRemove={() => setHasPendingRow(false)}
+              onIdChange={(newId) => ToolsService.renameTool(toolId, newId, scope)}
+              onStrategyChange={(strategy, ver) => ToolsService.setTool(toolId, strategy, ver, scope)}
+              onVersionChange={(ver) => ToolsService.setTool(toolId, parsed.strategy, ver, scope)}
+              onRemove={() => ToolsService.deleteTool(toolId, scope)}
             />
-          )}
-          {existingToolIds.length === 0 && !hasPendingRow && (
-            <Box display="flex" alignItems="center" minHeight="48">
-              <Text textStyle="body/md/regular" color="text/primary">
-                {isReadOnly ? (
-                  'No tools are set up here.'
-                ) : (
-                  <>
-                    Set up the first tool. Supports{' '}
-                    <BitkitTooltip text="Ruby">
-                      <IconRuby size="16" aria-label="Ruby" />
-                    </BitkitTooltip>{' '}
-                    <BitkitTooltip text="Flutter">
-                      <IconFlutter size="16" aria-label="Flutter" />
-                    </BitkitTooltip>{' '}
-                    <BitkitTooltip text="Node.js">
-                      <IconNodejs size="16" aria-label="Node.js" />
-                    </BitkitTooltip>{' '}
-                    <BitkitTooltip text="Python">
-                      <IconPython size="16" aria-label="Python" />
-                    </BitkitTooltip>{' '}
-                    and many more.
-                  </>
-                )}
-              </Text>
-            </Box>
-          )}
-        </Stack>
-      </BitkitTooltip>
+          );
+        })}
+        {hasPendingRow && (
+          <ToolRow
+            toolId=""
+            strategy={pendingStrategy}
+            version={pendingVersion}
+            existingToolIds={existingToolIds}
+            catalog={catalog}
+            allowUnset={allowUnset}
+            isCatalogLoading={isCatalogLoading}
+            isReadOnly={isReadOnly}
+            onIdChange={(newId) => {
+              ToolsService.setTool(newId, pendingStrategy, pendingVersion, scope);
+              setHasPendingRow(false);
+            }}
+            onStrategyChange={(strategy, ver) => {
+              setPendingStrategy(strategy);
+              setPendingVersion(ver);
+            }}
+            onVersionChange={(ver) => setPendingVersion(ver)}
+            onRemove={() => setHasPendingRow(false)}
+          />
+        )}
+        {existingToolIds.length === 0 && !hasPendingRow && (
+          <Box display="flex" alignItems="center" minHeight="48">
+            <Text textStyle="body/md/regular" color="text/primary">
+              {isReadOnly ? (
+                'No tools are set up here.'
+              ) : (
+                <>
+                  Set up the first tool. Supports{' '}
+                  <BitkitTooltip text="Ruby">
+                    <IconRuby size="16" aria-label="Ruby" />
+                  </BitkitTooltip>{' '}
+                  <BitkitTooltip text="Flutter">
+                    <IconFlutter size="16" aria-label="Flutter" />
+                  </BitkitTooltip>{' '}
+                  <BitkitTooltip text="Node.js">
+                    <IconNodejs size="16" aria-label="Node.js" />
+                  </BitkitTooltip>{' '}
+                  <BitkitTooltip text="Python">
+                    <IconPython size="16" aria-label="Python" />
+                  </BitkitTooltip>{' '}
+                  and many more.
+                </>
+              )}
+            </Text>
+          </Box>
+        )}
+      </Stack>
 
       {isCatalogError && <BitkitAlert variant="warning" messageText="Couldn't load tool suggestions." />}
 

--- a/source/javascripts/core/services/ToolsService.spec.ts
+++ b/source/javascripts/core/services/ToolsService.spec.ts
@@ -54,9 +54,9 @@ describe('ToolsService', () => {
     });
 
     it('tolerates non-string values from hand-edited YAML', () => {
-      expect(ToolsService.parseToolVersion(3.13 as unknown as string)).toEqual({ strategy: 'exact', version: '3.13' });
-      expect(ToolsService.parseToolVersion(null as unknown as string)).toEqual({ strategy: 'exact', version: '' });
-      expect(ToolsService.parseToolVersion(undefined as unknown as string)).toEqual({ strategy: 'exact', version: '' });
+      expect(ToolsService.parseToolVersion(3.13)).toEqual({ strategy: 'exact', version: '3.13' });
+      expect(ToolsService.parseToolVersion(null)).toEqual({ strategy: 'exact', version: '' });
+      expect(ToolsService.parseToolVersion(undefined)).toEqual({ strategy: 'exact', version: '' });
     });
 
     it('parses keywords case-insensitively', () => {

--- a/source/javascripts/core/services/ToolsService.spec.ts
+++ b/source/javascripts/core/services/ToolsService.spec.ts
@@ -53,6 +53,12 @@ describe('ToolsService', () => {
       expect(ToolsService.parseToolVersion(':latest')).toEqual({ strategy: 'exact', version: ':latest' });
     });
 
+    it('tolerates non-string values from hand-edited YAML', () => {
+      expect(ToolsService.parseToolVersion(3.13 as unknown as string)).toEqual({ strategy: 'exact', version: '3.13' });
+      expect(ToolsService.parseToolVersion(null as unknown as string)).toEqual({ strategy: 'exact', version: '' });
+      expect(ToolsService.parseToolVersion(undefined as unknown as string)).toEqual({ strategy: 'exact', version: '' });
+    });
+
     it('parses keywords case-insensitively', () => {
       expect(ToolsService.parseToolVersion('Latest')).toEqual({ strategy: 'latest-released' });
       expect(ToolsService.parseToolVersion('LATEST')).toEqual({ strategy: 'latest-released' });

--- a/source/javascripts/core/services/ToolsService.ts
+++ b/source/javascripts/core/services/ToolsService.ts
@@ -7,7 +7,7 @@ import WorkflowService from './WorkflowService';
 
 type ToolScope = { type: 'root' } | { type: 'workflow'; workflowId: string };
 
-function parseToolVersion(rawValue: string): ParsedToolVersion {
+function parseToolVersion(rawValue: unknown): ParsedToolVersion {
   // A value written by hand can be a number (`python: 3.13`) or empty, not the declared string.
   const raw = typeof rawValue === 'string' ? rawValue : String(rawValue ?? '');
   const lower = raw.toLowerCase();
@@ -229,8 +229,7 @@ function renameTool(oldId: string, newId: string, scope: ToolScope) {
     YmlUtils.updateKeyByPath(doc, [...toolsPath, oldId], newId);
 
     const tools = YmlUtils.getMapIn(doc, toolsPath, true);
-    // A hand-edited YAML value may be a number (`python: 3.13`) or empty rather than a string.
-    const parsed = parseToolVersion(String(tools.get(newId) ?? ''));
+    const parsed = parseToolVersion(tools.get(newId));
     // Then overwrite its value: an exact version or prefix picked for the old tool is very
     // unlikely to be valid for the new one, so only the strategy carries over.
     YmlUtils.setIn(tools, [newId], serializeToolVersion(nextParsedVersionOnRename(parsed)), false);

--- a/source/javascripts/core/services/ToolsService.ts
+++ b/source/javascripts/core/services/ToolsService.ts
@@ -7,7 +7,9 @@ import WorkflowService from './WorkflowService';
 
 type ToolScope = { type: 'root' } | { type: 'workflow'; workflowId: string };
 
-function parseToolVersion(raw: string): ParsedToolVersion {
+function parseToolVersion(rawValue: string): ParsedToolVersion {
+  // A value written by hand can be a number (`python: 3.13`) or empty, not the declared string.
+  const raw = typeof rawValue === 'string' ? rawValue : String(rawValue ?? '');
   const lower = raw.toLowerCase();
 
   if (lower === 'unset') {


### PR DESCRIPTION
## Task

This PR contains two bug fixes:
- `StackAndMachine` already computes `isReadOnlyView`, which is true on the merged config preview,
on a file that comes from another repository (or the caller can force it). That value never
reached tool setup, so the rows stayed interactive while `updateBitriseYmlDocument` dropped every
mutation. Edits looked accepted and then reverted: a new row vanished because the pending row was
cleared even though the write was ignored, and picking a strategy snapped back to the stored value.
- `Tools` is typed `Record<string, string>`, but hand written YAML can hold
`python: 3.13`, which parses as a number. `parseToolVersion` then threw
`TypeError: raw.toLowerCase is not a function` and the whole tool setup section failed to render.

## Changes

- Pass `isReadOnlyView` down to tool setup
- Mark the fields `readOnly` rather than `disabled`, so values stay legible and keyboard reachable
- Hide `Add new` and disable row removal in read only views
- Reuse the tooltip copy of the stack selectors above, so both halves of the card read the same
- Separate empty state copy for read only views
- Coerce non string values at the top of `parseToolVersion`, with cases for number, null, undefined
- New `StackAndMachine` story file: editable, modular editable, forced read only, merged config,
  cross repository file, read only expandable