### PR TITLE
Read the CI config expert verdict from the monolith, and let opted-out projects in [BIVS-3794]

### DIFF
--- a/source/javascripts/components/unified-editor/EntitySelector/EntitySelector.stories.tsx
+++ b/source/javascripts/components/unified-editor/EntitySelector/EntitySelector.stories.tsx
@@ -1,7 +1,7 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
-import { aiButtonDisabled, aiButtonEnabled } from '@/storyutils/getAISettings.utils';
+import { aiButtonEnabled } from '@/storyutils/getAISettings.utils';
 
 import EntitySelector, { EntitySelectorProps } from './EntitySelector';
 
@@ -56,16 +56,6 @@ export const WithSecondaryList: StoryObj<EntitySelectorProps> = {
 export const WithCreateWithAIButton: StoryObj<EntitySelectorProps> = {
   beforeEach: () => {
     window.parent.pageProps = aiButtonEnabled();
-  },
-  args: {
-    entityName: 'Workflow',
-  },
-  render: StoryComponent,
-};
-
-export const WithCreateWithAIButtonDisabled: StoryObj<EntitySelectorProps> = {
-  beforeEach: () => {
-    window.parent.pageProps = aiButtonDisabled();
   },
   args: {
     entityName: 'Workflow',

--- a/source/javascripts/components/unified-editor/EntitySelector/EntitySelector.stories.tsx
+++ b/source/javascripts/components/unified-editor/EntitySelector/EntitySelector.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { set } from 'es-toolkit/compat';
 import { useState } from 'react';
 
 import { aiButtonDisabled, aiButtonEnabled } from '@/storyutils/getAISettings.utils';
@@ -8,9 +7,6 @@ import EntitySelector, { EntitySelectorProps } from './EntitySelector';
 
 const meta: Meta<EntitySelectorProps> = {
   component: EntitySelector,
-  beforeEach: () => {
-    set(window, 'parent.globalProps.featureFlags.account.enable-ci-config-expert-agent', true);
-  },
   args: {
     entityIds: [
       'Spongebob',

--- a/source/javascripts/hooks/useAIButton.spec.tsx
+++ b/source/javascripts/hooks/useAIButton.spec.tsx
@@ -9,13 +9,19 @@ import { CiConfigExpertAvailability } from '@/typings/globals';
 
 import useAIButton from './useAIButton';
 
-let availability: CiConfigExpertAvailability | undefined = 'enabled';
+type Settings = { ai: { ciConfigExpert: { availability: CiConfigExpertAvailability } } } | undefined;
+
+const withAvailability = (availability: CiConfigExpertAvailability): Settings => ({
+  ai: { ciConfigExpert: { availability } },
+});
+
+let settings: Settings;
 
 jest.mock('@/core/analytics/SegmentBaseTracking', () => ({ __esModule: true, segmentTrack: jest.fn() }));
 jest.mock('@/core/utils/PageProps', () => ({
   __esModule: true,
   default: {
-    settings: () => ({ ai: { ciConfigExpert: { availability } } }),
+    settings: () => settings,
     appSlug: () => 'app-slug',
     app: () => ({}),
   },
@@ -36,7 +42,7 @@ const renderAIButton = () => renderHook(() => useAIButton({ action: 'explain_wor
 
 describe('useAIButton', () => {
   beforeEach(() => {
-    availability = 'enabled';
+    settings = withAvailability('enabled');
     bitriseYmlStore.setState({ tree: undefined });
   });
 
@@ -52,19 +58,19 @@ describe('useAIButton', () => {
 
   describe('availability', () => {
     it('hides every entry point when the agent is not available for the workspace', () => {
-      availability = 'unavailable';
+      settings = withAvailability('unavailable');
 
       expect(renderAIButton().isVisible).toBe(false);
     });
 
     it('hides every entry point when AI is switched off for the workspace', () => {
-      availability = 'disabled-by-workspace';
+      settings = withAvailability('disabled-by-workspace');
 
       expect(renderAIButton().isVisible).toBe(false);
     });
 
     it('points at the project settings when the project has not opted in', () => {
-      availability = 'disabled-by-project';
+      settings = withAvailability('disabled-by-project');
 
       const { isVisible, tooltipLabel, getAIButtonProps } = renderAIButton();
 
@@ -82,7 +88,7 @@ describe('useAIButton', () => {
     });
 
     it('hides every entry point when the parent has no settings at all (CLI mode)', () => {
-      availability = undefined;
+      settings = undefined;
 
       expect(renderAIButton().isVisible).toBe(false);
     });

--- a/source/javascripts/hooks/useAIButton.spec.tsx
+++ b/source/javascripts/hooks/useAIButton.spec.tsx
@@ -63,29 +63,20 @@ describe('useAIButton', () => {
       expect(renderAIButton().isVisible).toBe(false);
     });
 
-    it('hides every entry point when AI is switched off for the workspace', () => {
-      settings = withAvailability('disabled-by-workspace');
+    // An opted-out project or workspace is indistinguishable from an opted-in one here: the parent
+    // owns the difference and answers the click with the opt-in modal instead of the drawer.
+    it.each(['enabled', 'disabled-by-project', 'disabled-by-workspace'] as const)(
+      'offers a working entry point when the agent is available (%s)',
+      (availability) => {
+        settings = withAvailability(availability);
 
-      expect(renderAIButton().isVisible).toBe(false);
-    });
+        const { isVisible, tooltipLabel, getAIButtonProps } = renderAIButton();
 
-    it('points at the project settings when the project has not opted in', () => {
-      settings = withAvailability('disabled-by-project');
-
-      const { isVisible, tooltipLabel, getAIButtonProps } = renderAIButton();
-
-      expect(isVisible).toBe(true);
-      expect(getAIButtonProps().isDisabled).toBe(true);
-      expect(tooltipLabel).toBe('AI functions are disabled. Go to Project settings to turn them on.');
-    });
-
-    it('is enabled when the project has opted in', () => {
-      const { isVisible, tooltipLabel, getAIButtonProps } = renderAIButton();
-
-      expect(isVisible).toBe(true);
-      expect(getAIButtonProps().isDisabled).toBe(false);
-      expect(tooltipLabel).toBeUndefined();
-    });
+        expect(isVisible).toBe(true);
+        expect(getAIButtonProps().isDisabled).toBe(false);
+        expect(tooltipLabel).toBeUndefined();
+      },
+    );
 
     it('hides every entry point when the parent has no settings at all (CLI mode)', () => {
       settings = undefined;

--- a/source/javascripts/hooks/useAIButton.spec.tsx
+++ b/source/javascripts/hooks/useAIButton.spec.tsx
@@ -5,17 +5,17 @@ import { renderHook } from '@testing-library/react';
 
 import { TreeNode } from '@/core/models/Tree';
 import { bitriseYmlStore, initializeModularConfig } from '@/core/stores/BitriseYmlStore';
+import { CiConfigExpertAvailability } from '@/typings/globals';
 
 import useAIButton from './useAIButton';
 
-// The CI config expert agent and the workspace enablement are the other two gates; force them on so
-// the test isolates the modular gate added in BIVS-3735.
+let availability: CiConfigExpertAvailability | undefined = 'enabled';
+
 jest.mock('@/core/analytics/SegmentBaseTracking', () => ({ __esModule: true, segmentTrack: jest.fn() }));
-jest.mock('@/hooks/useFeatureFlag', () => ({ __esModule: true, default: () => true }));
 jest.mock('@/core/utils/PageProps', () => ({
   __esModule: true,
   default: {
-    settings: () => ({ ai: { ciConfigExpert: {} } }),
+    settings: () => ({ ai: { ciConfigExpert: { availability } } }),
     appSlug: () => 'app-slug',
     app: () => ({}),
   },
@@ -32,20 +32,59 @@ const ROOT: TreeNode = {
   includes: [],
 };
 
+const renderAIButton = () => renderHook(() => useAIButton({ action: 'explain_workflow' })).result.current;
+
 describe('useAIButton', () => {
-  it('is visible in a non-modular config', () => {
+  beforeEach(() => {
+    availability = 'enabled';
     bitriseYmlStore.setState({ tree: undefined });
+  });
 
-    const { result } = renderHook(() => useAIButton({ action: 'explain_workflow' }));
-
-    expect(result.current.isVisible).toBe(true);
+  it('is visible in a non-modular config', () => {
+    expect(renderAIButton().isVisible).toBe(true);
   });
 
   it('is hidden in a modular config (BIVS-3735)', () => {
     initializeModularConfig({ root: ROOT, branch: 'main', commitSha: SHA });
 
-    const { result } = renderHook(() => useAIButton({ action: 'explain_workflow' }));
+    expect(renderAIButton().isVisible).toBe(false);
+  });
 
-    expect(result.current.isVisible).toBe(false);
+  describe('availability', () => {
+    it('hides every entry point when the agent is not available for the workspace', () => {
+      availability = 'unavailable';
+
+      expect(renderAIButton().isVisible).toBe(false);
+    });
+
+    it('hides every entry point when AI is switched off for the workspace', () => {
+      availability = 'disabled-by-workspace';
+
+      expect(renderAIButton().isVisible).toBe(false);
+    });
+
+    it('points at the project settings when the project has not opted in', () => {
+      availability = 'disabled-by-project';
+
+      const { isVisible, tooltipLabel, getAIButtonProps } = renderAIButton();
+
+      expect(isVisible).toBe(true);
+      expect(getAIButtonProps().isDisabled).toBe(true);
+      expect(tooltipLabel).toBe('AI functions are disabled. Go to Project settings to turn them on.');
+    });
+
+    it('is enabled when the project has opted in', () => {
+      const { isVisible, tooltipLabel, getAIButtonProps } = renderAIButton();
+
+      expect(isVisible).toBe(true);
+      expect(getAIButtonProps().isDisabled).toBe(false);
+      expect(tooltipLabel).toBeUndefined();
+    });
+
+    it('hides every entry point when the parent has no settings at all (CLI mode)', () => {
+      availability = undefined;
+
+      expect(renderAIButton().isVisible).toBe(false);
+    });
   });
 });

--- a/source/javascripts/hooks/useAIButton.ts
+++ b/source/javascripts/hooks/useAIButton.ts
@@ -7,7 +7,6 @@ import GlobalProps from '@/core/utils/GlobalProps';
 import PageProps from '@/core/utils/PageProps';
 import WindowUtils from '@/core/utils/WindowUtils';
 import useCurrentPage from '@/hooks/useCurrentPage';
-import useFeatureFlag from '@/hooks/useFeatureFlag';
 import useParentMessageListener from '@/hooks/useParentMessageListener';
 import { useTree } from '@/hooks/useTree';
 
@@ -39,7 +38,6 @@ const useAIButton = (options: UseAIButtonOptions): UseAIButtonResult => {
   const { action, source, yamlSelector = 'workflow' } = options;
   const [isAgenticRunInProgress, setIsAgenticRunInProgress] = useState(false);
   const isAIDrawerOpen = useCiConfigExpertStore((s) => s.isAIDrawerOpen);
-  const enableCiConfigExpertAgent = useFeatureFlag('enable-ci-config-expert-agent');
   const selectedPage = useCurrentPage();
   const conversationId = useCiConfigExpertStore((s) => s.conversationId);
   const turnCount = useCiConfigExpertStore((s) => s.turnCount);
@@ -61,9 +59,11 @@ const useAIButton = (options: UseAIButtonOptions): UseAIButtonResult => {
   // hide every AI entry point while a modular config is open rather than offer a broken action (BIVS-3735).
   const isModular = Boolean(useTree());
 
-  const ciConfigExpert = PageProps.settings()?.ai.ciConfigExpert;
-  const isEnabledByWorkspace = !!ciConfigExpert && ciConfigExpert.disabled !== 'by-workspace';
-  const isVisible = enableCiConfigExpertAgent && isEnabledByWorkspace && !isModular;
+  // The monolith folds the plan entitlement and the workspace- and project-level opt-in into this
+  // one value, so every AI entry point on both sides of the iframe reads the same verdict.
+  const availability = PageProps.settings()?.ai?.ciConfigExpert?.availability;
+  const isVisible =
+    !!availability && availability !== 'unavailable' && availability !== 'disabled-by-workspace' && !isModular;
 
   let tooltipLabel;
   let isDisabled = false;
@@ -74,12 +74,9 @@ const useAIButton = (options: UseAIButtonOptions): UseAIButtonResult => {
       tooltipLabel = 'AI functions are not available while an agentic run is in progress.';
     } else if (isAIDrawerOpen) {
       isDisabled = true;
-    } else if (ciConfigExpert?.disabled === 'by-project') {
+    } else if (availability === 'disabled-by-project') {
       isDisabled = true;
       tooltipLabel = 'AI functions are disabled. Go to Project settings to turn them on.';
-    } else if (ciConfigExpert?.disabled === 'unsupported') {
-      isDisabled = true;
-      tooltipLabel = 'AI functions are not available on your current plan.';
     }
   }
 

--- a/source/javascripts/hooks/useAIButton.ts
+++ b/source/javascripts/hooks/useAIButton.ts
@@ -60,10 +60,11 @@ const useAIButton = (options: UseAIButtonOptions): UseAIButtonResult => {
   const isModular = Boolean(useTree());
 
   // The monolith folds the plan entitlement and the workspace- and project-level opt-in into this
-  // one value, so every AI entry point on both sides of the iframe reads the same verdict.
+  // one value, so every AI entry point on both sides of the iframe reads the same verdict. Only a
+  // workspace the assistant isn't available to at all hides them: an opted-out project still gets
+  // working buttons, and the parent answers the click with the opt-in modal instead of the drawer.
   const availability = PageProps.settings()?.ai?.ciConfigExpert?.availability;
-  const isVisible =
-    !!availability && availability !== 'unavailable' && availability !== 'disabled-by-workspace' && !isModular;
+  const isVisible = !!availability && availability !== 'unavailable' && !isModular;
 
   let tooltipLabel;
   let isDisabled = false;
@@ -74,9 +75,6 @@ const useAIButton = (options: UseAIButtonOptions): UseAIButtonResult => {
       tooltipLabel = 'AI functions are not available while an agentic run is in progress.';
     } else if (isAIDrawerOpen) {
       isDisabled = true;
-    } else if (availability === 'disabled-by-project') {
-      isDisabled = true;
-      tooltipLabel = 'AI functions are disabled. Go to Project settings to turn them on.';
     }
   }
 

--- a/source/javascripts/hooks/useFeatureFlag.ts
+++ b/source/javascripts/hooks/useFeatureFlag.ts
@@ -1,7 +1,6 @@
 import GlobalProps from '@/core/utils/GlobalProps';
 
 const defaultValues = {
-  'enable-ci-config-expert-agent': false,
   'enable-branch-switching': false,
   'enable-wfe-tool-versions': false,
   'enable-wfe-modular-yaml-editing': false,

--- a/source/javascripts/pages/PipelinesPage/PipelinesPage.stories.tsx
+++ b/source/javascripts/pages/PipelinesPage/PipelinesPage.stories.tsx
@@ -26,7 +26,6 @@ export default {
   ],
   beforeEach: () => {
     set(window, 'parent.pageProps.limits.isPipelinesAvailable', true);
-    set(window, 'parent.globalProps.featureFlags.account.enable-ci-config-expert-agent', true);
     window.parent.pageProps = aiButtonEnabled();
   },
 } as Meta<typeof PipelinesPage>;

--- a/source/javascripts/pages/PipelinesPage/PipelinesPage.stories.tsx
+++ b/source/javascripts/pages/PipelinesPage/PipelinesPage.stories.tsx
@@ -3,7 +3,7 @@ import { Meta, StoryObj } from '@storybook/react-vite';
 import { set } from 'es-toolkit/compat';
 
 import { getStacksAndMachines } from '@/core/api/StacksAndMachinesApi.mswMocks';
-import { aiButtonDisabled, aiButtonEnabled, aiButtonHidden } from '@/storyutils/getAISettings.utils';
+import { aiButtonEnabled, aiButtonUnavailable } from '@/storyutils/getAISettings.utils';
 
 import PipelinesPage from './PipelinesPage';
 
@@ -34,7 +34,7 @@ type Story = StoryObj<typeof PipelinesPage>;
 
 export const CreateFirstGraphPipeline: Story = {
   beforeEach: () => {
-    window.parent.pageProps = aiButtonHidden();
+    window.parent.pageProps = aiButtonUnavailable();
   },
   parameters: {
     bitriseYmlStore: { yml: { format_version: '2' } },
@@ -42,15 +42,6 @@ export const CreateFirstGraphPipeline: Story = {
 };
 
 export const EmptyWithCreateWithAI: Story = {
-  parameters: {
-    bitriseYmlStore: { yml: { format_version: '2' } },
-  },
-};
-
-export const EmptyWithCreateWithAIDisabled: Story = {
-  beforeEach: () => {
-    window.parent.pageProps = aiButtonDisabled();
-  },
   parameters: {
     bitriseYmlStore: { yml: { format_version: '2' } },
   },

--- a/source/javascripts/pages/PipelinesPage/components/EmptyStates/CreateFirstGraphPipelineEmptyState.stories.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/EmptyStates/CreateFirstGraphPipelineEmptyState.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { set } from 'es-toolkit/compat';
 
 import { aiButtonDisabled, aiButtonEnabled } from '@/storyutils/getAISettings.utils';
 
@@ -7,9 +6,6 @@ import CreateFirstGraphPipelineEmptyState from './CreateFirstGraphPipelineEmptyS
 
 export default {
   component: CreateFirstGraphPipelineEmptyState,
-  beforeEach: () => {
-    set(window, 'parent.globalProps.featureFlags.account.enable-ci-config-expert-agent', true);
-  },
 } as Meta<typeof CreateFirstGraphPipelineEmptyState>;
 
 export const CreateFirstGraphPipelineWithoutCreateWithAI: StoryObj<typeof CreateFirstGraphPipelineEmptyState> = {};

--- a/source/javascripts/pages/PipelinesPage/components/EmptyStates/CreateFirstGraphPipelineEmptyState.stories.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/EmptyStates/CreateFirstGraphPipelineEmptyState.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 
-import { aiButtonDisabled, aiButtonEnabled } from '@/storyutils/getAISettings.utils';
+import { aiButtonEnabled, aiButtonUnavailable } from '@/storyutils/getAISettings.utils';
 
 import CreateFirstGraphPipelineEmptyState from './CreateFirstGraphPipelineEmptyState';
 
@@ -8,16 +8,14 @@ export default {
   component: CreateFirstGraphPipelineEmptyState,
 } as Meta<typeof CreateFirstGraphPipelineEmptyState>;
 
-export const CreateFirstGraphPipelineWithoutCreateWithAI: StoryObj<typeof CreateFirstGraphPipelineEmptyState> = {};
+export const CreateFirstGraphPipelineWithoutCreateWithAI: StoryObj<typeof CreateFirstGraphPipelineEmptyState> = {
+  beforeEach: () => {
+    window.parent.pageProps = aiButtonUnavailable();
+  },
+};
 
 export const CreateFirstGraphPipelineWithCreateWithAI: StoryObj<typeof CreateFirstGraphPipelineEmptyState> = {
   beforeEach: () => {
     window.parent.pageProps = aiButtonEnabled();
-  },
-};
-
-export const CreateFirstGraphPipelineWithCreateWithAIDisabled: StoryObj<typeof CreateFirstGraphPipelineEmptyState> = {
-  beforeEach: () => {
-    window.parent.pageProps = aiButtonDisabled();
   },
 };

--- a/source/javascripts/pages/PipelinesPage/components/Toolbar/Toolbar.stories.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/Toolbar/Toolbar.stories.tsx
@@ -1,5 +1,4 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
-import { set } from 'es-toolkit/compat';
 
 import { aiButtonDisabled, aiButtonEnabled } from '@/storyutils/getAISettings.utils';
 
@@ -9,9 +8,6 @@ type Story = StoryObj<typeof Toolbar>;
 
 const meta: Meta<typeof Toolbar> = {
   component: Toolbar,
-  beforeEach: () => {
-    set(window, 'parent.globalProps.featureFlags.account.enable-ci-config-expert-agent', true);
-  },
   argTypes: {
     onCreatePipelineClick: { type: 'function' },
     onRunClick: { type: 'function' },

--- a/source/javascripts/pages/PipelinesPage/components/Toolbar/Toolbar.stories.tsx
+++ b/source/javascripts/pages/PipelinesPage/components/Toolbar/Toolbar.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react-vite';
 
-import { aiButtonDisabled, aiButtonEnabled } from '@/storyutils/getAISettings.utils';
+import { aiButtonEnabled } from '@/storyutils/getAISettings.utils';
 
 import Toolbar from './Toolbar';
 
@@ -21,12 +21,6 @@ export const Default: Story = {};
 export const WithCreateWithAIButton: StoryObj = {
   beforeEach: () => {
     window.parent.pageProps = aiButtonEnabled();
-  },
-};
-
-export const WithCreateWithAIButtonDisabled: StoryObj = {
-  beforeEach: () => {
-    window.parent.pageProps = aiButtonDisabled();
   },
 };
 

--- a/source/javascripts/pages/WorkflowsPage/WorkflowsPage.stories.tsx
+++ b/source/javascripts/pages/WorkflowsPage/WorkflowsPage.stories.tsx
@@ -14,7 +14,12 @@ import {
 import { getStacksAndMachines } from '@/core/api/StacksAndMachinesApi.mswMocks';
 import StepApiMocks from '@/core/api/StepApi.mswMocks';
 import YmlUtils from '@/core/utils/YmlUtils';
-import { aiButtonDisabled, aiButtonEnabled, aiButtonHidden } from '@/storyutils/getAISettings.utils';
+import {
+  aiButtonDisabled,
+  aiButtonEnabled,
+  aiButtonHidden,
+  aiButtonUnavailable,
+} from '@/storyutils/getAISettings.utils';
 
 import WorkflowsPage from './WorkflowsPage';
 
@@ -22,9 +27,6 @@ type Story = StoryObj<typeof WorkflowsPage>;
 
 const meta: Meta<typeof WorkflowsPage> = {
   component: WorkflowsPage,
-  beforeEach: () => {
-    set(window, 'parent.globalProps.featureFlags.account.enable-ci-config-expert-agent', true);
-  },
   parameters: {
     layout: 'fullscreen',
     msw: {
@@ -119,7 +121,6 @@ export const NoContainerDefinitions: Story = {
     })(),
   },
   beforeEach: () => {
-    set(window, 'parent.globalProps.featureFlags.account.enable-ci-config-expert-agent', true);
     window.parent.pageProps = aiButtonEnabled();
   },
 };
@@ -179,6 +180,20 @@ export const EmptyCreateWithAIDisabled: Story = {
 export const EmptyWithoutCreateWithAI: Story = {
   beforeEach: () => {
     window.parent.pageProps = aiButtonHidden();
+  },
+  parameters: {
+    bitriseYmlStore: (() => {
+      set(TEST_BITRISE_YML, 'workflows', {});
+      return { yml: TEST_BITRISE_YML, ymlDocument: YmlUtils.toDoc(stringify(TEST_BITRISE_YML)) };
+    })(),
+  },
+};
+
+// Renders the same as EmptyWithoutCreateWithAI today; the two diverge once opted-out workspaces get
+// the button plus the opt-in modal, and only this one stays button-less.
+export const EmptyWithAIUnavailable: Story = {
+  beforeEach: () => {
+    window.parent.pageProps = aiButtonUnavailable();
   },
   parameters: {
     bitriseYmlStore: (() => {

--- a/source/javascripts/pages/WorkflowsPage/WorkflowsPage.stories.tsx
+++ b/source/javascripts/pages/WorkflowsPage/WorkflowsPage.stories.tsx
@@ -14,12 +14,7 @@ import {
 import { getStacksAndMachines } from '@/core/api/StacksAndMachinesApi.mswMocks';
 import StepApiMocks from '@/core/api/StepApi.mswMocks';
 import YmlUtils from '@/core/utils/YmlUtils';
-import {
-  aiButtonDisabled,
-  aiButtonEnabled,
-  aiButtonHidden,
-  aiButtonUnavailable,
-} from '@/storyutils/getAISettings.utils';
+import { aiButtonEnabled, aiButtonUnavailable } from '@/storyutils/getAISettings.utils';
 
 import WorkflowsPage from './WorkflowsPage';
 
@@ -165,33 +160,7 @@ export const EmptyCreateWithAI: Story = {
   },
 };
 
-export const EmptyCreateWithAIDisabled: Story = {
-  beforeEach: () => {
-    window.parent.pageProps = aiButtonDisabled();
-  },
-  parameters: {
-    bitriseYmlStore: (() => {
-      set(TEST_BITRISE_YML, 'workflows', {});
-      return { yml: TEST_BITRISE_YML, ymlDocument: YmlUtils.toDoc(stringify(TEST_BITRISE_YML)) };
-    })(),
-  },
-};
-
 export const EmptyWithoutCreateWithAI: Story = {
-  beforeEach: () => {
-    window.parent.pageProps = aiButtonHidden();
-  },
-  parameters: {
-    bitriseYmlStore: (() => {
-      set(TEST_BITRISE_YML, 'workflows', {});
-      return { yml: TEST_BITRISE_YML, ymlDocument: YmlUtils.toDoc(stringify(TEST_BITRISE_YML)) };
-    })(),
-  },
-};
-
-// Renders the same as EmptyWithoutCreateWithAI today; the two diverge once opted-out workspaces get
-// the button plus the opt-in modal, and only this one stays button-less.
-export const EmptyWithAIUnavailable: Story = {
   beforeEach: () => {
     window.parent.pageProps = aiButtonUnavailable();
   },

--- a/source/javascripts/storyutils/getAISettings.utils.ts
+++ b/source/javascripts/storyutils/getAISettings.utils.ts
@@ -1,13 +1,10 @@
-type CiConfigExpertProps = {
-  disabled?: 'by-project' | 'by-workspace' | 'unsupported';
-  options?: { wfeIntegration: boolean };
-};
+import { CiConfigExpertAvailability } from '@/typings/globals';
 
-const withCiConfigExpert = ({ disabled, options }: CiConfigExpertProps = {}) => ({
+const withCiConfigExpert = (availability: CiConfigExpertAvailability) => ({
   ...window.parent.pageProps,
   settings: {
     ai: {
-      ciConfigExpert: disabled ? { disabled, options } : { options: options ?? { wfeIntegration: false } },
+      ciConfigExpert: { availability, options: { wfeIntegration: availability === 'enabled' } },
       failedBuilds: {
         disabled: 'by-project' as const,
         options: undefined,
@@ -20,8 +17,10 @@ const withCiConfigExpert = ({ disabled, options }: CiConfigExpertProps = {}) => 
   },
 });
 
-export const aiButtonEnabled = () => withCiConfigExpert({ options: { wfeIntegration: true } });
+export const aiButtonEnabled = () => withCiConfigExpert('enabled');
 
-export const aiButtonDisabled = () => withCiConfigExpert({ disabled: 'by-project' });
+export const aiButtonDisabled = () => withCiConfigExpert('disabled-by-project');
 
-export const aiButtonHidden = () => withCiConfigExpert({ disabled: 'by-workspace' });
+export const aiButtonHidden = () => withCiConfigExpert('disabled-by-workspace');
+
+export const aiButtonUnavailable = () => withCiConfigExpert('unavailable');

--- a/source/javascripts/storyutils/getAISettings.utils.ts
+++ b/source/javascripts/storyutils/getAISettings.utils.ts
@@ -19,8 +19,4 @@ const withCiConfigExpert = (availability: CiConfigExpertAvailability) => ({
 
 export const aiButtonEnabled = () => withCiConfigExpert('enabled');
 
-export const aiButtonDisabled = () => withCiConfigExpert('disabled-by-project');
-
-export const aiButtonHidden = () => withCiConfigExpert('disabled-by-workspace');
-
 export const aiButtonUnavailable = () => withCiConfigExpert('unavailable');

--- a/source/javascripts/typings/globals.d.ts
+++ b/source/javascripts/typings/globals.d.ts
@@ -74,7 +74,10 @@ declare global {
       };
       settings?: {
         ai: {
-          ciConfigExpert: AISettings<{ wfeIntegration: boolean }> & { availability: CiConfigExpertAvailability };
+          // Optional because the monolith only started sending it in bitrise-website#20666: a
+          // Workflow Editor build running against an older monolith gets the object without the
+          // field, so every read site has to guard.
+          ciConfigExpert: AISettings<{ wfeIntegration: boolean }> & { availability?: CiConfigExpertAvailability };
           failedBuilds: AISettings<any>;
           fixer: AISettings<any>;
         };

--- a/source/javascripts/typings/globals.d.ts
+++ b/source/javascripts/typings/globals.d.ts
@@ -3,6 +3,10 @@ import { BitriseYml } from '@/core/models/BitriseYml';
 
 export {};
 
+// The monolith's composed verdict on the CI config expert: the plan entitlement plus the
+// workspace- and project-level opt-in, resolved server-side (bitrise-website BIVS-3794).
+export type CiConfigExpertAvailability = 'unavailable' | 'enabled' | 'disabled-by-project' | 'disabled-by-workspace';
+
 export type AISettings<T> =
   | {
       disabled: 'by-project' | 'by-workspace' | 'unsupported';
@@ -70,7 +74,7 @@ declare global {
       };
       settings?: {
         ai: {
-          ciConfigExpert: AISettings<{ wfeIntegration: boolean }>;
+          ciConfigExpert: AISettings<{ wfeIntegration: boolean }> & { availability: CiConfigExpertAvailability };
           failedBuilds: AISettings<any>;
           fixer: AISettings<any>;
         };


### PR DESCRIPTION
[BIVS-3794](https://bitrise.atlassian.net/browse/BIVS-3794) — the editor side of showing the Ask AI button to users who haven't opted in. Two things: the editor stops deciding availability for itself, which brings back six in-editor entry points that are currently invisible to everyone, and an opted-out project gets working buttons instead of a dead end.

Pairs with [bitrise-website#20666](https://github.com/bitrise-io/bitrise-website/pull/20666), which adds the prop this reads. **Either order is safe** — see "Rollout" below.

## Why

`useAIButton` gated every in-editor AI entry point on the raw `enable-ci-config-expert-agent` flag, read from the parent window's `globalProps`. **That key doesn't reach the browser.** Server-side flag evaluation goes through Datadog with a LaunchDarkly fallback, but the browser payload only carries LaunchDarkly's client flags plus the specific Datadog flags listed in `DatadogFeatureFlagsClient::FRONTEND_FLAGS` — and this flag isn't on that list. So `useFeatureFlag('enable-ci-config-expert-agent')` falls back to its `false` default for everyone.

Confirmed on production, on a workspace and project that both have the assistant switched on: the header Ask AI button renders and works, and all six in-editor entry points are missing — "Create Workflow with AI", the workflow config panel's "Explain", the workflow empty state, the Pipelines toolbar, the graph-pipeline empty state, and the pipeline config drawer's "Explain".

The header button was unaffected because the monolith computes its verdict server-side and ships it as an explicit `globalProps` value rather than as a flag key. Reading that same verdict here is what brings the in-editor entry points back, and means the two sides can't drift apart again.

The second half is the actual feature. An opted-out project used to get the buttons rendered disabled with a tooltip pointing at a settings page — a dead end even when it did render. Now every entry point behaves the same and the parent answers the click with the opt-in modal.

## What changed

| Change | Detail |
|---|---|
| `useAIButton.ts` | Reads `availability`; no `useFeatureFlag`, no re-derivation, no opt-in tooltip. Only `unavailable` (or a modular config) hides the entry points; the agentic-run and drawer-open disabled states are untouched |
| `useFeatureFlag.ts` | `enable-ci-config-expert-agent` dropped from `defaultValues` |
| `globals.d.ts` | `CiConfigExpertAvailability` + the new `pageProps` field, optional because an editor build can run against a monolith that predates it |
| `getAISettings.utils.ts` | Story helper takes an availability; down to `aiButtonEnabled()` and `aiButtonUnavailable()` |
| 5 story files | Drop the `enable-ci-config-expert-agent` setup, and the story variants that now render identically to the available one |
| `useAIButton.spec.tsx` | Covers all four availability values plus CLI mode (no `settings` at all) |

The `unsupported` reason is gone too: `GetCIConfigExpertState` only ever returns `Enabled`, `by_project` or `by_workspace`, so that tooltip was unreachable.

Since the three available states now render the same thing in the editor, keeping a story for each would have been three identical screenshots. The spec tells them apart instead, and the visible difference lives in the parent's modal.

## Rollout

Nothing here has to be sequenced against the website, in either direction — not because the two are expected to land together, but because the receiving end no longer trusts the sender. `OPEN_CI_CONFIG_EXPERT` checks the opt-in state before opening the drawer, and answers with `CI_CONFIG_EXPERT_CLOSED` when it declines, so this PR reaching production ahead of the opt-in modal means a click that does nothing — not the assistant handed to a project that never opted in, and not an editor stuck thinking its drawer is open.

Two consequences worth knowing:

- Until the modal is wired up, a click on an opted-out project is a no-op. Today it's a disabled button with a tooltip pointing at a settings page, which is a dead end of a different shape.
- If this ships before the monolith sends `availability`, the AI entry points stay hidden until it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[BIVS-3794]: https://bitrise.atlassian.net/browse/BIVS-3794?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ