### PR TITLE
feat(tool setup): BE-2186 organize links, add one to stack reports 

### DIFF
--- a/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
+++ b/source/javascripts/components/StacksAndMachine/StackAndMachine.tsx
@@ -184,7 +184,13 @@ const StackAndMachine = ({
         </Notification>
       )}
       <DeprecatedMachineNotification machineTypeId={selectedMachineType.id} />
-      {isToolVersionsEnabled && <ToolVersions workflowId={workflowId} isReadOnly={isReadOnlyView} />}
+      {isToolVersionsEnabled && (
+        <ToolVersions
+          workflowId={workflowId}
+          isReadOnly={isReadOnlyView}
+          stackReportUrl={StackAndMachineService.getStackReportUrl(selectedStack, isInvalidStack)}
+        />
+      )}
     </StackAndMachineWrapper>
   );
 };

--- a/source/javascripts/components/ToolVersions/ToolVersions.stories.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.stories.tsx
@@ -10,6 +10,9 @@ import ToolVersions from './ToolVersions';
 
 const meta: Meta<typeof ToolVersions> = {
   component: ToolVersions,
+  args: {
+    stackReportUrl: 'https://bitrise.io/stacks/stack_reports/osx-xcode-16.0.x#languages-and-runtimes',
+  },
   decorators: [
     (Story) => (
       <Box padding="24">

--- a/source/javascripts/components/ToolVersions/ToolVersions.stories.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.stories.tsx
@@ -11,7 +11,7 @@ import ToolVersions from './ToolVersions';
 const meta: Meta<typeof ToolVersions> = {
   component: ToolVersions,
   args: {
-    stackReportUrl: 'https://bitrise.io/stacks/stack_reports/osx-xcode-16.0.x#languages-and-runtimes',
+    stackReportUrl: 'https://bitrise.io/stacks/stack_reports/osx-xcode-26.6.x#languages-and-runtimes',
   },
   decorators: [
     (Story) => (

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -26,11 +26,13 @@ import ToolRow from './ToolRow';
 
 type Props = {
   workflowId?: string;
+  /** Where "See the list of installed tools" points — the selected stack's report when there is one. */
+  stackReportUrl?: string;
   /** The store drops mutations here, so the rows must not pretend to accept edits. */
   isReadOnly?: boolean;
 };
 
-const ToolVersions = ({ workflowId, isReadOnly }: Props) => {
+const ToolVersions = ({ workflowId, stackReportUrl, isReadOnly }: Props) => {
   const scope: ToolScope = workflowId ? { type: 'workflow', workflowId } : { type: 'root' };
   const tools = useToolsForScope(scope);
   const { replace } = useNavigation();
@@ -75,6 +77,15 @@ const ToolVersions = ({ workflowId, isReadOnly }: Props) => {
             CLI and step use
           </BitkitLink>
         </Text>
+        {stackReportUrl && (
+          <Text textStyle="body/md/regular" color="text/secondary">
+            Not sure what a version keyword resolves to?{' '}
+            <BitkitLink href={stackReportUrl} isExternal suffixIcon={IconOpenInNew} colorVariant="purple">
+              See the list of installed tools
+            </BitkitLink>{' '}
+            on the selected stack.
+          </Text>
+        )}
         {scope.type === 'workflow' && (
           <Text textStyle="body/md/regular" color="text/secondary">
             Looking for global settings which apply to all workflows? Go to the{' '}

--- a/source/javascripts/components/ToolVersions/ToolVersions.tsx
+++ b/source/javascripts/components/ToolVersions/ToolVersions.tsx
@@ -24,10 +24,20 @@ import { paths } from '@/routes';
 
 import ToolRow from './ToolRow';
 
+const DOCS_URL =
+  'https://docs.bitrise.io/en/bitrise-ci/configure-builds/configuring-build-settings/configuring-tool-versions';
+const CLI_DOCS_URL = `${DOCS_URL}#tool-setup-during-workflow-execution`;
+
+const HeaderLinkSeparator = () => (
+  <Text as="span" color="text/tertiary" aria-hidden="true">
+    &middot;
+  </Text>
+);
+
 type Props = {
   workflowId?: string;
-  /** Where "See the list of installed tools" points — the selected stack's report when there is one. */
-  stackReportUrl?: string;
+  /** Where the "Installed tools" link points: the selected stack's report, or the stack index. */
+  stackReportUrl: string;
   /** The store drops mutations here, so the rows must not pretend to accept edits. */
   isReadOnly?: boolean;
 };
@@ -52,49 +62,33 @@ const ToolVersions = ({ workflowId, stackReportUrl, isReadOnly }: Props) => {
 
   return (
     <Stack gap="24" marginBlockStart="24" maxWidth={rem(800)}>
-      <Stack gap="4">
-        <Text textStyle="heading/h3">Tool setup</Text>
-        <Text textStyle="body/md/regular" color="text/secondary">
-          Customize tools and versions required in {scope.type === 'workflow' ? 'this workflow' : 'workflows'}. Tool
-          setup runs before the first step.{' '}
-          <BitkitLink
-            href="https://docs.bitrise.io/en/bitrise-ci/configure-builds/configuring-build-settings/configuring-tool-versions"
-            isExternal
-            suffixIcon={IconOpenInNew}
-            colorVariant="purple"
-          >
+      <Stack gap="8">
+        <Stack gap="4">
+          <Text textStyle="heading/h3">Tool setup</Text>
+          <Text textStyle="body/md/regular" color="text/secondary">
+            Customize tools and versions required in {scope.type === 'workflow' ? 'this workflow' : 'workflows'}. Tool
+            setup runs before the first step.
+          </Text>
+        </Stack>
+        <Box display="flex" alignItems="center" flexWrap="wrap" gap="8">
+          <BitkitLink href={DOCS_URL} isExternal suffixIcon={IconOpenInNew} colorVariant="purple">
             Learn more
           </BitkitLink>
-        </Text>
-        <Text textStyle="body/md/regular" color="text/secondary">
-          Need more flexibility or want to use an existing version file? Check out{' '}
-          <BitkitLink
-            href="https://docs.bitrise.io/en/bitrise-ci/configure-builds/configuring-build-settings/configuring-tool-versions#tool-setup-during-workflow-execution"
-            isExternal
-            suffixIcon={IconOpenInNew}
-            colorVariant="purple"
-          >
+          <HeaderLinkSeparator />
+          <BitkitLink href={CLI_DOCS_URL} isExternal suffixIcon={IconOpenInNew} colorVariant="purple">
             CLI and step use
           </BitkitLink>
-        </Text>
-        {stackReportUrl && (
-          <Text textStyle="body/md/regular" color="text/secondary">
-            Not sure what a version keyword resolves to?{' '}
-            <BitkitLink href={stackReportUrl} isExternal suffixIcon={IconOpenInNew} colorVariant="purple">
-              See the list of installed tools
-            </BitkitLink>{' '}
-            on the selected stack.
-          </Text>
-        )}
-        {scope.type === 'workflow' && (
-          <Text textStyle="body/md/regular" color="text/secondary">
-            Looking for global settings which apply to all workflows? Go to the{' '}
-            <BitkitLinkButton onClick={() => replace(paths.stacksAndMachines)}>
-              Stacks &amp; Machines page
-            </BitkitLinkButton>
-            .
-          </Text>
-        )}
+          <HeaderLinkSeparator />
+          <BitkitLink href={stackReportUrl} isExternal suffixIcon={IconOpenInNew} colorVariant="purple">
+            Installed tools
+          </BitkitLink>
+          {scope.type === 'workflow' && (
+            <>
+              <HeaderLinkSeparator />
+              <BitkitLinkButton onClick={() => replace(paths.stacksAndMachines)}>Global settings</BitkitLinkButton>
+            </>
+          )}
+        </Box>
       </Stack>
 
       <Stack gap="16">

--- a/source/javascripts/core/services/StackAndMachineService.spec.ts
+++ b/source/javascripts/core/services/StackAndMachineService.spec.ts
@@ -1687,6 +1687,38 @@ describe('StackAndMachineService', () => {
     });
   });
 
+  describe('getStackReportUrl', () => {
+    const stackWithId = (id: string): Stack => ({ ...stacks[0], id });
+
+    it('deep-links to the stack report, anchored at the tool list', () => {
+      expect(StackAndMachineService.getStackReportUrl(stackWithId('osx-xcode-16.0.x'), false)).toBe(
+        'https://bitrise.io/stacks/stack_reports/osx-xcode-16.0.x#languages-and-runtimes',
+      );
+    });
+
+    it('uses the stack ID verbatim for linux stacks too', () => {
+      expect(StackAndMachineService.getStackReportUrl(stackWithId('linux-docker-android-22.04'), false)).toBe(
+        'https://bitrise.io/stacks/stack_reports/linux-docker-android-22.04#languages-and-runtimes',
+      );
+    });
+
+    it('falls back to the stack index for an invalid stack', () => {
+      expect(StackAndMachineService.getStackReportUrl(stackWithId('osx-xcode-11'), true)).toBe(
+        'https://bitrise.io/stacks/',
+      );
+    });
+
+    it('falls back to the stack index for a self-hosted pool', () => {
+      expect(StackAndMachineService.getStackReportUrl(stackWithId('agent-pool-stack'), false)).toBe(
+        'https://bitrise.io/stacks/',
+      );
+    });
+
+    it('falls back to the stack index when no stack is resolved yet', () => {
+      expect(StackAndMachineService.getStackReportUrl(stackWithId(''), false)).toBe('https://bitrise.io/stacks/');
+    });
+  });
+
   describe('changeStackAndMachine', () => {
     describe('stack OS remains the same', () => {
       it('keeps the default stack and machine type', () => {

--- a/source/javascripts/core/services/StackAndMachineService.spec.ts
+++ b/source/javascripts/core/services/StackAndMachineService.spec.ts
@@ -1691,14 +1691,16 @@ describe('StackAndMachineService', () => {
     const stackWithId = (id: string): Stack => ({ ...stacks[0], id });
 
     it('deep-links to the stack report, anchored at the tool list', () => {
-      expect(StackAndMachineService.getStackReportUrl(stackWithId('osx-xcode-16.0.x'), false)).toBe(
-        'https://bitrise.io/stacks/stack_reports/osx-xcode-16.0.x#languages-and-runtimes',
+      expect(StackAndMachineService.getStackReportUrl(stackWithId('osx-xcode-26.6.x'), false)).toBe(
+        'https://bitrise.io/stacks/stack_reports/osx-xcode-26.6.x#languages-and-runtimes',
       );
     });
 
     it('uses the stack ID verbatim for linux stacks too', () => {
-      expect(StackAndMachineService.getStackReportUrl(stackWithId('linux-docker-android-22.04'), false)).toBe(
-        'https://bitrise.io/stacks/stack_reports/linux-docker-android-22.04#languages-and-runtimes',
+      expect(
+        StackAndMachineService.getStackReportUrl(stackWithId('ubuntu-resolute-26.04-bitrise-2026-android'), false),
+      ).toBe(
+        'https://bitrise.io/stacks/stack_reports/ubuntu-resolute-26.04-bitrise-2026-android#languages-and-runtimes',
       );
     });
 

--- a/source/javascripts/core/services/StackAndMachineService.ts
+++ b/source/javascripts/core/services/StackAndMachineService.ts
@@ -61,6 +61,24 @@ function isSelfHostedStack(stack: Stack) {
   return stack.id.startsWith('agent');
 }
 
+const STACKS_URL = 'https://bitrise.io/stacks/';
+
+/**
+ * Where to send someone who wants the list of tools preinstalled on their stack. A stack report
+ * is addressed by the stack ID verbatim, so the deep link points straight at the tool list.
+ *
+ * Falls back to the stack index when there is no report to link to: an unresolvable stack ID, a
+ * self-hosted pool (Bitrise publishes no report for those), or stacks not loaded yet. An unknown
+ * ID renders an empty placeholder page rather than a 404, so guessing is worse than the index.
+ */
+function getStackReportUrl(stack: Stack, isInvalidStack: boolean): string {
+  if (isInvalidStack || !stack.id || isSelfHostedStack(stack)) {
+    return STACKS_URL;
+  }
+
+  return `${STACKS_URL}stack_reports/${encodeURIComponent(stack.id)}#languages-and-runtimes`;
+}
+
 function getOsOfStack(stack: Stack): string {
   switch (stack.os) {
     case 'linux':
@@ -502,6 +520,7 @@ export default {
   toStackOption,
   toMachineTypeDetailedOption,
   getStackById,
+  getStackReportUrl,
   getMachinesOfStack,
   updateStackAndMachine,
   updateLicensePoolId,

--- a/source/javascripts/core/services/StackAndMachineService.ts
+++ b/source/javascripts/core/services/StackAndMachineService.ts
@@ -63,14 +63,7 @@ function isSelfHostedStack(stack: Stack) {
 
 const STACKS_URL = 'https://bitrise.io/stacks/';
 
-/**
- * Where to send someone who wants the list of tools preinstalled on their stack. A stack report
- * is addressed by the stack ID verbatim, so the deep link points straight at the tool list.
- *
- * Falls back to the stack index when there is no report to link to: an unresolvable stack ID, a
- * self-hosted pool (Bitrise publishes no report for those), or stacks not loaded yet. An unknown
- * ID renders an empty placeholder page rather than a 404, so guessing is worse than the index.
- */
+// Returns the URL of the stack report, or the stack index if the stack is invalid, self-hosted, or not specified.
 function getStackReportUrl(stack: Stack, isInvalidStack: boolean): string {
   if (isInvalidStack || !stack.id || isSelfHostedStack(stack)) {
     return STACKS_URL;


### PR DESCRIPTION
## Task

To add more meaning to the installed tool setup strategies the link to the installed tools is now displayed along with the other links.

The header had also grown to four stacked helper sentences, each with the same shape: a rhetorical
question with its link buried mid sentence, five lines before the first row.

## Changes

- `getStackReportUrl` builds a deep link to the selected stack's report, anchored at the tool list
- Fall back to the stack index for an invalid stack, a self hosted pool, and before stacks load
- Read `selectedStack.id`, never the `stackId` prop, which is empty on the `Default` option
- Collapse the header into a heading, one description line, and a row of links
- Shorten the labels to `Installed tools` and `Global settings`

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>