### PR TITLE
fix(analytics): always send include counts in modular-config props

### DIFF
--- a/source/javascripts/core/analytics/ConfigManagementAnalytics.ts
+++ b/source/javascripts/core/analytics/ConfigManagementAnalytics.ts
@@ -21,13 +21,19 @@ const ENTITY_TYPE_BY_KIND: Record<EntityKind, string> = {
 
 /**
  * Modular-config properties shared by several events: whether the config is modular (has any
- * include) and, if so, how many includes it has in total and how many of those are cross-repo.
- * Derived from the loaded tree; `{ is_modular_config: false }` in single-file mode.
+ * include), how many includes it has in total and how many of those are cross-repo. Derived from
+ * the loaded tree. In single-file mode (no tree — either modular is off, or the root yml has no
+ * includes) both counts are sent as an explicit 0 rather than omitted: the tracking plan requires
+ * them on every event, and a missing key reads as lost data instead of "no includes".
  */
 function modularConfigProps() {
   const { tree } = bitriseYmlStore.getState();
   if (!tree) {
-    return { is_modular_config: false as const };
+    return {
+      is_modular_config: false as const,
+      number_of_includes_in_bitrise_yml: 0,
+      number_of_cross_repo_includes_in_bitrise_yml: 0,
+    };
   }
 
   let includes = 0;


### PR DESCRIPTION
## Summary

Avo flagged `Push Config Changes Failed` events arriving without `number_of_cross_repo_includes_in_bitrise_yml` and `number_of_includes_in_bitrise_yml`. The expectation is that a config with no includes reports `0`, not a missing property.

The cause is in `modularConfigProps()`: its single-file branch returned only `{ is_modular_config: false }`, so when spread into the event payload the two count keys were never created — they went out as absent keys, not as `undefined` values.

This also covers the case where modular YAML is *enabled* but the root yml has no includes: `InitialDataLoader` deliberately falls back to the plain single-file document when `root.includes.length === 0`, which leaves `tree` undefined — exactly the situation where we want an explicit `0`.

## Changes

- `modularConfigProps()` now returns `number_of_includes_in_bitrise_yml: 0` and `number_of_cross_repo_includes_in_bitrise_yml: 0` alongside `is_modular_config: false` in single-file mode.
- Updated the helper's doc comment to state why the counts are explicit zeros rather than omitted.

Four events share this helper, so all of them are fixed:

- `Push Config Changes Attempted`
- `Push Config Changes Succeeded`
- `Push Config Changes Failed`
- `Config Branch Loaded`

The modular branch is unchanged — when a tree exists there is at least one include by construction, so both counts were already always sent there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)