### PR TITLE
Open the module that defines a URL-addressed entity in modular configs

### DIFF
--- a/source/javascripts/core/models/Tree.ts
+++ b/source/javascripts/core/models/Tree.ts
@@ -51,6 +51,9 @@ export type EntityIndex = {
 
 export type EntityKind = keyof EntityIndex;
 
+/** An entity a URL points at (`#!/workflows?workflow_id=deploy`), to be resolved against the index. */
+export type EntityDeepLink = { kind: EntityKind; id: string };
+
 /** Bootstrap response (`GET /config/tree`). Always tree-shaped; a non-modular config is a single root node with `includes: []`. */
 export type GetConfigResponse = {
   root: TreeNode;

--- a/source/javascripts/core/services/EntityIndexService.spec.ts
+++ b/source/javascripts/core/services/EntityIndexService.spec.ts
@@ -41,6 +41,45 @@ describe('EntityIndexService', () => {
     });
   });
 
+  describe('deepLinkNodeId', () => {
+    it('resolves an entity the same way definingNodeId does', () => {
+      expect(EntityIndexService.deepLinkNodeId(index, { kind: 'workflows', id: 'release' })).toBe('n_pinned');
+      expect(EntityIndexService.deepLinkNodeId(index, { kind: 'stepBundles', id: 'common' })).toBe('n_shared');
+      expect(EntityIndexService.deepLinkNodeId(index, { kind: 'workflows', id: 'build' })).toBe('n_root');
+    });
+
+    it('resolves a generated parallel-workflow id back to its source workflow', () => {
+      expect(EntityIndexService.deepLinkNodeId(index, { kind: 'workflows', id: 'release_3' })).toBe('n_pinned');
+    });
+
+    it('prefers an exact match over the parallel-workflow fallback', () => {
+      const withSuffixedId: EntityIndex = {
+        ...index,
+        workflows: { ...index.workflows, release_3: [{ nodeId: 'n_suffixed' }] },
+      };
+
+      expect(EntityIndexService.deepLinkNodeId(withSuffixedId, { kind: 'workflows', id: 'release_3' })).toBe(
+        'n_suffixed',
+      );
+    });
+
+    it('applies the parallel-workflow fallback to workflows only', () => {
+      const withSuffixedLink: EntityIndex = {
+        ...index,
+        pipelines: { deploy: [{ nodeId: 'n_pipelines' }] },
+      };
+
+      expect(
+        EntityIndexService.deepLinkNodeId(withSuffixedLink, { kind: 'pipelines', id: 'deploy_2' }),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when no module defines the entity', () => {
+      expect(EntityIndexService.deepLinkNodeId(index, { kind: 'workflows', id: 'missing' })).toBeUndefined();
+      expect(EntityIndexService.deepLinkNodeId(index, { kind: 'workflows', id: 'missing_2' })).toBeUndefined();
+    });
+  });
+
   describe('buildFromFiles', () => {
     function node(nodeId: string, includes: TreeNode[] = []): TreeNode {
       return {

--- a/source/javascripts/core/services/EntityIndexService.ts
+++ b/source/javascripts/core/services/EntityIndexService.ts
@@ -1,6 +1,7 @@
 import { Document } from 'yaml';
 
 import { EntityDeepLink, EntityDefinition, EntityIndex, EntityKind, TreeNode } from '@/core/models/Tree';
+import { parallelWorkflowSourceId } from '@/core/utils/CommonUtils';
 import YmlUtils from '@/core/utils/YmlUtils';
 
 // Map-shaped YAML sections (entity id → definition), generically indexed by the DFS below.
@@ -27,14 +28,11 @@ function definingNodeId(index: EntityIndex, kind: EntityKind, id: string): strin
   return definitionsOf(index, kind, id)[0]?.nodeId;
 }
 
-// A parallel workflow is materialised at build time as `<id>_<n>` copies that only ever exist in
-// the build, never in the config — so links arriving from a build can carry one of those ids.
-const PARALLEL_WORKFLOW_VARIANT_REGEX = /_\d+$/;
-
 /**
  * The `nodeId` of the module defining the entity a URL points at, or `undefined` when no module
  * defines it. Like {@link definingNodeId}, but resolves a generated parallel-workflow id back to
- * its source workflow — the same fallback `useSelectedWorkflow` applies when picking the selection.
+ * its source workflow — sharing {@link parallelWorkflowSourceId} with `useSelectedWorkflow`, so the
+ * module this opens and the workflow that page then selects can't disagree.
  */
 function deepLinkNodeId(index: EntityIndex, { kind, id }: EntityDeepLink): string | undefined {
   const exactMatch = definingNodeId(index, kind, id);
@@ -42,8 +40,8 @@ function deepLinkNodeId(index: EntityIndex, { kind, id }: EntityDeepLink): strin
     return exactMatch;
   }
 
-  const sourceId = id.replace(PARALLEL_WORKFLOW_VARIANT_REGEX, '');
-  return sourceId === id ? undefined : definingNodeId(index, kind, sourceId);
+  const sourceId = parallelWorkflowSourceId(id);
+  return sourceId ? definingNodeId(index, kind, sourceId) : undefined;
 }
 
 /** Build the entity index live from open file documents (mirrors the BE builder) so cross-file detection stays correct before save. */

--- a/source/javascripts/core/services/EntityIndexService.ts
+++ b/source/javascripts/core/services/EntityIndexService.ts
@@ -1,6 +1,6 @@
 import { Document } from 'yaml';
 
-import { EntityDefinition, EntityIndex, EntityKind, TreeNode } from '@/core/models/Tree';
+import { EntityDeepLink, EntityDefinition, EntityIndex, EntityKind, TreeNode } from '@/core/models/Tree';
 import YmlUtils from '@/core/utils/YmlUtils';
 
 // Map-shaped YAML sections (entity id → definition), generically indexed by the DFS below.
@@ -25,6 +25,25 @@ function definitionsOf(index: EntityIndex, kind: EntityKind, id: string): Entity
 /** The `nodeId` of the top-most (highest-precedence) node defining this entity; use `definitionsOf` when every layer matters. */
 function definingNodeId(index: EntityIndex, kind: EntityKind, id: string): string | undefined {
   return definitionsOf(index, kind, id)[0]?.nodeId;
+}
+
+// A parallel workflow is materialised at build time as `<id>_<n>` copies that only ever exist in
+// the build, never in the config — so links arriving from a build can carry one of those ids.
+const PARALLEL_WORKFLOW_VARIANT_REGEX = /_\d+$/;
+
+/**
+ * The `nodeId` of the module defining the entity a URL points at, or `undefined` when no module
+ * defines it. Like {@link definingNodeId}, but resolves a generated parallel-workflow id back to
+ * its source workflow — the same fallback `useSelectedWorkflow` applies when picking the selection.
+ */
+function deepLinkNodeId(index: EntityIndex, { kind, id }: EntityDeepLink): string | undefined {
+  const exactMatch = definingNodeId(index, kind, id);
+  if (exactMatch || kind !== 'workflows') {
+    return exactMatch;
+  }
+
+  const sourceId = id.replace(PARALLEL_WORKFLOW_VARIANT_REGEX, '');
+  return sourceId === id ? undefined : definingNodeId(index, kind, sourceId);
 }
 
 /** Build the entity index live from open file documents (mirrors the BE builder) so cross-file detection stays correct before save. */
@@ -106,6 +125,7 @@ export default {
   emptyEntityIndex,
   definingNodeId,
   definitionsOf,
+  deepLinkNodeId,
   buildFromFiles,
   equals,
 };

--- a/source/javascripts/core/stores/BitriseYmlStore.modular.spec.ts
+++ b/source/javascripts/core/stores/BitriseYmlStore.modular.spec.ts
@@ -145,6 +145,16 @@ describe('BitriseYmlStore — modular tree', () => {
       expect(bitriseYmlStore.getState().selectedNodeId).toBe('child-a');
     });
 
+    it('opens the defining module for a non-workflow kind too', () => {
+      const root = buildRoot();
+      root.includes[0].contents = 'step_bundles:\n  shared-setup: {}\n';
+      initializeModularConfig({ root, deepLink: { kind: 'stepBundles', id: 'shared-setup' } });
+
+      const state = bitriseYmlStore.getState();
+      expect(state.selectedNodeId).toBe('child-a');
+      expect(state.yml.step_bundles?.['shared-setup']).toBeDefined();
+    });
+
     it('keeps the root file selected when the linked entity is defined there', () => {
       const root = buildRoot();
       root.contents = 'workflows:\n  root-only: {}\n';

--- a/source/javascripts/core/stores/BitriseYmlStore.modular.spec.ts
+++ b/source/javascripts/core/stores/BitriseYmlStore.modular.spec.ts
@@ -119,6 +119,50 @@ describe('BitriseYmlStore — modular tree', () => {
       });
     });
 
+    it('opens and selects the module defining the entity the URL points at', () => {
+      initializeModularConfig({ root: buildRoot(), deepLink: { kind: 'workflows', id: 'child-b' } });
+
+      const state = bitriseYmlStore.getState();
+      expect(state.selectedNodeId).toBe('child-b');
+      // The root tab stays open next to it, so the module is reached without losing the entry point.
+      expect(state.openTabs).toEqual([
+        { nodeId: 'root', isPreview: false },
+        { nodeId: 'child-b', isPreview: false },
+      ]);
+      // The active document is the module's, so the linked workflow resolves for the pages.
+      expect(state.yml.workflows?.['child-b']).toBeDefined();
+    });
+
+    it('selects a read-only module when that is where the linked entity is defined', () => {
+      initializeModularConfig({ root: buildRoot(), deepLink: { kind: 'workflows', id: 'readonly' } });
+
+      expect(bitriseYmlStore.getState().selectedNodeId).toBe('readonly');
+    });
+
+    it('follows a generated parallel-workflow id to the module defining its source workflow', () => {
+      initializeModularConfig({ root: buildRoot(), deepLink: { kind: 'workflows', id: 'child-a_3' } });
+
+      expect(bitriseYmlStore.getState().selectedNodeId).toBe('child-a');
+    });
+
+    it('keeps the root file selected when the linked entity is defined there', () => {
+      const root = buildRoot();
+      root.contents = 'workflows:\n  root-only: {}\n';
+      initializeModularConfig({ root, deepLink: { kind: 'workflows', id: 'root-only' } });
+
+      const state = bitriseYmlStore.getState();
+      expect(state.selectedNodeId).toBe('root');
+      expect(state.openTabs).toEqual([{ nodeId: 'root', isPreview: false }]);
+    });
+
+    it('keeps the root file selected when no module defines the linked entity', () => {
+      initializeModularConfig({ root: buildRoot(), deepLink: { kind: 'workflows', id: 'nowhere-to-be-found' } });
+
+      const state = bitriseYmlStore.getState();
+      expect(state.selectedNodeId).toBe('root');
+      expect(state.openTabs).toEqual([{ nodeId: 'root', isPreview: false }]);
+    });
+
     it('keeps the entity index live as module files are edited (cross-file detection before save)', () => {
       updateFileDocument('child-a', ({ doc }) => {
         YmlUtils.setIn(doc, ['workflows', 'brand-new'], {});

--- a/source/javascripts/core/stores/BitriseYmlStore.ts
+++ b/source/javascripts/core/stores/BitriseYmlStore.ts
@@ -383,7 +383,11 @@ export function initializeModularConfig({
   mergedYml?: string;
   branch?: string;
   commitSha?: string;
-  /** Entity the opening URL points at, so the module defining it is the one opened. */
+  /**
+   * Entity the current URL points at, so the module defining it is the one opened. Resolved on
+   * every (re)initialisation — the first load and a branch reload alike — but deliberately not on
+   * tab switches, where falling back to the newly selected file's own entities is intended.
+   */
   deepLink?: EntityDeepLink;
 }) {
   const files = buildFileSlices(root);

--- a/source/javascripts/core/stores/BitriseYmlStore.ts
+++ b/source/javascripts/core/stores/BitriseYmlStore.ts
@@ -4,7 +4,7 @@ import { createStore, ExtractState, StoreApi } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
 
 import { BitriseYml } from '../models/BitriseYml';
-import { EntityIndex, TreeNode, TreeNodeSource } from '../models/Tree';
+import { EntityDeepLink, EntityIndex, TreeNode, TreeNodeSource } from '../models/Tree';
 import EntityIndexService from '../services/EntityIndexService';
 import TreeService from '../services/TreeService';
 import RuntimeUtils from '../utils/RuntimeUtils';
@@ -377,19 +377,33 @@ export function initializeModularConfig({
   mergedYml,
   branch,
   commitSha,
+  deepLink,
 }: {
   root: TreeNode;
   mergedYml?: string;
   branch?: string;
   commitSha?: string;
+  /** Entity the opening URL points at, so the module defining it is the one opened. */
+  deepLink?: EntityDeepLink;
 }) {
   const files = buildFileSlices(root);
   const entityIndex = EntityIndexService.buildFromFiles(root, files);
 
+  // A URL can point at an entity defined in an included module. Landing on the root file would
+  // leave that entity unresolvable there and the page would silently select some other one, so open
+  // the defining module alongside the root tab and make it active. An entity no module defines
+  // keeps the root file selected, leaving the page's own fallback in charge.
+  const linkedNodeId = deepLink ? EntityIndexService.deepLinkNodeId(entityIndex, deepLink) : undefined;
+  const selectedNodeId = linkedNodeId && files[linkedNodeId] ? linkedNodeId : root.nodeId;
+  const openTabs: OpenTab[] = [{ nodeId: root.nodeId, isPreview: false }];
+  if (selectedNodeId !== root.nodeId) {
+    openTabs.push({ nodeId: selectedNodeId, isPreview: false });
+  }
+
   bitriseYmlStore.setState({
-    ...modularTreePatch(root, files, entityIndex, files[root.nodeId]),
-    selectedNodeId: root.nodeId,
-    openTabs: [{ nodeId: root.nodeId, isPreview: false }],
+    ...modularTreePatch(root, files, entityIndex, files[selectedNodeId]),
+    selectedNodeId,
+    openTabs,
     // Seed the merged tab from the bootstrap merge; if absent, leave stale so it fetches on first open.
     mergedYml,
     mergedYmlStale: mergedYml === undefined,

--- a/source/javascripts/core/utils/CommonUtils.spec.ts
+++ b/source/javascripts/core/utils/CommonUtils.spec.ts
@@ -1,0 +1,18 @@
+import { parallelWorkflowSourceId } from './CommonUtils';
+
+describe('parallelWorkflowSourceId', () => {
+  it('strips the generated parallel-workflow suffix', () => {
+    expect(parallelWorkflowSourceId('sharded-tests_13')).toBe('sharded-tests');
+    expect(parallelWorkflowSourceId('build_0')).toBe('build');
+  });
+
+  it('strips only the trailing suffix, keeping an id that legitimately ends in `_<n>`', () => {
+    expect(parallelWorkflowSourceId('build_2_3')).toBe('build_2');
+  });
+
+  it('returns undefined when the id carries no such suffix', () => {
+    expect(parallelWorkflowSourceId('build')).toBeUndefined();
+    expect(parallelWorkflowSourceId('build_')).toBeUndefined();
+    expect(parallelWorkflowSourceId('build_v2')).toBeUndefined();
+  });
+});

--- a/source/javascripts/core/utils/CommonUtils.spec.ts
+++ b/source/javascripts/core/utils/CommonUtils.spec.ts
@@ -1,4 +1,4 @@
-import { parallelWorkflowSourceId } from './CommonUtils';
+import { parallelWorkflowSourceId, searchParamsFromLocation } from './CommonUtils';
 
 describe('parallelWorkflowSourceId', () => {
   it('strips the generated parallel-workflow suffix', () => {
@@ -14,5 +14,25 @@ describe('parallelWorkflowSourceId', () => {
     expect(parallelWorkflowSourceId('build')).toBeUndefined();
     expect(parallelWorkflowSourceId('build_')).toBeUndefined();
     expect(parallelWorkflowSourceId('build_v2')).toBeUndefined();
+  });
+});
+
+describe('searchParamsFromLocation', () => {
+  it('reads the params of a hash location', () => {
+    expect(searchParamsFromLocation('#!/workflows?workflow_id=deploy&tab=configuration')).toEqual({
+      workflow_id: 'deploy',
+      tab: 'configuration',
+    });
+  });
+
+  it('takes the last value of a duplicated param', () => {
+    expect(searchParamsFromLocation('#!/workflows?workflow_id=first&workflow_id=last')).toEqual({
+      workflow_id: 'last',
+    });
+  });
+
+  it('returns an empty object when there is no query string', () => {
+    expect(searchParamsFromLocation('#!/workflows')).toEqual({});
+    expect(searchParamsFromLocation('')).toEqual({});
   });
 });

--- a/source/javascripts/core/utils/CommonUtils.ts
+++ b/source/javascripts/core/utils/CommonUtils.ts
@@ -20,6 +20,15 @@ function parallelWorkflowSourceId(id: string): string | undefined {
   return sourceId === id ? undefined : sourceId;
 }
 
+/**
+ * Search params of a (hash) location, as a plain object. On a duplicated param the LAST value wins
+ * — the semantics every `?workflow_id=`/`?pipeline=` reader in the app shares, so a hand-built link
+ * can't be read one way here and another way by the page selectors.
+ */
+function searchParamsFromLocation(location: string): Record<string, string> {
+  return Object.fromEntries(new URLSearchParams(location.split('?')[1] || ''));
+}
+
 function findScrollContainer(element?: HTMLElement | null) {
   if (!element) {
     return null;
@@ -70,4 +79,12 @@ function getCookie(cname: string): string {
   return '';
 }
 
-export { download, findScrollContainer, generateUniqueEntityId, getCookie, getFormattedDate, parallelWorkflowSourceId };
+export {
+  download,
+  findScrollContainer,
+  generateUniqueEntityId,
+  getCookie,
+  getFormattedDate,
+  parallelWorkflowSourceId,
+  searchParamsFromLocation,
+};

--- a/source/javascripts/core/utils/CommonUtils.ts
+++ b/source/javascripts/core/utils/CommonUtils.ts
@@ -6,6 +6,20 @@ function generateUniqueEntityId(existingIds: string[], prefix: string, i = 0) {
   return potentialId;
 }
 
+// A parallel workflow is materialised at build time as `<id>_<n>` copies that only ever exist in
+// the build, never in the config — so an id arriving from a build can carry one of those suffixes.
+const PARALLEL_WORKFLOW_VARIANT_REGEX = /_\d+$/;
+
+/**
+ * The source workflow id behind a generated parallel-workflow id (`sharded-tests_13` →
+ * `sharded-tests`), or `undefined` when the id carries no such suffix. The inverse of the
+ * `<prefix>_<n>` convention {@link generateUniqueEntityId} produces.
+ */
+function parallelWorkflowSourceId(id: string): string | undefined {
+  const sourceId = id.replace(PARALLEL_WORKFLOW_VARIANT_REGEX, '');
+  return sourceId === id ? undefined : sourceId;
+}
+
 function findScrollContainer(element?: HTMLElement | null) {
   if (!element) {
     return null;
@@ -56,4 +70,4 @@ function getCookie(cname: string): string {
   return '';
 }
 
-export { download, findScrollContainer, generateUniqueEntityId, getCookie, getFormattedDate };
+export { download, findScrollContainer, generateUniqueEntityId, getCookie, getFormattedDate, parallelWorkflowSourceId };

--- a/source/javascripts/hooks/useJumpToDefinition.ts
+++ b/source/javascripts/hooks/useJumpToDefinition.ts
@@ -7,7 +7,7 @@ import { bitriseYmlStore, openTab, recordActiveTabLocation } from '@/core/stores
 import { useEntityIndex } from '@/hooks/useEntityIndex';
 import useNavigation from '@/hooks/useNavigation';
 import useSearchParams from '@/hooks/useSearchParams';
-import { paths } from '@/routes';
+import { entityDeepLinkParam, paths } from '@/routes';
 
 const KIND_PATH: Record<EntityKind, string> = {
   workflows: paths.workflows,
@@ -15,14 +15,6 @@ const KIND_PATH: Record<EntityKind, string> = {
   stepBundles: paths.stepBundles,
   containers: paths.containers,
   appEnvs: paths.envVars,
-};
-
-// Per-entity deep-link param. Container/appEnvs pages have no per-entity route param — opening the
-// defining file's tab (below) lands the user on the right page, so they have no entry here.
-const KIND_PARAM: Partial<Record<EntityKind, string>> = {
-  workflows: 'workflow_id',
-  pipelines: 'pipeline',
-  stepBundles: 'step_bundle_id',
 };
 
 /**
@@ -60,7 +52,9 @@ export default function useJumpToDefinition() {
       openTab(nodeId, { preview: false });
 
       const params: Record<string, string> = {};
-      const param = KIND_PARAM[kind];
+      // Container/appEnvs pages have no per-entity param — opening the defining file's tab (above)
+      // already lands the user on the right page.
+      const param = entityDeepLinkParam(kind);
       if (param) {
         params[param] = id;
       }

--- a/source/javascripts/hooks/useSearchParams.ts
+++ b/source/javascripts/hooks/useSearchParams.ts
@@ -1,7 +1,9 @@
 import { Dispatch, SetStateAction, useCallback, useEffect, useState } from 'react';
 
+import { searchParamsFromLocation } from '@/core/utils/CommonUtils';
+
 export const getSearchParamsFromLocationHash = (): Record<string, string> => {
-  return Object.fromEntries(new URLSearchParams(window.parent.location.hash.split('?')[1] || ''));
+  return searchParamsFromLocation(window.parent.location.hash);
 };
 
 export const setSearchParamsInLocationHash = (newSearchParams: Record<string, string>) => {

--- a/source/javascripts/hooks/useSelectedWorkflow.spec.tsx
+++ b/source/javascripts/hooks/useSelectedWorkflow.spec.tsx
@@ -80,6 +80,19 @@ describe('useSelectedWorkflow', () => {
       expect(window.parent.location.hash).toContain('workflow_id=wf3');
     });
 
+    it('agrees with the page selector on which value of a duplicated workflow_id wins', () => {
+      // Both layers read the same location, so they must resolve a duplicated param identically:
+      // if bootstrap took the first value it would open the module for `wf1` while the page
+      // selected `wf3`, which is the lost-selection bug this whole path exists to prevent.
+      window.parent.location.hash = '#/workflows?workflow_id=wf1&workflow_id=wf3';
+      initializeModularConfigFromLocation(root);
+
+      const { result } = renderHook(() => useSelectedWorkflow());
+
+      expect(result.current[0]).toBe('wf3');
+      expect(window.parent.location.hash).toContain('workflow_id=wf3');
+    });
+
     it('falls back to the root file when no module defines the linked workflow', () => {
       window.parent.location.hash = '#/workflows?workflow_id=does-not-exist';
       initializeModularConfigFromLocation(root);

--- a/source/javascripts/hooks/useSelectedWorkflow.spec.tsx
+++ b/source/javascripts/hooks/useSelectedWorkflow.spec.tsx
@@ -3,9 +3,20 @@
  */
 import { renderHook } from '@testing-library/react';
 
-import { updateBitriseYmlDocumentByString } from '@/core/stores/BitriseYmlStore';
+import { TreeNode } from '@/core/models/Tree';
+import { initializeModularConfig, updateBitriseYmlDocumentByString } from '@/core/stores/BitriseYmlStore';
+import { deepLinkedEntity } from '@/routes';
 
 import useSelectedWorkflow from './useSelectedWorkflow';
+
+function moduleNode(nodeId: string, contents: string, includes: TreeNode[] = []): TreeNode {
+  return { nodeId, path: `${nodeId}.yml`, contents, source: null, commitSha: 'sha', editable: true, includes };
+}
+
+/** Bootstrap a modular config the way `main.tsx` does: the URL decides which module opens. */
+function initializeModularConfigFromLocation(root: TreeNode) {
+  initializeModularConfig({ root, deepLink: deepLinkedEntity(window.parent.location.hash) });
+}
 
 describe('useSelectedWorkflow', () => {
   beforeEach(() => {
@@ -54,5 +65,29 @@ describe('useSelectedWorkflow', () => {
     const { result } = renderHook(() => useSelectedWorkflow());
 
     expect(result.current[0]).toBe('wf2');
+  });
+
+  describe('in a modular config', () => {
+    const root = moduleNode('root', 'workflows:\n  wf1: {}\n', [moduleNode('module', 'workflows:\n  wf3: {}\n')]);
+
+    it('resolves a link to a workflow defined in an included module', () => {
+      window.parent.location.hash = '#/workflows?workflow_id=wf3';
+      initializeModularConfigFromLocation(root);
+
+      const { result } = renderHook(() => useSelectedWorkflow());
+
+      expect(result.current[0]).toBe('wf3');
+      expect(window.parent.location.hash).toContain('workflow_id=wf3');
+    });
+
+    it('falls back to the root file when no module defines the linked workflow', () => {
+      window.parent.location.hash = '#/workflows?workflow_id=does-not-exist';
+      initializeModularConfigFromLocation(root);
+
+      const { result } = renderHook(() => useSelectedWorkflow());
+
+      expect(result.current[0]).toBe('wf1');
+      expect(window.parent.location.hash).toContain('workflow_id=wf1');
+    });
   });
 });

--- a/source/javascripts/hooks/useSelectedWorkflow.ts
+++ b/source/javascripts/hooks/useSelectedWorkflow.ts
@@ -1,11 +1,10 @@
 import { omit } from 'es-toolkit';
 import { useCallback, useEffect, useMemo } from 'react';
 
+import { parallelWorkflowSourceId } from '@/core/utils/CommonUtils';
 import { useWorkflows } from '@/hooks/useWorkflows';
 
 import useSearchParams, { getSearchParamsFromLocationHash } from './useSearchParams';
-
-const GENERATED_WORKFLOW_ID_REGEX = /_[\d]+$/g;
 
 function selectValidWorkflowId(workflowIds: string[], requestedId?: string | null): string {
   if (requestedId) {
@@ -15,8 +14,8 @@ function selectValidWorkflowId(workflowIds: string[], requestedId?: string | nul
 
     // Check if the requested ID is a generated variant of an existing workflow ID (parallel workflow)
     // e.g., if the requested ID is "sharded-tests_13", check if "sharded-tests" exists
-    const originalId = requestedId.replace(GENERATED_WORKFLOW_ID_REGEX, '');
-    if (workflowIds.includes(originalId)) {
+    const originalId = parallelWorkflowSourceId(requestedId);
+    if (originalId && workflowIds.includes(originalId)) {
       return originalId;
     }
   }

--- a/source/javascripts/layouts/InitialDataLoader.spec.tsx
+++ b/source/javascripts/layouts/InitialDataLoader.spec.tsx
@@ -1,0 +1,198 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, render, screen } from '@testing-library/react';
+import { ComponentType, ReactNode } from 'react';
+
+import { GetConfigResponse, TreeNode } from '@/core/models/Tree';
+import { bitriseYmlStore } from '@/core/stores/BitriseYmlStore';
+import PageProps from '@/core/utils/PageProps';
+import RuntimeUtils from '@/core/utils/RuntimeUtils';
+import useSelectedWorkflow from '@/hooks/useSelectedWorkflow';
+import MainLayout from '@/layouts/MainLayout';
+
+import InitialDataLoader from './InitialDataLoader';
+
+/**
+ * Stands in for a routed page: it reads the selected workflow exactly the way the real pages do.
+ * It is deliberately NOT lazy, so it mounts in the same commit as the loader's bootstrap effect —
+ * the sequencing a branch reload (or any already-loaded route chunk) really produces, and the one
+ * in which passive effects run child-first.
+ */
+const probeRenders: Array<{ storeWasBootstrapped: boolean; selectedWorkflowId: string }> = [];
+function WorkflowsPageProbe() {
+  const [selectedWorkflowId] = useSelectedWorkflow();
+  probeRenders.push({
+    storeWasBootstrapped: Boolean(bitriseYmlStore.getState().tree),
+    selectedWorkflowId,
+  });
+  return <div data-testid="selected-workflow">{selectedWorkflowId}</div>;
+}
+
+// The real route table is lazy (and pulls the whole page graph); swap in the probe as the workflows
+// page. `deepLinkedEntity` stays real — it is part of what this test exercises.
+jest.mock('@/routes', () => ({
+  ...jest.requireActual('@/routes'),
+  preloadRoutes: jest.fn(),
+  routes: [{ path: '/workflows', component: WorkflowsPageProbe }],
+}));
+
+// `wouter` ships untransformed ESM, and its matching isn't what's under test — the router is reduced
+// to "render the route" so the real gate (MainLayout's `isConfigLoading` branch, fed by the loader's
+// context value) is the only thing deciding whether the page mounts.
+jest.mock('wouter', () => ({
+  __esModule: true,
+  Router: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  Switch: ({ children }: { children?: ReactNode }) => <>{children}</>,
+  Route: ({ component: Component }: { component: ComponentType }) => <Component />,
+  Redirect: () => null,
+}));
+
+// Chrome that isn't part of the gating decision.
+jest.mock('@/components/Header', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/components/Navigation', () => ({ __esModule: true, default: () => null }));
+jest.mock('@/pages/YmlPage/components/OpenFileTabs/OpenFileTabs', () => ({ __esModule: true, default: () => null }));
+jest.mock('@chakra-ui/react/box', () => ({ Box: ({ children }: { children?: ReactNode }) => <div>{children}</div> }));
+
+// Only the primitives the loader and LoadingState render; keeps the bitkit barrel (and its markdown
+// dependency tree) out of the test.
+jest.mock('@bitrise/bitkit', () => ({
+  Box: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
+  Button: ({ children }: { children?: ReactNode }) => <button type="button">{children}</button>,
+  Image: () => <img alt="" />,
+  Link: ({ children }: { children?: ReactNode }) => <a href="/">{children}</a>,
+  ProgressBitbot: () => <div data-testid="loading-state" />,
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+  useToast: () => jest.fn(),
+}));
+
+jest.mock('@datadog/browser-rum', () => ({ datadogRum: { addError: jest.fn() } }));
+jest.mock('@/core/analytics/ConfigManagementAnalytics', () => ({ trackConfigBranchLoaded: jest.fn() }));
+jest.mock('@/hooks/useYmlLanguageServices', () => ({ __esModule: true, default: jest.fn() }));
+jest.mock('@/hooks/useCloseAIDrawer', () => ({ __esModule: true, default: jest.fn() }));
+
+let treeQuery: { data?: GetConfigResponse; error: null; refetch: jest.Mock } = {
+  data: undefined,
+  error: null,
+  refetch: jest.fn(),
+};
+jest.mock('@/hooks/useCiConfigTree', () => ({ useGetCiConfigTree: () => treeQuery }));
+jest.mock('@/hooks/useCiConfig', () => ({
+  useGetCiConfig: () => ({ data: undefined, error: null, isLoading: false, refetch: jest.fn() }),
+}));
+
+let ymlSettingsQuery: { data?: { usesRepositoryYml: boolean }; isPending: boolean } = {
+  data: { usesRepositoryYml: true },
+  isPending: false,
+};
+jest.mock('@/hooks/useCiConfigSettings', () => ({ useCiConfigSettings: () => ymlSettingsQuery }));
+jest.mock('@/hooks/useFeatureFlag', () => ({ __esModule: true, default: () => true }));
+
+function node(nodeId: string, contents: string, includes: TreeNode[] = []): TreeNode {
+  return { nodeId, path: `${nodeId}.yml`, contents, source: null, commitSha: 'sha', editable: true, includes };
+}
+
+/** A modular tree whose `module-only` workflow exists ONLY in an included file, never in the root. */
+function modularConfig(branch: string): GetConfigResponse {
+  return {
+    root: node('root', 'workflows:\n  root-wf: {}\n', [node('module', 'workflows:\n  module-only: {}\n')]),
+    branch,
+  };
+}
+
+function renderApp() {
+  return render(
+    <InitialDataLoader>
+      <MainLayout />
+    </InitialDataLoader>,
+  );
+}
+
+/** Announce a hash change the way the browser does, so the search-param readers pick it up. */
+function navigateTo(hash: string) {
+  act(() => {
+    window.parent.location.hash = hash;
+    window.parent.dispatchEvent(new Event('hashchange'));
+  });
+}
+
+describe('InitialDataLoader', () => {
+  beforeEach(() => {
+    probeRenders.length = 0;
+    treeQuery = { data: undefined, error: null, refetch: jest.fn() };
+    ymlSettingsQuery = { data: { usesRepositoryYml: true }, isPending: false };
+    jest.spyOn(PageProps, 'appSlug').mockReturnValue('app-1');
+    jest.spyOn(RuntimeUtils, 'isProduction').mockReturnValue(false);
+    jest.spyOn(RuntimeUtils, 'isWebsiteMode').mockReturnValue(false);
+    bitriseYmlStore.setState({ tree: undefined, files: {}, selectedNodeId: undefined, openTabs: [] });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('keeps routes unmounted while the config is still loading', () => {
+    window.parent.location.hash = '#/workflows?workflow_id=module-only';
+
+    renderApp();
+
+    expect(screen.queryByTestId('selected-workflow')).toBeNull();
+    expect(probeRenders).toHaveLength(0);
+    // Nothing has touched the URL, so the id is still there for the bootstrap to resolve.
+    expect(window.parent.location.hash).toContain('workflow_id=module-only');
+  });
+
+  it('never lets a route render against an un-bootstrapped store, so a module-only id survives', () => {
+    window.parent.location.hash = '#/workflows?workflow_id=module-only';
+    const { rerender } = renderApp();
+
+    // The query resolves. Routes mount in the same commit the bootstrap effect runs in — passive
+    // effects run child-first, so an ungated page would validate `module-only` against an empty
+    // store, find nothing, and strip it from the URL before the bootstrap ever read it.
+    treeQuery = { data: modularConfig('main'), error: null, refetch: jest.fn() };
+    rerender(
+      <InitialDataLoader>
+        <MainLayout />
+      </InitialDataLoader>,
+    );
+
+    expect(probeRenders.length).toBeGreaterThan(0);
+    expect(probeRenders.every((r) => r.storeWasBootstrapped)).toBe(true);
+    expect(probeRenders[0].selectedWorkflowId).toBe('module-only');
+    expect(screen.getByTestId('selected-workflow').textContent).toBe('module-only');
+    expect(window.parent.location.hash).toContain('workflow_id=module-only');
+    // Bootstrap resolved the link to the module that actually defines the workflow.
+    expect(bitriseYmlStore.getState().selectedNodeId).toBe('module');
+  });
+
+  it('re-gates routes on a branch switch until the new branch is bootstrapped', () => {
+    jest.spyOn(RuntimeUtils, 'isWebsiteMode').mockReturnValue(true);
+    window.parent.location.hash = '#/workflows?branch=main&workflow_id=module-only';
+    treeQuery = { data: modularConfig('main'), error: null, refetch: jest.fn() };
+
+    const { rerender } = renderApp();
+    expect(screen.getByTestId('selected-workflow').textContent).toBe('module-only');
+
+    // Switching branch invalidates the bootstrapped config a render before the new one arrives. The
+    // gate is derived, so it closes in that very render and the page unmounts, instead of validating
+    // the requested id against the previous branch's config.
+    treeQuery = { data: undefined, error: null, refetch: jest.fn() };
+    navigateTo('#/workflows?branch=feature&workflow_id=module-only');
+    expect(screen.queryByTestId('selected-workflow')).toBeNull();
+
+    // The feature branch defines the workflow in a module too; the link must survive the reload.
+    probeRenders.length = 0;
+    treeQuery = { data: modularConfig('feature'), error: null, refetch: jest.fn() };
+    rerender(
+      <InitialDataLoader>
+        <MainLayout />
+      </InitialDataLoader>,
+    );
+
+    expect(probeRenders.length).toBeGreaterThan(0);
+    expect(probeRenders.every((r) => r.storeWasBootstrapped)).toBe(true);
+    expect(screen.getByTestId('selected-workflow').textContent).toBe('module-only');
+    expect(window.parent.location.hash).toContain('workflow_id=module-only');
+    expect(bitriseYmlStore.getState().selectedNodeId).toBe('module');
+  });
+});

--- a/source/javascripts/layouts/InitialDataLoader.spec.tsx
+++ b/source/javascripts/layouts/InitialDataLoader.spec.tsx
@@ -1,7 +1,7 @@
 /**
  * @jest-environment jsdom
  */
-import { act, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { ComponentType, ReactNode } from 'react';
 
 import { GetConfigResponse, TreeNode } from '@/core/models/Tree';
@@ -53,17 +53,30 @@ jest.mock('@/components/Header', () => ({ __esModule: true, default: () => null 
 jest.mock('@/components/Navigation', () => ({ __esModule: true, default: () => null }));
 jest.mock('@/pages/YmlPage/components/OpenFileTabs/OpenFileTabs', () => ({ __esModule: true, default: () => null }));
 jest.mock('@chakra-ui/react/box', () => ({ Box: ({ children }: { children?: ReactNode }) => <div>{children}</div> }));
+jest.mock('@chakra-ui/react/text', () => ({
+  Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
+}));
+jest.mock('@chakra-ui/react/image', () => ({ Image: () => <img alt="" /> }));
 
-// Only the primitives the loader and LoadingState render; keeps the bitkit barrel (and its markdown
-// dependency tree) out of the test.
+// The v2 barrel re-exports a markdown component whose ESM dependency tree doesn't belong in this
+// test, so the two components the error branch renders are stubbed. Toasts are captured so the
+// branch-load notifications stay assertable.
+const createBitkitToastMock = jest.fn();
+jest.mock('@bitrise/bitkit-v2', () => ({
+  BitkitButton: ({ children, onClick }: { children?: ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  BitkitLink: ({ children, href }: { children?: ReactNode; href?: string }) => <a href={href}>{children}</a>,
+  createBitkitToast: (...args: unknown[]) => createBitkitToastMock(...args),
+}));
+
+// `LoadingState` is still a v1 component; only the spinner it renders is needed here.
 jest.mock('@bitrise/bitkit', () => ({
   Box: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
-  Button: ({ children }: { children?: ReactNode }) => <button type="button">{children}</button>,
-  Image: () => <img alt="" />,
-  Link: ({ children }: { children?: ReactNode }) => <a href="/">{children}</a>,
   ProgressBitbot: () => <div data-testid="loading-state" />,
   Text: ({ children }: { children?: ReactNode }) => <span>{children}</span>,
-  useToast: () => jest.fn(),
 }));
 
 jest.mock('@datadog/browser-rum', () => ({ datadogRum: { addError: jest.fn() } }));
@@ -71,11 +84,12 @@ jest.mock('@/core/analytics/ConfigManagementAnalytics', () => ({ trackConfigBran
 jest.mock('@/hooks/useYmlLanguageServices', () => ({ __esModule: true, default: jest.fn() }));
 jest.mock('@/hooks/useCloseAIDrawer', () => ({ __esModule: true, default: jest.fn() }));
 
-let treeQuery: { data?: GetConfigResponse; error: null; refetch: jest.Mock } = {
-  data: undefined,
-  error: null,
-  refetch: jest.fn(),
+type TreeQuery = {
+  data?: GetConfigResponse;
+  error: { status?: number; statusText?: string; message?: string } | null;
+  refetch: jest.Mock;
 };
+let treeQuery: TreeQuery = { data: undefined, error: null, refetch: jest.fn() };
 jest.mock('@/hooks/useCiConfigTree', () => ({ useGetCiConfigTree: () => treeQuery }));
 jest.mock('@/hooks/useCiConfig', () => ({
   useGetCiConfig: () => ({ data: undefined, error: null, isLoading: false, refetch: jest.fn() }),
@@ -119,6 +133,7 @@ function navigateTo(hash: string) {
 describe('InitialDataLoader', () => {
   beforeEach(() => {
     probeRenders.length = 0;
+    createBitkitToastMock.mockClear();
     treeQuery = { data: undefined, error: null, refetch: jest.fn() };
     ymlSettingsQuery = { data: { usesRepositoryYml: true }, isPending: false };
     jest.spyOn(PageProps, 'appSlug').mockReturnValue('app-1');
@@ -163,6 +178,32 @@ describe('InitialDataLoader', () => {
     expect(window.parent.location.hash).toContain('workflow_id=module-only');
     // Bootstrap resolved the link to the module that actually defines the workflow.
     expect(bitriseYmlStore.getState().selectedNodeId).toBe('module');
+  });
+
+  it('reports a branch fallback through a v2 toast', () => {
+    jest.spyOn(RuntimeUtils, 'isWebsiteMode').mockReturnValue(true);
+    window.parent.location.hash = '#/workflows?branch=feature&workflow_id=module-only';
+    // The requested branch has no config, so the default branch is loaded instead.
+    treeQuery = { data: modularConfig('main'), error: null, refetch: jest.fn() };
+
+    renderApp();
+
+    expect(createBitkitToastMock).toHaveBeenCalledWith({
+      variant: 'warning',
+      messageText: 'Config unavailable on feature. Using main (default branch).',
+    });
+  });
+
+  it('renders the error screen and retries from it', () => {
+    const refetch = jest.fn();
+    treeQuery = { data: undefined, error: { status: 500, statusText: 'Server Error', message: 'Boom' }, refetch };
+
+    renderApp();
+
+    expect(screen.getByText('500 - Server Error')).toBeDefined();
+    expect(screen.getByText('Boom')).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+    expect(refetch).toHaveBeenCalled();
   });
 
   it('re-gates routes on a branch switch until the new branch is bootstrapped', () => {

--- a/source/javascripts/layouts/InitialDataLoader.tsx
+++ b/source/javascripts/layouts/InitialDataLoader.tsx
@@ -1,4 +1,7 @@
-import { Box, Button, Image, Link, Text, useToast } from '@bitrise/bitkit';
+import { BitkitButton, BitkitLink, createBitkitToast } from '@bitrise/bitkit-v2';
+import { Box } from '@chakra-ui/react/box';
+import { Image } from '@chakra-ui/react/image';
+import { Text } from '@chakra-ui/react/text';
 import { datadogRum } from '@datadog/browser-rum';
 import { PropsWithChildren, useEffect, useRef, useState } from 'react';
 import { useEventListener } from 'usehooks-ts';
@@ -27,7 +30,6 @@ import errorImg from '../../images/error-hairball.svg';
  * guarantees (children never render against an un-bootstrapped store) is testable.
  */
 const InitialDataLoader = ({ children }: PropsWithChildren) => {
-  const toast = useToast();
   const isLoaded = useRef(false);
   const isTracked = useRef(false);
   // Two trackers for the same milestone, with different jobs. The ref is the re-entry guard: it's
@@ -84,7 +86,8 @@ const InitialDataLoader = ({ children }: PropsWithChildren) => {
 
   useEventListener('error', (e) => {
     datadogRum.addError(e);
-    toast({ duration: null, status: 'error', isClosable: true, description: e.message || 'Unknown error' });
+    // `critical` already persists until dismissed, which is what the old `duration: null` asked for.
+    createBitkitToast({ variant: 'critical', messageText: e.message || 'Unknown error' });
   });
 
   useEventListener('unhandledrejection', (e) => {
@@ -94,7 +97,7 @@ const InitialDataLoader = ({ children }: PropsWithChildren) => {
       return;
     }
     datadogRum.addError(e.reason);
-    toast({ duration: null, status: 'error', isClosable: true, description: e.reason?.message || 'Unknown error' });
+    createBitkitToast({ variant: 'critical', messageText: e.reason?.message || 'Unknown error' });
   });
 
   useEffect(() => {
@@ -132,16 +135,14 @@ const InitialDataLoader = ({ children }: PropsWithChildren) => {
 
       if (requestedBranch) {
         if (configBranch && configBranch === requestedBranch) {
-          toast({
-            status: 'success',
-            isClosable: true,
-            description: `Configuration is loaded from ${requestedBranch} branch.`,
+          createBitkitToast({
+            variant: 'success',
+            messageText: `Configuration is loaded from ${requestedBranch} branch.`,
           });
         } else if (configBranch && configBranch !== requestedBranch) {
-          toast({
-            status: 'warning',
-            isClosable: true,
-            description: `Config unavailable on ${requestedBranch}. Using ${configBranch} (default branch).`,
+          createBitkitToast({
+            variant: 'warning',
+            messageText: `Config unavailable on ${requestedBranch}. Using ${configBranch} (default branch).`,
           });
         }
       }
@@ -156,7 +157,7 @@ const InitialDataLoader = ({ children }: PropsWithChildren) => {
       // eslint-disable-next-line react-hooks/set-state-in-effect
       setBootstrappedBranch(requestedBranch);
     }
-  }, [data, requestedBranch, toast, isModularEnabled, legacyConfig.data, treeConfig.data, configBranch]);
+  }, [data, requestedBranch, isModularEnabled, legacyConfig.data, treeConfig.data, configBranch]);
 
   useEffect(() => {
     if (data && ymlSettings?.usesRepositoryYml && !isTracked.current) {
@@ -177,30 +178,31 @@ const InitialDataLoader = ({ children }: PropsWithChildren) => {
 
     return (
       <Box
-        px="5%"
-        gap="3rem"
+        gap="48"
         width="100vw"
         height="100vh"
         display="flex"
-        marginX="auto"
         alignItems="center"
+        marginInline="auto"
+        paddingInline="5%"
         backgroundImage="linear-gradient(315deg, var(--colors-purple-30), var(--colors-purple-10))"
       >
-        <Box display="flex" flexDir="column" gap="32" textColor="text/on-color" maxWidth="50%">
-          <Link href="/" title="Go to Dashboard">
+        <Box display="flex" flexDirection="column" gap="32" color="text/on-color" maxWidth="50%">
+          <BitkitLink href="/" title="Go to Dashboard">
             <Image src={bitriseLogo} />
-          </Link>
+          </BitkitLink>
           <Box>
-            <Text size="3" fontFamily="Source Code Pro, monospace" textTransform="uppercase" mb="16">
+            <Text textStyle="code/lg" textTransform="uppercase" marginBlockEnd="16">
               {detailedErrorMessage}
             </Text>
-            <Text textStyle="heading/h2" fontWeight="bold" fontSize="48" lineHeight="1.2">
-              {error?.message}
-            </Text>
+            {/* `display/lg` is the 48px bold token this headline already used. BitkitHeading can't
+                express it — it takes the size from its level, topping out at 30px — so keeping the
+                hero at its current size means the display token rather than that component. */}
+            <Text textStyle="display/lg">{error?.message}</Text>
           </Box>
-          <Button alignSelf="start" variant="primary" size="lg" onClick={() => refetch()}>
+          <BitkitButton alignSelf="start" variant="primary" size="lg" onClick={() => refetch()}>
             Try again
-          </Button>
+          </BitkitButton>
         </Box>
         <Box>
           <Image src={errorImg} />

--- a/source/javascripts/layouts/InitialDataLoader.tsx
+++ b/source/javascripts/layouts/InitialDataLoader.tsx
@@ -1,0 +1,224 @@
+import { Box, Button, Image, Link, Text, useToast } from '@bitrise/bitkit';
+import { datadogRum } from '@datadog/browser-rum';
+import { PropsWithChildren, useEffect, useRef, useState } from 'react';
+import { useEventListener } from 'usehooks-ts';
+
+import { trackConfigBranchLoaded } from '@/core/analytics/ConfigManagementAnalytics';
+import { initializeBitriseYmlDocument, initializeModularConfig } from '@/core/stores/BitriseYmlStore';
+import PageProps from '@/core/utils/PageProps';
+import RuntimeUtils from '@/core/utils/RuntimeUtils';
+import { useGetCiConfig } from '@/hooks/useCiConfig';
+import { useCiConfigSettings } from '@/hooks/useCiConfigSettings';
+import { useGetCiConfigTree } from '@/hooks/useCiConfigTree';
+import useCloseAIDrawer from '@/hooks/useCloseAIDrawer';
+import useFeatureFlag from '@/hooks/useFeatureFlag';
+import useSearchParams from '@/hooks/useSearchParams';
+import useYmlHasChanges from '@/hooks/useYmlHasChanges';
+import useYmlLanguageServices from '@/hooks/useYmlLanguageServices';
+import { ConfigLoadingProvider } from '@/layouts/ConfigLoading.context';
+import { deepLinkedEntity, preloadRoutes } from '@/routes';
+
+import bitriseLogo from '../../images/bitrise-logo.svg';
+import errorImg from '../../images/error-hairball.svg';
+
+/**
+ * Owns the bootstrap: resolves which config endpoint to hit, loads it into `BitriseYmlStore`, and
+ * only then lets its children render. Extracted from the app entry point so the mount sequencing it
+ * guarantees (children never render against an un-bootstrapped store) is testable.
+ */
+const InitialDataLoader = ({ children }: PropsWithChildren) => {
+  const toast = useToast();
+  const isLoaded = useRef(false);
+  const isTracked = useRef(false);
+  // Two trackers for the same milestone, with different jobs. The ref is the re-entry guard: it's
+  // written synchronously, so a StrictMode double-invoke (or any effect re-run) can't bootstrap
+  // twice. The state is what CHILDREN observe — only a re-render can reopen the gate below, which a
+  // ref alone would never trigger. `null` = nothing bootstrapped yet, distinct from the `undefined`
+  // of "no branch requested".
+  const loadedBranch = useRef<string | undefined | null>(null);
+  const [bootstrappedBranch, setBootstrappedBranch] = useState<string | undefined | null>(null);
+  const hasChanges = useYmlHasChanges();
+  const [searchParams] = useSearchParams();
+  const isWebsiteMode = RuntimeUtils.isWebsiteMode();
+  const requestedBranch = isWebsiteMode ? searchParams.branch : undefined;
+
+  const { data: ymlSettings, isPending: isYmlSettingsPending } = useCiConfigSettings();
+  useYmlLanguageServices();
+  useCloseAIDrawer();
+
+  // Modular editing only makes sense for repo-stored configs (where includes/modules can exist);
+  // a Bitrise-stored config can't have modules, so it stays on the legacy single-file flow even
+  // with the flag on. In website mode it's ramped behind the LD flag. CLI mode has no LaunchDarkly
+  // (and no Bitrise storage), so it's simply on — a non-modular config resolves to a single-node
+  // tree, which the editor drives exactly like the single-file flow.
+  const isModularFlagEnabled = useFeatureFlag('enable-wfe-modular-yaml-editing');
+  const canBeModular = !isWebsiteMode || ymlSettings?.usesRepositoryYml === true;
+  const isModularEnabled = canBeModular && (isWebsiteMode ? isModularFlagEnabled : true);
+
+  // In website mode with the flag on, the storage type decides which endpoint to hit, so
+  // wait for the settings to resolve before fetching (don't fire the tree query then switch
+  // to legacy once it turns out to be Bitrise-stored). Flag off or CLI → decide immediately.
+  const isStorageKnown = !(isModularFlagEnabled && isWebsiteMode) || !isYmlSettingsPending;
+
+  const legacyConfig = useGetCiConfig(
+    { projectSlug: PageProps.appSlug(), skipValidation: true, branch: requestedBranch },
+    { enabled: isStorageKnown && !isModularEnabled },
+  );
+  const treeConfig = useGetCiConfigTree(
+    { projectSlug: PageProps.appSlug(), branch: requestedBranch },
+    { enabled: isStorageKnown && isModularEnabled },
+  );
+
+  const { data, error, refetch } = isModularEnabled ? treeConfig : legacyConfig;
+  const configBranch = isModularEnabled ? treeConfig.data?.branch : legacyConfig.data?.branch;
+
+  // The config is in the store AND it's the one the URL asks for. Both halves matter: `data`
+  // arrives a commit before the bootstrap effect runs, and a branch switch invalidates a config
+  // that was legitimately bootstrapped for the previous branch.
+  const isBootstrapped = Boolean(data) && bootstrappedBranch === requestedBranch;
+
+  useEventListener('beforeunload', (e) => {
+    // NOTE: The return is important for the browser to show the dialog
+    return RuntimeUtils.isProduction() && hasChanges && e.preventDefault();
+  });
+
+  useEventListener('error', (e) => {
+    datadogRum.addError(e);
+    toast({ duration: null, status: 'error', isClosable: true, description: e.message || 'Unknown error' });
+  });
+
+  useEventListener('unhandledrejection', (e) => {
+    // Monaco rejects with a benign "Canceled" sentinel when a model is disposed (e.g. tab switch); not a real error.
+    const reason = e.reason as { name?: string; message?: string } | undefined;
+    if (reason?.name === 'Canceled' || reason?.message === 'Canceled') {
+      return;
+    }
+    datadogRum.addError(e.reason);
+    toast({ duration: null, status: 'error', isClosable: true, description: e.reason?.message || 'Unknown error' });
+  });
+
+  useEffect(() => {
+    if (data && loadedBranch.current !== requestedBranch) {
+      if (isModularEnabled) {
+        const config = treeConfig.data;
+        if (config) {
+          if (config.root.includes.length === 0) {
+            // No includes → no modules: even with modular enabled, present it as a plain single-file
+            // config (no tree/tabs/merged view). Saving still works — it's repo-stored, so the push
+            // flow handles the single-file case (`bitriseYml`), and the mode is re-decided per branch.
+            initializeBitriseYmlDocument({
+              ymlString: config.root.contents,
+              version: '',
+              branch: config.branch,
+              commitSha: config.root.commitSha,
+            });
+          } else {
+            initializeModularConfig({
+              root: config.root,
+              mergedYml: config.mergedYml,
+              branch: config.branch,
+              commitSha: config.root.commitSha,
+              // Resolved against the whole tree here, before any page reads the config: an entity
+              // addressed by the URL may live in an included module, not in the root file. This
+              // effect also runs on a branch switch, which re-resolves the link against the newly
+              // loaded tree — keeping the user on the module defining the entity they're viewing.
+              deepLink: deepLinkedEntity(window.parent.location.hash),
+            });
+          }
+        }
+      } else if (legacyConfig.data) {
+        initializeBitriseYmlDocument(legacyConfig.data);
+      }
+
+      if (requestedBranch) {
+        if (configBranch && configBranch === requestedBranch) {
+          toast({
+            status: 'success',
+            isClosable: true,
+            description: `Configuration is loaded from ${requestedBranch} branch.`,
+          });
+        } else if (configBranch && configBranch !== requestedBranch) {
+          toast({
+            status: 'warning',
+            isClosable: true,
+            description: `Config unavailable on ${requestedBranch}. Using ${configBranch} (default branch).`,
+          });
+        }
+      }
+      loadedBranch.current = requestedBranch;
+      if (!isLoaded.current) {
+        setTimeout(preloadRoutes, 1000);
+        isLoaded.current = true;
+      }
+      // Last: opens the gate below, so children first render against an initialized store. The
+      // extra render this costs IS the fix — tracking this in the ref alone would leave children
+      // rendering a commit early, which is the race this replaces. Keep the setState.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setBootstrappedBranch(requestedBranch);
+    }
+  }, [data, requestedBranch, toast, isModularEnabled, legacyConfig.data, treeConfig.data, configBranch]);
+
+  useEffect(() => {
+    if (data && ymlSettings?.usesRepositoryYml && !isTracked.current) {
+      isTracked.current = true;
+      trackConfigBranchLoaded(configBranch);
+    }
+  }, [data, ymlSettings?.usesRepositoryYml, configBranch]);
+
+  if (error) {
+    let detailedErrorMessage = 'Error - Failed to load the bitrise.yml';
+    if (error.status) {
+      if (error.data?.error_msg) {
+        detailedErrorMessage = `${error.status} - ${error.data.error_msg}`;
+      } else if (error.statusText) {
+        detailedErrorMessage = `${error.status} - ${error.statusText}`;
+      }
+    }
+
+    return (
+      <Box
+        px="5%"
+        gap="3rem"
+        width="100vw"
+        height="100vh"
+        display="flex"
+        marginX="auto"
+        alignItems="center"
+        backgroundImage="linear-gradient(315deg, var(--colors-purple-30), var(--colors-purple-10))"
+      >
+        <Box display="flex" flexDir="column" gap="32" textColor="text/on-color" maxWidth="50%">
+          <Link href="/" title="Go to Dashboard">
+            <Image src={bitriseLogo} />
+          </Link>
+          <Box>
+            <Text size="3" fontFamily="Source Code Pro, monospace" textTransform="uppercase" mb="16">
+              {detailedErrorMessage}
+            </Text>
+            <Text textStyle="heading/h2" fontWeight="bold" fontSize="48" lineHeight="1.2">
+              {error?.message}
+            </Text>
+          </Box>
+          <Button alignSelf="start" variant="primary" size="lg" onClick={() => refetch()}>
+            Try again
+          </Button>
+        </Box>
+        <Box>
+          <Image src={errorImg} />
+        </Box>
+      </Box>
+    );
+  }
+
+  // Expose whether the config is still loading (settings check + tree/legacy fetch) so the layout
+  // can show the loading state in the content area while keeping the header + navigation visible.
+  //
+  // Gated on the bootstrap having run, not merely on `data` having arrived. Passive effects run
+  // child-first, so routes mounted in the same commit as the effect above would run their own
+  // selection effects first — against an empty (or previous branch's) store — and "correct" the
+  // URL, stripping an id that only resolves once the config is in the store. Deriving the gate
+  // (rather than flipping it from an effect) also closes it in the very render where the requested
+  // branch changes, so a branch switch unmounts the routes before they can see the stale config.
+  return <ConfigLoadingProvider value={!isBootstrapped}>{children}</ConfigLoadingProvider>;
+};
+
+export default InitialDataLoader;

--- a/source/javascripts/main.tsx
+++ b/source/javascripts/main.tsx
@@ -29,7 +29,7 @@ import bitriseLogo from '../images/bitrise-logo.svg';
 import errorImg from '../images/error-hairball.svg';
 import { trackConfigBranchLoaded } from './core/analytics/ConfigManagementAnalytics';
 import useYmlHasChanges from './hooks/useYmlHasChanges';
-import { preloadRoutes } from './routes';
+import { deepLinkedEntity, preloadRoutes } from './routes';
 
 const loaders = [];
 if (import.meta.env.CLARITY === 'true') {
@@ -171,6 +171,9 @@ const InitialDataLoader = ({ children }: PropsWithChildren) => {
               mergedYml: config.mergedYml,
               branch: config.branch,
               commitSha: config.root.commitSha,
+              // Resolved against the whole tree here, before any page reads the config: an entity
+              // addressed by the URL may live in an included module, not in the root file.
+              deepLink: deepLinkedEntity(window.parent.location.hash),
             });
           }
         }

--- a/source/javascripts/main.tsx
+++ b/source/javascripts/main.tsx
@@ -172,7 +172,9 @@ const InitialDataLoader = ({ children }: PropsWithChildren) => {
               branch: config.branch,
               commitSha: config.root.commitSha,
               // Resolved against the whole tree here, before any page reads the config: an entity
-              // addressed by the URL may live in an included module, not in the root file.
+              // addressed by the URL may live in an included module, not in the root file. This
+              // effect also runs on a branch switch, which re-resolves the link against the newly
+              // loaded tree — keeping the user on the module defining the entity they're viewing.
               deepLink: deepLinkedEntity(window.parent.location.hash),
             });
           }

--- a/source/javascripts/main.tsx
+++ b/source/javascripts/main.tsx
@@ -1,35 +1,18 @@
 /* _eslint-disable import/no-import-module-exports */
 import '@/monaco-workers';
 
-import { Box, Button, Image, Link, Provider, Text, useToast } from '@bitrise/bitkit';
+import { Provider } from '@bitrise/bitkit';
 import { BitkitProvider } from '@bitrise/bitkit-v2';
-import { datadogRum } from '@datadog/browser-rum';
 import { ErrorBoundary } from '@datadog/browser-rum-react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactFlowProvider } from '@xyflow/react';
-import { ComponentProps, PropsWithChildren, StrictMode, useEffect, useRef } from 'react';
+import { ComponentProps, StrictMode, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
-import { useEventListener } from 'usehooks-ts';
 
 import Client from '@/core/api/client';
-import { initializeBitriseYmlDocument, initializeModularConfig } from '@/core/stores/BitriseYmlStore';
-import PageProps from '@/core/utils/PageProps';
 import RuntimeUtils from '@/core/utils/RuntimeUtils';
-import { useGetCiConfig } from '@/hooks/useCiConfig';
-import { useCiConfigSettings } from '@/hooks/useCiConfigSettings';
-import { useGetCiConfigTree } from '@/hooks/useCiConfigTree';
-import useCloseAIDrawer from '@/hooks/useCloseAIDrawer';
-import useFeatureFlag from '@/hooks/useFeatureFlag';
-import useSearchParams from '@/hooks/useSearchParams';
-import useYmlLanguageServices from '@/hooks/useYmlLanguageServices';
-import { ConfigLoadingProvider } from '@/layouts/ConfigLoading.context';
+import InitialDataLoader from '@/layouts/InitialDataLoader';
 import MainLayout from '@/layouts/MainLayout';
-
-import bitriseLogo from '../images/bitrise-logo.svg';
-import errorImg from '../images/error-hairball.svg';
-import { trackConfigBranchLoaded } from './core/analytics/ConfigManagementAnalytics';
-import useYmlHasChanges from './hooks/useYmlHasChanges';
-import { deepLinkedEntity, preloadRoutes } from './routes';
 
 const loaders = [];
 if (import.meta.env.CLARITY === 'true') {
@@ -88,178 +71,6 @@ const PassThroughFallback: ComponentProps<typeof ErrorBoundary>['fallback'] = ({
   }, [resetError]);
 
   return null;
-};
-
-const InitialDataLoader = ({ children }: PropsWithChildren) => {
-  const toast = useToast();
-  const isLoaded = useRef(false);
-  const isTracked = useRef(false);
-  const loadedBranch = useRef<string | undefined | null>(null);
-  const hasChanges = useYmlHasChanges();
-  const [searchParams] = useSearchParams();
-  const isWebsiteMode = RuntimeUtils.isWebsiteMode();
-  const requestedBranch = isWebsiteMode ? searchParams.branch : undefined;
-
-  const { data: ymlSettings, isPending: isYmlSettingsPending } = useCiConfigSettings();
-  useYmlLanguageServices();
-  useCloseAIDrawer();
-
-  // Modular editing only makes sense for repo-stored configs (where includes/modules can exist);
-  // a Bitrise-stored config can't have modules, so it stays on the legacy single-file flow even
-  // with the flag on. In website mode it's ramped behind the LD flag. CLI mode has no LaunchDarkly
-  // (and no Bitrise storage), so it's simply on — a non-modular config resolves to a single-node
-  // tree, which the editor drives exactly like the single-file flow.
-  const isModularFlagEnabled = useFeatureFlag('enable-wfe-modular-yaml-editing');
-  const canBeModular = !isWebsiteMode || ymlSettings?.usesRepositoryYml === true;
-  const isModularEnabled = canBeModular && (isWebsiteMode ? isModularFlagEnabled : true);
-
-  // In website mode with the flag on, the storage type decides which endpoint to hit, so
-  // wait for the settings to resolve before fetching (don't fire the tree query then switch
-  // to legacy once it turns out to be Bitrise-stored). Flag off or CLI → decide immediately.
-  const isStorageKnown = !(isModularFlagEnabled && isWebsiteMode) || !isYmlSettingsPending;
-
-  const legacyConfig = useGetCiConfig(
-    { projectSlug: PageProps.appSlug(), skipValidation: true, branch: requestedBranch },
-    { enabled: isStorageKnown && !isModularEnabled },
-  );
-  const treeConfig = useGetCiConfigTree(
-    { projectSlug: PageProps.appSlug(), branch: requestedBranch },
-    { enabled: isStorageKnown && isModularEnabled },
-  );
-
-  const { data, error, refetch } = isModularEnabled ? treeConfig : legacyConfig;
-  const configBranch = isModularEnabled ? treeConfig.data?.branch : legacyConfig.data?.branch;
-
-  useEventListener('beforeunload', (e) => {
-    // NOTE: The return is important for the browser to show the dialog
-    return RuntimeUtils.isProduction() && hasChanges && e.preventDefault();
-  });
-
-  useEventListener('error', (e) => {
-    datadogRum.addError(e);
-    toast({ duration: null, status: 'error', isClosable: true, description: e.message || 'Unknown error' });
-  });
-
-  useEventListener('unhandledrejection', (e) => {
-    // Monaco rejects with a benign "Canceled" sentinel when a model is disposed (e.g. tab switch); not a real error.
-    const reason = e.reason as { name?: string; message?: string } | undefined;
-    if (reason?.name === 'Canceled' || reason?.message === 'Canceled') {
-      return;
-    }
-    datadogRum.addError(e.reason);
-    toast({ duration: null, status: 'error', isClosable: true, description: e.reason?.message || 'Unknown error' });
-  });
-
-  useEffect(() => {
-    if (data && loadedBranch.current !== requestedBranch) {
-      if (isModularEnabled) {
-        const config = treeConfig.data;
-        if (config) {
-          if (config.root.includes.length === 0) {
-            // No includes → no modules: even with modular enabled, present it as a plain single-file
-            // config (no tree/tabs/merged view). Saving still works — it's repo-stored, so the push
-            // flow handles the single-file case (`bitriseYml`), and the mode is re-decided per branch.
-            initializeBitriseYmlDocument({
-              ymlString: config.root.contents,
-              version: '',
-              branch: config.branch,
-              commitSha: config.root.commitSha,
-            });
-          } else {
-            initializeModularConfig({
-              root: config.root,
-              mergedYml: config.mergedYml,
-              branch: config.branch,
-              commitSha: config.root.commitSha,
-              // Resolved against the whole tree here, before any page reads the config: an entity
-              // addressed by the URL may live in an included module, not in the root file. This
-              // effect also runs on a branch switch, which re-resolves the link against the newly
-              // loaded tree — keeping the user on the module defining the entity they're viewing.
-              deepLink: deepLinkedEntity(window.parent.location.hash),
-            });
-          }
-        }
-      } else if (legacyConfig.data) {
-        initializeBitriseYmlDocument(legacyConfig.data);
-      }
-
-      if (requestedBranch) {
-        if (configBranch && configBranch === requestedBranch) {
-          toast({
-            status: 'success',
-            isClosable: true,
-            description: `Configuration is loaded from ${requestedBranch} branch.`,
-          });
-        } else if (configBranch && configBranch !== requestedBranch) {
-          toast({
-            status: 'warning',
-            isClosable: true,
-            description: `Config unavailable on ${requestedBranch}. Using ${configBranch} (default branch).`,
-          });
-        }
-      }
-      loadedBranch.current = requestedBranch;
-      if (!isLoaded.current) {
-        setTimeout(preloadRoutes, 1000);
-        isLoaded.current = true;
-      }
-    }
-  }, [data, requestedBranch, toast, isModularEnabled, legacyConfig.data, treeConfig.data, configBranch]);
-
-  useEffect(() => {
-    if (data && ymlSettings?.usesRepositoryYml && !isTracked.current) {
-      isTracked.current = true;
-      trackConfigBranchLoaded(configBranch);
-    }
-  }, [data, ymlSettings?.usesRepositoryYml, configBranch]);
-
-  if (error) {
-    let detailedErrorMessage = 'Error - Failed to load the bitrise.yml';
-    if (error.status) {
-      if (error.data?.error_msg) {
-        detailedErrorMessage = `${error.status} - ${error.data.error_msg}`;
-      } else if (error.statusText) {
-        detailedErrorMessage = `${error.status} - ${error.statusText}`;
-      }
-    }
-
-    return (
-      <Box
-        px="5%"
-        gap="3rem"
-        width="100vw"
-        height="100vh"
-        display="flex"
-        marginX="auto"
-        alignItems="center"
-        backgroundImage="linear-gradient(315deg, var(--colors-purple-30), var(--colors-purple-10))"
-      >
-        <Box display="flex" flexDir="column" gap="32" textColor="text/on-color" maxWidth="50%">
-          <Link href="/" title="Go to Dashboard">
-            <Image src={bitriseLogo} />
-          </Link>
-          <Box>
-            <Text size="3" fontFamily="Source Code Pro, monospace" textTransform="uppercase" mb="16">
-              {detailedErrorMessage}
-            </Text>
-            <Text textStyle="heading/h2" fontWeight="bold" fontSize="48" lineHeight="1.2">
-              {error?.message}
-            </Text>
-          </Box>
-          <Button alignSelf="start" variant="primary" size="lg" onClick={() => refetch()}>
-            Try again
-          </Button>
-        </Box>
-        <Box>
-          <Image src={errorImg} />
-        </Box>
-      </Box>
-    );
-  }
-
-  // Expose whether the config is still loading (settings check + tree/legacy fetch) so the layout
-  // can show the loading state in the content area while keeping the header + navigation visible.
-  return <ConfigLoadingProvider value={!data}>{children}</ConfigLoadingProvider>;
 };
 
 const App = () => {

--- a/source/javascripts/routes.spec.ts
+++ b/source/javascripts/routes.spec.ts
@@ -46,6 +46,17 @@ describe('deepLinkedEntity', () => {
     expect(deepLinkedEntity('#!/step_bundlesx?step_bundle_id=common')).toBeUndefined();
   });
 
+  it('reads a duplicated param the same way the page selectors do (last value wins)', () => {
+    // `URLSearchParams.get()` would take the first value here, while the selectors read the hash
+    // through `getSearchParamsFromLocationHash()` and take the last — so bootstrap would open the
+    // module for one workflow and the page would then select the other.
+    expect(deepLinkedEntity('#!/workflows?workflow_id=module-wf&workflow_id=root-wf')).toEqual({
+      kind: 'workflows',
+      id: 'root-wf',
+    });
+    expect(deepLinkedEntity('#!/workflows?workflow_id=module-wf&workflow_id=')).toBeUndefined();
+  });
+
   it('still matches a sub-path of an entity page', () => {
     expect(deepLinkedEntity('#!/workflows/?workflow_id=deploy')).toEqual({ kind: 'workflows', id: 'deploy' });
     expect(deepLinkedEntity('#!/workflows/steps?workflow_id=deploy')).toEqual({ kind: 'workflows', id: 'deploy' });

--- a/source/javascripts/routes.spec.ts
+++ b/source/javascripts/routes.spec.ts
@@ -1,0 +1,42 @@
+import { deepLinkedEntity } from './routes';
+
+describe('deepLinkedEntity', () => {
+  it('reads the entity a hash location addresses', () => {
+    expect(deepLinkedEntity('#!/workflows?workflow_id=test_minimal')).toEqual({
+      kind: 'workflows',
+      id: 'test_minimal',
+    });
+    expect(deepLinkedEntity('#!/pipelines?pipeline=nightly')).toEqual({ kind: 'pipelines', id: 'nightly' });
+    expect(deepLinkedEntity('#!/step_bundles?step_bundle_id=common')).toEqual({
+      kind: 'stepBundles',
+      id: 'common',
+    });
+  });
+
+  it('ignores the other params a link may carry', () => {
+    expect(deepLinkedEntity('#!/workflows?tab=configuration&workflow_id=test_minimal&branch=main')).toEqual({
+      kind: 'workflows',
+      id: 'test_minimal',
+    });
+  });
+
+  it('accepts a bare router path as well as a raw hash', () => {
+    expect(deepLinkedEntity('/workflows?workflow_id=deploy')).toEqual({ kind: 'workflows', id: 'deploy' });
+  });
+
+  it('returns undefined when the page carries no entity id', () => {
+    expect(deepLinkedEntity('#!/workflows')).toBeUndefined();
+    expect(deepLinkedEntity('#!/workflows?branch=main')).toBeUndefined();
+    expect(deepLinkedEntity('#!/workflows?workflow_id=')).toBeUndefined();
+  });
+
+  it('returns undefined for pages that do not address a single entity', () => {
+    expect(deepLinkedEntity('#!/secrets?workflow_id=deploy')).toBeUndefined();
+    expect(deepLinkedEntity('#!/yml?workflow_id=deploy')).toBeUndefined();
+    expect(deepLinkedEntity('')).toBeUndefined();
+  });
+
+  it('does not confuse a pipeline link for a workflow one', () => {
+    expect(deepLinkedEntity('#!/pipelines?workflow_id=deploy')).toBeUndefined();
+  });
+});

--- a/source/javascripts/routes.spec.ts
+++ b/source/javascripts/routes.spec.ts
@@ -39,4 +39,15 @@ describe('deepLinkedEntity', () => {
   it('does not confuse a pipeline link for a workflow one', () => {
     expect(deepLinkedEntity('#!/pipelines?workflow_id=deploy')).toBeUndefined();
   });
+
+  it('matches the page on a segment boundary, not as a bare prefix', () => {
+    expect(deepLinkedEntity('#!/workflows-old?workflow_id=deploy')).toBeUndefined();
+    expect(deepLinkedEntity('#!/pipelines_v2?pipeline=nightly')).toBeUndefined();
+    expect(deepLinkedEntity('#!/step_bundlesx?step_bundle_id=common')).toBeUndefined();
+  });
+
+  it('still matches a sub-path of an entity page', () => {
+    expect(deepLinkedEntity('#!/workflows/?workflow_id=deploy')).toEqual({ kind: 'workflows', id: 'deploy' });
+    expect(deepLinkedEntity('#!/workflows/steps?workflow_id=deploy')).toEqual({ kind: 'workflows', id: 'deploy' });
+  });
 });

--- a/source/javascripts/routes.tsx
+++ b/source/javascripts/routes.tsx
@@ -33,8 +33,12 @@ export function entityDeepLinkParam(kind: EntityKind): string | undefined {
  * workflow. `undefined` when the location isn't an entity page, or carries no entity id.
  */
 export function deepLinkedEntity(location: string): EntityDeepLink | undefined {
-  const [path, search] = location.replace(/^#?!?\/?/, '').split('?');
-  const route = ENTITY_DEEP_LINKS.find(({ path: entityPath }) => `/${path}`.startsWith(entityPath));
+  const [rawPath, search] = location.replace(/^#?!?\/?/, '').split('?');
+  const path = `/${rawPath}`;
+  // Segment boundary, not a bare prefix: an unrelated `/workflows-old` page is not a workflow link.
+  const route = ENTITY_DEEP_LINKS.find(
+    ({ path: entityPath }) => path === entityPath || path.startsWith(`${entityPath}/`),
+  );
   const id = route && new URLSearchParams(search).get(route.param);
   return id ? { kind: route.kind, id } : undefined;
 }

--- a/source/javascripts/routes.tsx
+++ b/source/javascripts/routes.tsx
@@ -1,6 +1,7 @@
 import { lazyWithPreload } from 'react-lazy-with-preload';
 
 import { EntityDeepLink, EntityKind } from '@/core/models/Tree';
+import { searchParamsFromLocation } from '@/core/utils/CommonUtils';
 
 export const paths = {
   workflows: '/workflows',
@@ -33,13 +34,15 @@ export function entityDeepLinkParam(kind: EntityKind): string | undefined {
  * workflow. `undefined` when the location isn't an entity page, or carries no entity id.
  */
 export function deepLinkedEntity(location: string): EntityDeepLink | undefined {
-  const [rawPath, search] = location.replace(/^#?!?\/?/, '').split('?');
+  const [rawPath] = location.replace(/^#?!?\/?/, '').split('?');
   const path = `/${rawPath}`;
   // Segment boundary, not a bare prefix: an unrelated `/workflows-old` page is not a workflow link.
   const route = ENTITY_DEEP_LINKS.find(
     ({ path: entityPath }) => path === entityPath || path.startsWith(`${entityPath}/`),
   );
-  const id = route && new URLSearchParams(search).get(route.param);
+  // Read the id through the shared parser, so a duplicated param can't resolve to one entity here
+  // and a different one in the page selectors — which would re-open the very bug this fixes.
+  const id = route && searchParamsFromLocation(location)[route.param];
   return id ? { kind: route.kind, id } : undefined;
 }
 

--- a/source/javascripts/routes.tsx
+++ b/source/javascripts/routes.tsx
@@ -1,5 +1,7 @@
 import { lazyWithPreload } from 'react-lazy-with-preload';
 
+import { EntityDeepLink, EntityKind } from '@/core/models/Tree';
+
 export const paths = {
   workflows: '/workflows',
   pipelines: '/pipelines',
@@ -12,6 +14,30 @@ export const paths = {
   licenses: '/licenses',
   yml: '/yml',
 };
+
+// Pages that address a single entity through a search param. Kinds without one (containers,
+// project env vars) are reached by page alone, so they can't be deep-linked to an entity.
+const ENTITY_DEEP_LINKS: ReadonlyArray<{ kind: EntityKind; path: string; param: string }> = [
+  { kind: 'workflows', path: paths.workflows, param: 'workflow_id' },
+  { kind: 'pipelines', path: paths.pipelines, param: 'pipeline' },
+  { kind: 'stepBundles', path: paths.stepBundles, param: 'step_bundle_id' },
+];
+
+/** The search param carrying the entity id on a kind's page; `undefined` for kinds without one. */
+export function entityDeepLinkParam(kind: EntityKind): string | undefined {
+  return ENTITY_DEEP_LINKS.find((link) => link.kind === kind)?.param;
+}
+
+/**
+ * The entity a router location addresses — `#!/workflows?workflow_id=deploy` → the `deploy`
+ * workflow. `undefined` when the location isn't an entity page, or carries no entity id.
+ */
+export function deepLinkedEntity(location: string): EntityDeepLink | undefined {
+  const [path, search] = location.replace(/^#?!?\/?/, '').split('?');
+  const route = ENTITY_DEEP_LINKS.find(({ path: entityPath }) => `/${path}`.startsWith(entityPath));
+  const id = route && new URLSearchParams(search).get(route.param);
+  return id ? { kind: route.kind, id } : undefined;
+}
 
 export const routes = [
   {


### PR DESCRIPTION
### Problem
With modular YAML, opening a link to a workflow that lives in an *included* config file lands on the wrong workflow.

`initializeModularConfig` always selected the root `bitrise.yml` as the active tab. The pages then read the active document only, so `useSelectedWorkflow` couldn't find the requested `workflow_id` there, fell back to the first runnable workflow, and its self-correcting effect rewrote the URL — the requested id was silently lost. Same class of bug for `?pipeline=` and `?step_bundle_id=`.

### Fix
Resolve the entity the URL addresses against the entity index *during* tree bootstrap, and select the module that defines it (keeping the root tab open next to it).

- `routes.tsx` — new `deepLinkedEntity(location)` maps a router location to `{ kind, id }` (`/workflows?workflow_id=` → workflows, `/pipelines?pipeline=` → pipelines, `/step_bundles?step_bundle_id=` → step bundles). Also exports `entityDeepLinkParam(kind)`, replacing the duplicate map that lived in `useJumpToDefinition` so the two can't drift.
- `EntityIndexService.deepLinkNodeId(index, link)` — index lookup for a URL-addressed entity; falls back from a generated parallel-workflow id (`build-and-test_3`) to its source workflow, mirroring what `useSelectedWorkflow` already does for the selection.
- `initializeModularConfig({ ..., deepLink })` — selects the defining module instead of the root file; `main.tsx` passes `deepLinkedEntity(window.parent.location.hash)`.
- `CommonUtils.parallelWorkflowSourceId` / `CommonUtils.searchParamsFromLocation` — shared helpers so the deep-link resolution and the pages' own selection logic can't drift out of sync on parallel-workflow ids or duplicated query params.

Bootstrap resolves the entity against the whole tree, and a **loading gate** is what keeps the pages from running first — see the section below. Resolution deliberately does not fire on later tab switches, where falling back to the newly-selected file's own entities is the intended behaviour.

### Mount sequencing (the riskiest part of this PR)
The first version of this fix assumed that resolving at bootstrap inherently lands before any page reads the config. That was wrong, and `7850933` fixes it.

`data` arriving made the routes mount in the **same commit** as the bootstrap effect, and React runs passive mount effects child-first — so `useSelectedWorkflow` / `usePipelineSelector` / `useSelectedStepBundle` validated against an empty (or the previous branch's) store and rewrote the hash *before* the bootstrap ran, stripping a module-only id. Deterministic on a branch reload once the route chunk was cached.

Two changes:

- **`InitialDataLoader` extracted** from `main.tsx` into `layouts/InitialDataLoader.tsx` — a move, no behaviour change of its own, so the mount sequencing it guarantees is testable.
- **The gate is keyed on the bootstrap having run, not on the fetch resolving** (`!data` → `!isBootstrapped`):
  ```ts
  const isBootstrapped = Boolean(data) && bootstrappedBranch === requestedBranch;
  ```
  Both halves matter: `data` arrives a commit before the effect runs, and a branch switch must invalidate a config that was legitimately bootstrapped for the previous branch. It's *derived during render* rather than flipped from an effect, so the gate closes in the very render where the requested branch changes — the routes unmount before they can observe the stale config. `MainLayout` renders `<LoadingState />` in place of the `<Router>` while the gate is closed, so no route effect can run early.

`bootstrappedBranch` state is deliberately paired with the existing `loadedBranch` ref rather than replacing it: the ref is the synchronous re-entry guard (a StrictMode double-invoke can't bootstrap twice), the state is what children observe — a ref alone would never trigger the re-render that reopens the gate.

### Assumptions (flagging for review)
1. **The defining module is selected, not the read-only "Merged config" tab.** The bug report guessed the merged tab should be the default; the module resolves the entity just as well, keeps it editable, and matches where jump-to-definition already takes the user. Easy to switch if you'd rather land on the merged view.
2. When several modules define the entity, the top-most (winning) layer is picked — same precedence rule as the rest of the modular UI.
3. An entity that no module defines keeps the root file selected, so the existing page-level fallback stays in charge (no behaviour change there).

### Tests
- `routes.spec.ts` — location → entity parsing, incl. extra params, non-entity pages, empty ids, and duplicated-param last-value semantics.
- `EntityIndexService.spec.ts` — `deepLinkNodeId`, incl. the parallel-workflow fallback and that it's workflow-only.
- `BitriseYmlStore.modular.spec.ts` — bootstrap selects/opens the defining module (incl. a read-only one), keeps the root selected when the entity is in root or nowhere, and covers step bundles.
- `CommonUtils.spec.ts` — the shared parallel-workflow-id and search-params parsers.
- `useSelectedWorkflow.spec.tsx` — end-to-end: a link to a workflow in an included module now resolves and the URL is preserved (incl. the duplicated-param case); unknown ids still fall back.
- `InitialDataLoader.spec.tsx` (new) — the sequencing guarantee: routes stay unmounted while the config loads, a route never renders against an un-bootstrapped store (so a module-only id survives), and a branch switch re-gates until the new branch is bootstrapped. The last two fail against the old `!data` gate.

Verified: `npx jest` 1479/1479 pass, `tsc --noEmit` clean, `eslint` 0 errors, `knip` output byte-identical to `origin/master`, `vite build` OK.
