### PR TITLE
Send the AI button source to the parent in the OPEN_CI_CONFIG_EXPERT payload

### DIFF
--- a/source/javascripts/hooks/useAIButton.spec.tsx
+++ b/source/javascripts/hooks/useAIButton.spec.tsx
@@ -5,6 +5,8 @@ import { renderHook } from '@testing-library/react';
 
 import { TreeNode } from '@/core/models/Tree';
 import { bitriseYmlStore, initializeModularConfig } from '@/core/stores/BitriseYmlStore';
+import { useCiConfigExpertStore } from '@/core/stores/CiConfigExpertStore';
+import WindowUtils from '@/core/utils/WindowUtils';
 import { CiConfigExpertAvailability } from '@/typings/globals';
 
 import useAIButton from './useAIButton';
@@ -44,10 +46,26 @@ describe('useAIButton', () => {
   beforeEach(() => {
     settings = withAvailability('enabled');
     bitriseYmlStore.setState({ tree: undefined });
+    useCiConfigExpertStore.setState({ isAIDrawerOpen: false });
   });
 
   it('is visible in a non-modular config', () => {
     expect(renderAIButton().isVisible).toBe(true);
+  });
+
+  // The parent forwards the source to its opt-in popup tracking, so it must cross the iframe boundary.
+  it('sends the source to the parent in the OPEN_CI_CONFIG_EXPERT payload', () => {
+    const postMessage = jest.spyOn(WindowUtils, 'postMessageToParent').mockImplementation(() => {});
+
+    const { getAIButtonProps } = renderHook(() =>
+      useAIButton({ action: 'explain_pipeline', source: 'pipeline_drawer' }),
+    ).result.current;
+    getAIButtonProps().onClick();
+
+    expect(postMessage).toHaveBeenCalledWith(
+      'OPEN_CI_CONFIG_EXPERT',
+      expect.objectContaining({ action: 'explain_pipeline', source: 'pipeline_drawer' }),
+    );
   });
 
   it('is hidden in a modular config (BIVS-3735)', () => {

--- a/source/javascripts/hooks/useAIButton.spec.tsx
+++ b/source/javascripts/hooks/useAIButton.spec.tsx
@@ -19,7 +19,6 @@ const withAvailability = (availability: CiConfigExpertAvailability): Settings =>
 
 let settings: Settings;
 
-jest.mock('@/core/analytics/SegmentBaseTracking', () => ({ __esModule: true, segmentTrack: jest.fn() }));
 jest.mock('@/core/utils/PageProps', () => ({
   __esModule: true,
   default: {

--- a/source/javascripts/hooks/useAIButton.ts
+++ b/source/javascripts/hooks/useAIButton.ts
@@ -14,6 +14,7 @@ type OpenCiConfigExpertPayload = {
   action: string;
   bitriseYmlContents: string;
   selectedPage: string;
+  source?: string;
   yamlSelector: string;
 };
 
@@ -94,6 +95,7 @@ const useAIButton = (options: UseAIButtonOptions): UseAIButtonResult => {
       action,
       bitriseYmlContents: getYmlString(),
       selectedPage: selectedPage || '',
+      source,
       yamlSelector,
     };
     WindowUtils.postMessageToParent('OPEN_CI_CONFIG_EXPERT', payload);

--- a/source/javascripts/hooks/useAIButton.ts
+++ b/source/javascripts/hooks/useAIButton.ts
@@ -1,9 +1,7 @@
 import { useState } from 'react';
 
-import { segmentTrack } from '@/core/analytics/SegmentBaseTracking';
 import { getYmlString } from '@/core/stores/BitriseYmlStore';
 import { useCiConfigExpertStore } from '@/core/stores/CiConfigExpertStore';
-import GlobalProps from '@/core/utils/GlobalProps';
 import PageProps from '@/core/utils/PageProps';
 import WindowUtils from '@/core/utils/WindowUtils';
 import useCurrentPage from '@/hooks/useCurrentPage';
@@ -40,8 +38,6 @@ const useAIButton = (options: UseAIButtonOptions): UseAIButtonResult => {
   const [isAgenticRunInProgress, setIsAgenticRunInProgress] = useState(false);
   const isAIDrawerOpen = useCiConfigExpertStore((s) => s.isAIDrawerOpen);
   const selectedPage = useCurrentPage();
-  const conversationId = useCiConfigExpertStore((s) => s.conversationId);
-  const turnCount = useCiConfigExpertStore((s) => s.turnCount);
 
   useParentMessageListener('DISABLE_AI_BUTTONS', () => {
     setIsAgenticRunInProgress(true);
@@ -80,17 +76,9 @@ const useAIButton = (options: UseAIButtonOptions): UseAIButtonResult => {
   }
 
   const onClick = () => {
-    segmentTrack('AI Assistant Opened', {
-      workspace_slug: GlobalProps.workspaceSlug(),
-      app_slug: PageProps.appSlug(),
-      source,
-      ai_assistant_conversation_id: conversationId,
-      ai_assistant_action: action,
-      is_resumed: !!turnCount,
-      prior_turn_count: turnCount ?? 0,
-      ai_assistant_type: 'ai_config_assistant',
-    });
-
+    // The website is the canonical emitter of "AI Assistant Opened": it fires the event when the
+    // drawer actually opens, for every entry point, using the `source` carried in the payload below.
+    // Tracking it here too would double-count every editor-initiated open.
     const payload: OpenCiConfigExpertPayload = {
       action,
       bitriseYmlContents: getYmlString(),


### PR DESCRIPTION
## Summary

The `source` passed to `useAIButton` (e.g. `pipeline_drawer`) was only used for the editor's own `AI Assistant Opened` Segment event — it never crossed the iframe boundary. The website reads `source` from the `OPEN_CI_CONFIG_EXPERT` postMessage payload and forwards it to its opt-in popup tracking events, so those events initiated from editor buttons were missing the `source` property entirely (the website's lodash merge drops `undefined` keys, so the key was absent rather than `null`).

With `source` now arriving, the website's `trackEditorInitiatedDrawerOpened` guard (`if (!source) return`) passes, so both sides would emit `AI Assistant Opened` for every editor-initiated click. To avoid double-counting, this PR also removes the editor's own emission and makes the website the single canonical emitter.

## Changes

- Added `source` to the `OpenCiConfigExpertPayload` type and to the payload object in `useAIButton`, so the parent window receives it.
- Removed the `segmentTrack('AI Assistant Opened', ...)` call from `useAIButton`'s `onClick`, along with the now-dead `segmentTrack`/`GlobalProps` imports and `conversationId`/`turnCount` selectors (the store fields stay — `Header.tsx` and `Navigation.tsx` still use them).
- Added a test asserting the `source` is included in the `OPEN_CI_CONFIG_EXPERT` payload; reset `CiConfigExpertStore` state between tests; dropped the no-longer-needed `SegmentBaseTracking` jest mock.

## ⚠️ Deliberate metric change: `AI Assistant Opened`

- The event is now emitted **only by the website**, for both the header and the editor entry points.
- **Event volume will drop**: clicks that end in the opt-in popup (opted-out projects) or in nothing at all (`availability === 'unavailable'`) no longer produce the event — the website fires it only when the drawer actually opens. That funnel is covered by the `AI Assistant Opt In Popup Shown` / `Dismissed` / `Attempted` events instead.
- `source_service_name` on this event changes from `workflow-editor` to `bitrise-website` for editor-initiated opens.

## Test plan

- [x] `npx jest --testPathPattern="useAIButton"` — 8/8 passing
- [x] ESLint + `tsc --noEmit` clean on the touched files
- [ ] Verify on the website that opt-in popup events initiated from editor AI buttons now include `source`
- [ ] Verify exactly one `AI Assistant Opened` fires per editor-initiated drawer open (from `bitrise-website`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)