### PR TITLE
[CI-6349] fix: revalidate both Intercom instances on in-editor navigation

### DIFF
--- a/source/javascripts/hooks/useHashLocation.ts
+++ b/source/javascripts/hooks/useHashLocation.ts
@@ -21,20 +21,7 @@ const useHashLocation: BaseLocationHook = () => {
 
   useEffect(() => {
     const listener = () => {
-      const parentHash = window.parent.location.hash;
-      setPath(`/${parentHash.replace(/^#?!?\/?/, '')}`);
-
-      // Intercom boots inside this iframe's own document, so its "Current page URL contains…"
-      // targeting reads THIS window's own location — but the router only ever writes to
-      // window.parent's hash (whether from navigate() below, an Intercom tour step's own button,
-      // or anything else touching the parent's location), so this window's location is otherwise
-      // frozen at whatever it was on the iframe's initial load. Mirror the parent's hash onto our
-      // own location first, so Intercom's page-URL check has something current to see, then nudge
-      // it to re-evaluate. Calling Intercom('update') alone is not enough while this URL is stale.
-      if (window.location.hash !== parentHash) {
-        window.location.hash = parentHash;
-      }
-      window.Intercom?.('update');
+      setPath(`/${window.parent.location.hash.replace(/^#?!?\/?/, '')}`);
     };
 
     window.parent.addEventListener('hashchange', listener);

--- a/source/javascripts/lib/intrcm.js
+++ b/source/javascripts/lib/intrcm.js
@@ -1,5 +1,21 @@
 const APP_ID = import.meta.env.INTERCOM_APP_ID;
 
+const syncOwnUrlWithParentHash = () => {
+  const url = new URL(window.location.href);
+
+  if (url.hash === window.parent.location.hash) {
+    return;
+  }
+
+  url.hash = window.parent.location.hash;
+  window.history.replaceState(window.history.state, '', url);
+};
+
+const revalidatePageTargetingOfBothInstances = () => {
+  window.Intercom?.('update');
+  window.parent.Intercom?.('update');
+};
+
 if (APP_ID) {
   window.intercomSettings = {
     app_id: APP_ID,
@@ -8,6 +24,15 @@ if (APP_ID) {
   };
 
   (function () { var w = window; var ic = w.Intercom; if (typeof ic === "function") { ic('update', w.intercomSettings); } else { var d = document; var i = function () { i.c(arguments); }; i.q = []; i.c = function (args) { i.q.push(args); }; w.Intercom = i; var l = function () { var s = d.createElement('script'); s.type = 'text/javascript'; s.async = true; s.src = 'https://widget.intercom.io/widget/' + APP_ID; var x = d.getElementsByTagName('script')[0]; x.parentNode.insertBefore(s, x); }; if (document.readyState === 'complete') { l(); } else if (w.attachEvent) { w.attachEvent('onload', l); } else { w.addEventListener('load', l, false); } } })();
+
+  const isEmbeddedInParentWindow = window.parent !== window;
+
+  if (isEmbeddedInParentWindow) {
+    window.parent.addEventListener('hashchange', () => {
+      syncOwnUrlWithParentHash();
+      revalidatePageTargetingOfBothInstances();
+    });
+  }
 }
 
 export { };

--- a/source/javascripts/typings/globals.d.ts
+++ b/source/javascripts/typings/globals.d.ts
@@ -22,8 +22,6 @@ declare global {
 
   interface Window {
     DD_RUM: typeof import('@datadog/browser-rum').datadogRum | undefined;
-    // source/javascripts/lib/intrcm.js — the Intercom widget bootstrap snippet.
-    Intercom?: (...args: unknown[]) => void;
     // webpack.config.js
     localFeatureFlags: Partial<{
       [s: string]: string | number | boolean;


### PR DESCRIPTION
Follow-up to #1870 / #1872: page-targeted tours still only fired for whichever editor page loaded first. Three reasons, all in the sync those PRs put in `useHashLocation`'s effect.

**Nothing told the top window's Intercom that a navigation had happened.** The platform shell boots its own instance — the one that owns the launcher and can highlight anything outside the iframe — and its URL already carries the editor's hash, but `navigate()` only calls `window.parent.history.replaceState()` and Intercom counts page views by path, so a hash-only change never re-evaluates its rules. The editor is the only place that knows a navigation happened, so it now pings both instances and lets each match what it can: a tour only sees the DOM of the document whose instance runs it.

**The ping fired once per `useHashLocation` instance.** That hook isn't a router singleton — `Header`, `Navigation`, `MainLayout`, `InvalidYmlRedirect` and `useCurrentPage`'s / `useNavigation`'s callers each hold one — so one hash change produced ~a dozen identical `Intercom('update')` calls in a tick, twice that under StrictMode, which Intercom dedupes and throttles. In `lib/intrcm.js` it's a module side effect instead: installed once, only with `INTERCOM_APP_ID` set, no React lifecycle.

**`window.location.hash = …` pushed a history entry** on top of `navigate()`'s, so Back needed two presses per tab switch. `replaceState` costs none, and is what Intercom's SPA detection hooks.

Still needs doing in Intercom, not in code: WFE-DOM tours should match `workflow_editor_content`, a token only the iframe URL has; anything spanning both documents has to be split in two (`data-intercom-target="Workflows button"` lives in the shell's `AppPageLayout.tsx`). And check the `workflow-editor-version` flag before judging prod — #1870/#1872 only landed around 2.5.16112.

🤖 Generated with [Claude Code](https://claude.com/claude-code)