### PR TITLE
Handle YAML aliases and empty nodes in document reads

### DIFF
--- a/source/javascripts/core/services/ContainerService.spec.tsx
+++ b/source/javascripts/core/services/ContainerService.spec.tsx
@@ -8,6 +8,7 @@ import {
   updateBitriseYmlDocumentByString,
 } from '@/core/stores/BitriseYmlStore';
 
+import YmlUtils from '../utils/YmlUtils';
 import ContainerService from './ContainerService';
 
 const MODULAR_SHA = 'a1b2c3d4e5f6789012345678901234567890abcd';
@@ -1789,6 +1790,131 @@ describe('ContainerService', () => {
             bitriseYmlStore.getState().ymlDocument,
           ),
         ).toEqual([{ id: 'ubuntu', recreate: false }]);
+      });
+
+      it('resolves an execution container written as an alias', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          containers:
+            ubuntu:
+              type: execution
+              image: ubuntu:20.04
+          _image: &image ubuntu
+          workflows:
+            wf1:
+              steps:
+              - script:
+                  execution_container: *image
+        `);
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Execution,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toEqual([{ id: 'ubuntu', recreate: false }]);
+      });
+
+      it('resolves an execution container whose recreate map is written as an alias', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          _ref: &ref
+            ubuntu:
+              recreate: true
+          workflows:
+            wf1:
+              steps:
+              - script:
+                  execution_container: *ref
+        `);
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Execution,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toEqual([{ id: 'ubuntu', recreate: true }]);
+      });
+
+      it('resolves a service_containers sequence written as an alias', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          _services: &services
+          - postgres
+          workflows:
+            wf1:
+              steps:
+              - script:
+                  service_containers: *services
+        `);
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Service,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toEqual([{ id: 'postgres', recreate: false }]);
+      });
+
+      // An unresolved alias inside a subtree serializes to `{ source: '<anchor>' }`, which a
+      // JSON-based parse would report as a container literally named "source".
+      it('resolves a single service_containers entry written as an alias', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          _service: &service postgres
+          workflows:
+            wf1:
+              steps:
+              - script:
+                  service_containers:
+                  - *service
+                  - redis
+        `);
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Service,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toEqual([
+          { id: 'postgres', recreate: false },
+          { id: 'redis', recreate: false },
+        ]);
+      });
+
+      it('matches the expanded YAML when both fields alias a shared defaults block', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          _defaults:
+            image: &img ruby-3
+            svcs: &svc [postgres]
+          workflows:
+            wf1:
+              steps:
+              - script@1:
+                  execution_container: *img
+                  service_containers: *svc
+        `);
+
+        const doc = bitriseYmlStore.getState().ymlDocument;
+
+        // The references the card shows must agree with what `toJSON()` — and the CLI — see.
+        expect(YmlUtils.toJSON(doc).workflows?.wf1?.steps?.[0]).toEqual({
+          'script@1': { execution_container: 'ruby-3', service_containers: ['postgres'] },
+        });
+        expect(
+          ContainerService.getContainerReferenceFromInstance('workflows', 'wf1', 0, ContainerType.Execution, doc),
+        ).toEqual([{ id: 'ruby-3', recreate: false }]);
+        expect(
+          ContainerService.getContainerReferenceFromInstance('workflows', 'wf1', 0, ContainerType.Service, doc),
+        ).toEqual([{ id: 'postgres', recreate: false }]);
       });
 
       it('resolves container references on an aliased workflow', () => {

--- a/source/javascripts/core/services/ContainerService.spec.tsx
+++ b/source/javascripts/core/services/ContainerService.spec.tsx
@@ -1325,7 +1325,7 @@ describe('ContainerService', () => {
         ).toBeUndefined();
       });
 
-      it('should throw error when step index does not exist', () => {
+      it('should return undefined when step index does not exist', () => {
         updateBitriseYmlDocumentByString(yaml`
         workflows:
           wf1:
@@ -1333,7 +1333,7 @@ describe('ContainerService', () => {
               - script: {}
       `);
 
-        expect(() =>
+        expect(
           ContainerService.getContainerReferenceFromInstance(
             'workflows',
             'wf1',
@@ -1341,7 +1341,7 @@ describe('ContainerService', () => {
             ContainerType.Execution,
             bitriseYmlStore.getState().ymlDocument,
           ),
-        ).toThrow('Step at index 5 not found in workflows.wf1');
+        ).toBeUndefined();
       });
     });
 
@@ -1599,7 +1599,7 @@ describe('ContainerService', () => {
         ).toBeUndefined();
       });
 
-      it('should throw error when step index does not exist', () => {
+      it('should return undefined when step index does not exist', () => {
         updateBitriseYmlDocumentByString(yaml`
         workflows:
           wf1:
@@ -1607,7 +1607,7 @@ describe('ContainerService', () => {
               - script: {}
       `);
 
-        expect(() =>
+        expect(
           ContainerService.getContainerReferenceFromInstance(
             'workflows',
             'wf1',
@@ -1615,7 +1615,7 @@ describe('ContainerService', () => {
             ContainerType.Service,
             bitriseYmlStore.getState().ymlDocument,
           ),
-        ).toThrow('Step at index 10 not found in workflows.wf1');
+        ).toBeUndefined();
       });
     });
 
@@ -1678,6 +1678,144 @@ describe('ContainerService', () => {
       expect(result2).toEqual([{ id: 'node', recreate: false }]);
       expect(result3).toEqual([{ id: 'postgres', recreate: false }]);
       expect(result4).toBeUndefined();
+    });
+
+    describe('steps the editor cannot read as a `{cvs: options}` map', () => {
+      // Every case below reaches this function through StepCard's render, so none of them may throw.
+      it.each([
+        ['written as a plain string', 'script@1'],
+        ['written without a value', ''],
+      ])('returns undefined for a step %s', (_, stepValue) => {
+        updateBitriseYmlDocumentByString(yaml`
+          workflows:
+            wf1:
+              steps:
+              - ${stepValue}
+        `);
+
+        const doc = bitriseYmlStore.getState().ymlDocument;
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance('workflows', 'wf1', 0, ContainerType.Execution, doc),
+        ).toBeUndefined();
+        expect(
+          ContainerService.getContainerReferenceFromInstance('workflows', 'wf1', 0, ContainerType.Service, doc),
+        ).toBeUndefined();
+      });
+
+      it('returns undefined when the workflow itself is not a map', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          workflows:
+            wf1: some-string
+        `);
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Execution,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toBeUndefined();
+      });
+
+      it('returns undefined when service_containers is not a sequence', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          workflows:
+            wf1:
+              steps:
+              - script:
+                  service_containers: postgres
+        `);
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Service,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toBeUndefined();
+      });
+
+      it('skips reference entries that name no container', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          workflows:
+            wf1:
+              steps:
+              - script:
+                  service_containers:
+                  - {}
+                  -
+                  - postgres
+        `);
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Service,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toEqual([{ id: 'postgres', recreate: false }]);
+      });
+    });
+
+    describe('steps and workflows written with YAML anchors', () => {
+      it('resolves container references on an aliased step', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          containers:
+            ubuntu:
+              type: execution
+              image: ubuntu:20.04
+          _step: &common_step
+            script:
+              execution_container: ubuntu
+          workflows:
+            wf1:
+              steps:
+              - *common_step
+        `);
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Execution,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toEqual([{ id: 'ubuntu', recreate: false }]);
+      });
+
+      it('resolves container references on an aliased workflow', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          containers:
+            postgres:
+              type: service
+              image: postgres:13
+          _workflow: &common_workflow
+            steps:
+            - script:
+                service_containers:
+                - postgres
+          workflows:
+            wf1: *common_workflow
+        `);
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Service,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toEqual([{ id: 'postgres', recreate: false }]);
+      });
     });
   });
 

--- a/source/javascripts/core/services/ContainerService.spec.tsx
+++ b/source/javascripts/core/services/ContainerService.spec.tsx
@@ -2204,6 +2204,86 @@ describe('ContainerService', () => {
   });
 
   describe('getWorkflowsUsingContainer', () => {
+    // These usage counts drive the "Used by N Workflows" label and the delete warning, so a
+    // reference the scan cannot read reads as "unused" — the container can then be deleted without
+    // a warning, leaving the alias dangling.
+    describe('references written as aliases', () => {
+      it('should count a workflow that references a container through an alias', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          _defaults:
+            image: &img ruby-3
+          containers:
+            ruby-3:
+              image: ruby:3
+          workflows:
+            aliased:
+              steps:
+              - script@1:
+                  execution_container: *img
+            plain:
+              steps:
+              - script@1:
+                  execution_container: ruby-3
+        `);
+
+        const doc = bitriseYmlStore.getState().ymlDocument;
+
+        expect(ContainerService.getWorkflowsUsingContainer(doc, 'ruby-3')).toEqual(['plain', 'aliased']);
+        expect([...ContainerService.getWorkflowsUsingContainers(doc, ['ruby-3'])]).toEqual([
+          ['ruby-3', ['plain', 'aliased']],
+        ]);
+      });
+
+      it('should count aliased service sequences, aliased entries and aliased step bundle references', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          _services: &services
+          - postgres
+          _one: &one postgres
+          containers:
+            postgres:
+              image: postgres:13
+          step_bundles:
+            b1:
+              execution_container: *one
+          workflows:
+            wf_seq:
+              steps:
+              - script@1:
+                  service_containers: *services
+            wf_entry:
+              steps:
+              - script@1:
+                  service_containers:
+                  - *one
+            wf_bundle:
+              steps:
+              - bundle::b1: {}
+        `);
+
+        expect(ContainerService.getWorkflowsUsingContainer(bitriseYmlStore.getState().ymlDocument, 'postgres')).toEqual(
+          ['wf_seq', 'wf_entry', 'wf_bundle'],
+        );
+      });
+
+      it('should still report a container referenced only through aliases as used', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          _image: &img ruby-3
+          containers:
+            ruby-3:
+              image: ruby:3
+          workflows:
+            only_aliased:
+              steps:
+              - script@1:
+                  execution_container: *img
+        `);
+
+        expect(ContainerService.getWorkflowsUsingContainer(bitriseYmlStore.getState().ymlDocument, 'ruby-3')).toEqual([
+          'only_aliased',
+        ]);
+      });
+    });
+
     describe('execution container target', () => {
       it('should return workflows using a specific execution container', () => {
         updateBitriseYmlDocumentByString(yaml`

--- a/source/javascripts/core/services/ContainerService.ts
+++ b/source/javascripts/core/services/ContainerService.ts
@@ -257,45 +257,64 @@ function getAllContainers(containers: Containers, selector: (container: Containe
     .filter(selector);
 }
 
-// `undefined` for a reference that names no container (an empty map, an empty seq item, a number).
-// Both callers run during render, where throwing would take down the whole card.
-function parseContainerReference(value: unknown): ContainerReference | undefined {
-  if (typeof value === 'string') {
-    return value ? { id: value, recreate: false } : undefined;
-  }
+/** The plain value behind a node, resolving an alias first. */
+function scalarValueOf(doc: Document, node: unknown) {
+  const resolved = YmlUtils.resolveAlias(doc, node);
 
-  if (typeof value !== 'object' || value === null) {
-    return undefined;
-  }
-
-  const [containerId, config] = Object.entries(value as Record<string, { recreate?: boolean }>)[0] ?? [];
-
-  if (!containerId) {
-    return undefined;
-  }
-
-  return { id: containerId, recreate: config?.recreate === true };
+  return isScalar(resolved) ? resolved.value : resolved;
 }
 
-function getContainerReferences(type: ContainerType, yamlMap: YAMLMap): ContainerReference[] | undefined {
-  if (type === ContainerType.Execution) {
-    const node = yamlMap.get(ContainerReferenceField.Execution);
+/**
+ * A container reference — a bare id (`ubuntu`) or `{ id: { recreate: true } }` — or `undefined` when
+ * the node names no container (an empty map, an empty seq item, a number).
+ *
+ * Read off the nodes rather than via `toJSON()`, and resolved against `doc` at every level: a
+ * reference can be written as `*anchor` (or hold one), and a subtree containing an unresolved alias
+ * serializes to `{ source: '<anchor>' }`, which would parse as a container literally named "source".
+ * Every caller runs during render, where throwing would take down the whole card.
+ */
+function parseContainerReference(doc: Document, node: unknown): ContainerReference | undefined {
+  const resolved = YmlUtils.resolveAlias(doc, node);
 
-    if (!node || (!isMap(node) && typeof node !== 'string')) {
+  if (isMap(resolved)) {
+    const pair = resolved.items[0];
+    const id = pair ? scalarValueOf(doc, pair.key) : undefined;
+
+    if (typeof id !== 'string' || !id) {
       return undefined;
     }
 
-    const value = isMap(node) ? node.toJSON() : node;
-    const reference = parseContainerReference(value);
+    const options = YmlUtils.resolveAlias(doc, pair?.value);
+    const recreate = isMap(options) ? scalarValueOf(doc, options.get('recreate', true)) : undefined;
+
+    return { id, recreate: recreate === true };
+  }
+
+  const value = isScalar(resolved) ? resolved.value : resolved;
+
+  return typeof value === 'string' && value ? { id: value, recreate: false } : undefined;
+}
+
+// `doc` is the alias-resolution root: an anchor referenced from a step is almost always declared
+// elsewhere in the file, so resolving against `yamlMap` alone would never find it.
+function getContainerReferences(
+  type: ContainerType,
+  yamlMap: YAMLMap,
+  doc: Document,
+): ContainerReference[] | undefined {
+  if (type === ContainerType.Execution) {
+    const reference = parseContainerReference(doc, yamlMap.get(ContainerReferenceField.Execution, true));
+
     return reference ? [reference] : undefined;
   }
 
   if (type === ContainerType.Service) {
-    // `services:` is only usable as a sequence; any other shape (a bare scalar, a map) is left to
-    // the YAML validator to report rather than thrown from here, mid-render.
-    const node = YmlUtils.getIn(yamlMap, [ContainerReferenceField.Service], true);
-    const references = (isSeq(node) ? (node.toJSON() as unknown[]) : [])
-      .map(parseContainerReference)
+    // Resolved first: `*anchor` pointing at a sequence is a config the CLI runs, not a bad shape.
+    // What's left after that — a bare scalar, a map — is genuinely unusable here, and reporting it
+    // is the YAML validator's job rather than something to throw over mid-render.
+    const node = YmlUtils.resolveAlias(doc, yamlMap.get(ContainerReferenceField.Service, true));
+    const references = (isSeq(node) ? node.items : [])
+      .map((item) => parseContainerReference(doc, item))
       .filter((reference): reference is ContainerReference => Boolean(reference));
 
     if (references.length > 0) {
@@ -313,7 +332,7 @@ function getContainerReferencesFromStepBundleDefinition(sourceId: string, type: 
     return undefined;
   }
 
-  return getContainerReferences(type, yamlMap);
+  return getContainerReferences(type, yamlMap, doc);
 }
 
 function getContainerReferenceFromInstance(
@@ -334,7 +353,7 @@ function getContainerReferenceFromInstance(
     return undefined;
   }
 
-  return getContainerReferences(type, yamlMap);
+  return getContainerReferences(type, yamlMap, doc);
 }
 
 // The container id a reference node points at — a bare scalar id, or the first key of a

--- a/source/javascripts/core/services/ContainerService.ts
+++ b/source/javascripts/core/services/ContainerService.ts
@@ -359,6 +359,11 @@ function getContainerReferenceFromInstance(
 // The container id a reference node points at — a bare scalar id, or the first key of a
 // `{ id: {opts} }` map — or undefined if it isn't a container reference. The inverse of the shapes
 // `referencesContainer` matched (a scalar equal to the id, or a map whose first key is the id).
+//
+// Read the node with `YmlUtils.getIn`, never `doc.getIn`: the paths handed to this come from
+// `getMatchingPaths`, which enumerates `toJSON()` and so happily matches a leaf written as
+// `*anchor`. A native read hands back the raw `Alias` — neither a map nor a scalar — and the
+// reference silently disappears from the usage counts.
 function referencedContainerId(node: unknown): string | undefined {
   if (isMap(node)) {
     return node.items.length > 0 ? String(node.items[0]?.key) : undefined;
@@ -397,7 +402,7 @@ function getWorkflowsUsingContainers(doc: Document, containerIds: string[]): Map
     ...YmlUtils.getMatchingPaths(doc, ExecutionContainerWildcardRefPath),
     ...YmlUtils.getMatchingPaths(doc, ServiceContainerWildcardRefPath),
   ].forEach(([path]) => {
-    const containerId = referencedContainerId(doc.getIn(path));
+    const containerId = referencedContainerId(YmlUtils.getIn(doc, path, true));
     if (containerId && ids.has(containerId)) {
       bucket(directByContainer, containerId, String(path[1]), () => []);
     }
@@ -410,7 +415,7 @@ function getWorkflowsUsingContainers(doc: Document, containerIds: string[]): Map
     ...YmlUtils.getMatchingPaths(doc, StepBundleExecutionContainerWildcardRefPath),
     ...YmlUtils.getMatchingPaths(doc, StepBundleServiceContainerWildcardRefPath),
   ].forEach(([path]) => {
-    const containerId = referencedContainerId(doc.getIn(path));
+    const containerId = referencedContainerId(YmlUtils.getIn(doc, path, true));
     if (containerId && ids.has(containerId)) {
       bucket(stepBundleIdsByContainer, containerId, String(path[1]), () => new Set<string>());
     }

--- a/source/javascripts/core/services/ContainerService.ts
+++ b/source/javascripts/core/services/ContainerService.ts
@@ -1,5 +1,5 @@
 import { uniq } from 'es-toolkit';
-import { Document, isMap, isScalar, YAMLMap } from 'yaml';
+import { Document, isMap, isScalar, isSeq, YAMLMap } from 'yaml';
 
 import { ContainerModel, Containers } from '@/core/models/BitriseYml';
 import { Container, ContainerReference, ContainerReferenceField, ContainerType } from '@/core/models/Container';
@@ -53,10 +53,14 @@ function getStepDataOrThrowError(
     throw new Error(`Invalid step data at index ${stepIndex} in ${source} '${sourceId}'`);
   }
 
-  if (isMap(pair.value)) {
-    return pair.value;
+  const stepData = YmlUtils.resolveAlias(doc, pair.value);
+
+  if (isMap(stepData)) {
+    return stepData;
   }
 
+  // An option-less step (`- script@1:`) has no map to write into yet; materialize one. Checked on
+  // the raw value, not the resolved one, so a dangling alias isn't silently overwritten.
   if (pair.value == null || (isScalar(pair.value) && pair.value.value == null)) {
     const emptyMap = new YAMLMap();
     pair.value = emptyMap;
@@ -64,6 +68,29 @@ function getStepDataOrThrowError(
   }
 
   throw new Error(`Invalid step data at index ${stepIndex} in ${source} '${sourceId}'`);
+}
+
+/**
+ * The option map of a step (`- script@1: {...}` → the `{...}`), or `undefined` when the step is
+ * absent — a cross-file workflow, a step bundle defined in another module — or isn't a
+ * `{cvs: options}` map at all. Unlike `getStepDataOrThrowError` this neither throws nor materializes
+ * a missing option map, so it is safe to call while rendering.
+ */
+function findStepData(
+  doc: Document,
+  source: 'workflows' | 'step_bundles',
+  sourceId: string,
+  stepIndex: number,
+): YAMLMap | undefined {
+  const step = YmlUtils.getIn(doc, [source, sourceId, 'steps', stepIndex], true);
+
+  if (!isMap(step)) {
+    return undefined;
+  }
+
+  const stepData = YmlUtils.resolveAlias(doc, step.items[0]?.value);
+
+  return isMap(stepData) ? stepData : undefined;
 }
 
 function addContainerReference(
@@ -230,17 +257,21 @@ function getAllContainers(containers: Containers, selector: (container: Containe
     .filter(selector);
 }
 
-type ContainerReferenceValue = string | Record<string, { recreate?: boolean }>;
-
-function parseContainerReference(value: ContainerReferenceValue): ContainerReference {
+// `undefined` for a reference that names no container (an empty map, an empty seq item, a number).
+// Both callers run during render, where throwing would take down the whole card.
+function parseContainerReference(value: unknown): ContainerReference | undefined {
   if (typeof value === 'string') {
-    return { id: value, recreate: false };
+    return value ? { id: value, recreate: false } : undefined;
   }
 
-  const [containerId, config] = Object.entries(value)[0] ?? [];
+  if (typeof value !== 'object' || value === null) {
+    return undefined;
+  }
+
+  const [containerId, config] = Object.entries(value as Record<string, { recreate?: boolean }>)[0] ?? [];
 
   if (!containerId) {
-    throw new Error(`Container not found. Ensure that the container exists in the 'containers' section.`);
+    return undefined;
   }
 
   return { id: containerId, recreate: config?.recreate === true };
@@ -255,15 +286,20 @@ function getContainerReferences(type: ContainerType, yamlMap: YAMLMap): Containe
     }
 
     const value = isMap(node) ? node.toJSON() : node;
-    return [parseContainerReference(value)];
+    const reference = parseContainerReference(value);
+    return reference ? [reference] : undefined;
   }
 
   if (type === ContainerType.Service) {
-    const serviceContainers = YmlUtils.getSeqIn(yamlMap, [ContainerReferenceField.Service])?.toJSON() as
-      ContainerReferenceValue[] | undefined;
+    // `services:` is only usable as a sequence; any other shape (a bare scalar, a map) is left to
+    // the YAML validator to report rather than thrown from here, mid-render.
+    const node = YmlUtils.getIn(yamlMap, [ContainerReferenceField.Service], true);
+    const references = (isSeq(node) ? (node.toJSON() as unknown[]) : [])
+      .map(parseContainerReference)
+      .filter((reference): reference is ContainerReference => Boolean(reference));
 
-    if (serviceContainers && serviceContainers.length > 0) {
-      return serviceContainers.map(parseContainerReference);
+    if (references.length > 0) {
+      return references;
     }
   }
 
@@ -272,8 +308,8 @@ function getContainerReferences(type: ContainerType, yamlMap: YAMLMap): Containe
 
 function getContainerReferencesFromStepBundleDefinition(sourceId: string, type: ContainerType, doc: Document) {
   // A cross-file bundle definition is absent here; return none rather than throwing (throwing crashes the card during render).
-  const yamlMap = YmlUtils.getMapIn(doc, ['step_bundles', sourceId]);
-  if (!yamlMap) {
+  const yamlMap = YmlUtils.getIn(doc, ['step_bundles', sourceId], true);
+  if (!isMap(yamlMap)) {
     return undefined;
   }
 
@@ -290,13 +326,14 @@ function getContainerReferenceFromInstance(
   if (source === 'step_bundles' && stepIndex === -1) {
     return getContainerReferencesFromStepBundleDefinition(sourceId, type, doc);
   }
-  // A cross-file source (a workflow/step bundle defined in another module) is absent from the active
-  // document; return none rather than throwing (throwing crashes the card during render) — mirrors
-  // getContainerReferencesFromStepBundleDefinition.
-  if (!YmlUtils.getMapIn(doc, [source, sourceId])) {
+  // This runs on every StepCard render, so it must not throw: a cross-file source (a workflow/step
+  // bundle defined in another module) is absent from the active document, and a step can be written
+  // in a shape this can't read. Either way the card renders without container references.
+  const yamlMap = findStepData(doc, source, sourceId, stepIndex);
+  if (!yamlMap) {
     return undefined;
   }
-  const yamlMap = getStepDataOrThrowError(doc, source, sourceId, stepIndex);
+
   return getContainerReferences(type, yamlMap);
 }
 

--- a/source/javascripts/core/services/StackAndMachineService.spec.ts
+++ b/source/javascripts/core/services/StackAndMachineService.spec.ts
@@ -2575,6 +2575,89 @@ describe('StackAndMachineService', () => {
           );
         }).toThrow(`Workflow nonexistent not found. Ensure that the workflow exists in the 'workflows' section.`);
       });
+
+      it('fills in meta when it is written without a value', () => {
+        updateBitriseYmlDocumentByString(
+          yaml`
+            workflows:
+              primary:
+                meta:
+                steps: []`,
+        );
+
+        StackAndMachineService.updateStackAndMachine(
+          { stackId: 'osx-xcode-16', machineTypeId: 'mac-m1' },
+          StackAndMachineSource.Workflow,
+          'primary',
+        );
+
+        expect(getYmlString()).toEqual(yaml`
+          workflows:
+            primary:
+              meta:
+                bitrise.io:
+                  stack: osx-xcode-16
+                  machine_type_id: mac-m1
+              steps: []
+        `);
+      });
+
+      it('fills in meta.[bitrise.io] when it is written without a value', () => {
+        updateBitriseYmlDocumentByString(
+          yaml`
+            workflows:
+              primary:
+                meta:
+                  bitrise.io:
+                steps: []`,
+        );
+
+        StackAndMachineService.updateStackAndMachine(
+          { stackId: 'osx-xcode-16', machineTypeId: 'mac-m1' },
+          StackAndMachineSource.Workflow,
+          'primary',
+        );
+
+        expect(getYmlString()).toEqual(yaml`
+          workflows:
+            primary:
+              meta:
+                bitrise.io:
+                  stack: osx-xcode-16
+                  machine_type_id: mac-m1
+              steps: []
+        `);
+      });
+
+      it('writes through a meta block shared via a YAML anchor', () => {
+        updateBitriseYmlDocumentByString(
+          yaml`
+            _meta: &common_meta
+              bitrise.io:
+                stack: osx-xcode-15
+            workflows:
+              primary:
+                meta: *common_meta
+                steps: []`,
+        );
+
+        StackAndMachineService.updateStackAndMachine(
+          { stackId: 'osx-xcode-16', machineTypeId: 'mac-m1' },
+          StackAndMachineSource.Workflow,
+          'primary',
+        );
+
+        expect(getYmlString()).toEqual(yaml`
+          _meta: &common_meta
+            bitrise.io:
+              stack: osx-xcode-16
+              machine_type_id: mac-m1
+          workflows:
+            primary:
+              meta: *common_meta
+              steps: []
+        `);
+      });
     });
   });
 });

--- a/source/javascripts/core/services/StepService.spec.ts
+++ b/source/javascripts/core/services/StepService.spec.ts
@@ -1892,6 +1892,42 @@ describe('StepService', () => {
     });
   });
 
+  describe('aliased step data', () => {
+    it('should edit the anchored inputs instead of replacing the alias with an empty list', () => {
+      updateBitriseYmlDocumentByString(yaml`
+        workflows:
+          base:
+            steps:
+            - script@1:
+                inputs: &common_inputs
+                - content: echo hi
+                - other: 1
+          wf:
+            steps:
+            - script@1:
+                inputs: *common_inputs
+      `);
+
+      StepService.updateStepInput('workflows', 'wf', 0, 'content', 'echo bye');
+
+      // `other: 1` must survive, and `wf` must still reference the anchor. (yaml indents a block
+      // sequence that follows an anchor; that reformatting is unrelated to this edit.)
+      expect(getYmlString()).toEqual(yaml`
+        workflows:
+          base:
+            steps:
+            - script@1:
+                inputs: &common_inputs
+                  - content: echo bye
+                  - other: 1
+          wf:
+            steps:
+            - script@1:
+                inputs: *common_inputs
+      `);
+    });
+  });
+
   describe('getStepOrThrowError', () => {
     it('should resolve a step written as an alias', () => {
       const doc = YmlUtils.toDoc(yaml`

--- a/source/javascripts/core/services/StepService.spec.ts
+++ b/source/javascripts/core/services/StepService.spec.ts
@@ -2,6 +2,7 @@ import { StepApiResult } from '@/core/api/StepApi';
 
 import { BITRISE_STEP_LIBRARY_SSH_URL, BITRISE_STEP_LIBRARY_URL, Step } from '../models/Step';
 import { getYmlString, updateBitriseYmlDocumentByString } from '../stores/BitriseYmlStore';
+import YmlUtils from '../utils/YmlUtils';
 import StepService from './StepService';
 
 jest.mock('@/../images/step/icon-default.svg', () => 'default-icon');
@@ -1887,6 +1888,66 @@ describe('StepService', () => {
       expectErrors(
         [() => StepService.changeStepVersion('workflows', 'primary', 2, '1.2.3')],
         ['Step at index 2 not found in workflows.primary'],
+      );
+    });
+  });
+
+  describe('getStepOrThrowError', () => {
+    it('should resolve a step written as an alias', () => {
+      const doc = YmlUtils.toDoc(yaml`
+        _step: &common_step
+          script@1:
+            inputs:
+            - content: echo hi
+        workflows:
+          primary:
+            steps:
+            - activate-ssh-key@4: {}
+            - *common_step
+      `);
+
+      expect(StepService.getStepOrThrowError('workflows', 'primary', 1, doc).toJSON()).toEqual({
+        'script@1': { inputs: [{ content: 'echo hi' }] },
+      });
+    });
+
+    it('should resolve a workflow written as an alias', () => {
+      const doc = YmlUtils.toDoc(yaml`
+        _workflow: &common_workflow
+          steps:
+          - script@1: {}
+        workflows:
+          primary: *common_workflow
+      `);
+
+      expect(StepService.getStepOrThrowError('workflows', 'primary', 0, doc).toJSON()).toEqual({ 'script@1': {} });
+    });
+
+    it.each([
+      ['a plain string', 'script@1'],
+      ['no value at all', ''],
+      ['an alias with no matching anchor', '*missing_anchor'],
+    ])('should report a step written as %s as a missing step, not as a YAML shape error', (_, stepValue) => {
+      const doc = YmlUtils.toDoc(yaml`
+        workflows:
+          primary:
+            steps:
+            - ${stepValue}
+      `);
+
+      expect(() => StepService.getStepOrThrowError('workflows', 'primary', 0, doc)).toThrow(
+        'Step at index 0 not found in workflows.primary',
+      );
+    });
+
+    it('should report a workflow of an unexpected shape as missing, not as a YAML shape error', () => {
+      const doc = YmlUtils.toDoc(yaml`
+        workflows:
+          primary: some-string
+      `);
+
+      expect(() => StepService.getStepOrThrowError('workflows', 'primary', 0, doc)).toThrow(
+        'workflows.primary not found',
       );
     });
   });

--- a/source/javascripts/core/services/StepService.spec.ts
+++ b/source/javascripts/core/services/StepService.spec.ts
@@ -1940,6 +1940,48 @@ describe('StepService', () => {
       );
     });
 
+    it('should keep move and clone operating on the raw sequence item for an aliased step', () => {
+      const source = yaml`
+        _step: &common_step
+          script@1: {}
+        workflows:
+          primary:
+            steps:
+            - a@1: {}
+            - *common_step
+      `;
+
+      // Moving must relocate the `*common_step` item itself. Reinserting the node it resolves to
+      // would inline the anchored map here and emit a second `&common_step`.
+      updateBitriseYmlDocumentByString(source);
+      StepService.moveStep('workflows', 'primary', 1, 0);
+
+      expect(getYmlString()).toEqual(yaml`
+        _step: &common_step
+          script@1: {}
+        workflows:
+          primary:
+            steps:
+            - *common_step
+            - a@1: {}
+      `);
+
+      // Cloning an alias yields another alias, not a copy of the anchored map.
+      updateBitriseYmlDocumentByString(source);
+      StepService.cloneStep('workflows', 'primary', 1);
+
+      expect(getYmlString()).toEqual(yaml`
+        _step: &common_step
+          script@1: {}
+        workflows:
+          primary:
+            steps:
+            - a@1: {}
+            - *common_step
+            - *common_step
+      `);
+    });
+
     it('should report a workflow of an unexpected shape as missing, not as a YAML shape error', () => {
       const doc = YmlUtils.toDoc(yaml`
         workflows:

--- a/source/javascripts/core/services/StepService.ts
+++ b/source/javascripts/core/services/StepService.ts
@@ -1,6 +1,6 @@
 import { compact, isString, uniq } from 'es-toolkit';
 import semver from 'semver';
-import { Document, isMap, isScalar, YAMLMap } from 'yaml';
+import { Document, isMap, isNode, isScalar, YAMLMap } from 'yaml';
 
 import defaultIcon from '@/../images/step/icon-default.svg';
 import { AlgoliaStepInfo } from '@/core/api/AlgoliaApi';
@@ -438,13 +438,17 @@ function addStep(source: Source, sourceId: string, cvs: string, to: number) {
   });
 }
 
+// `getStepOrThrowError` returns the node an alias resolves to, which is what every *data* edit
+// below wants. The two structural edits are the exception: they rearrange the sequence itself, so
+// they validate through it but move the raw sequence item. Reinserting a resolved node in place of
+// a `*anchor` item would inline the anchored map at the new position and emit a second `&anchor`.
 function moveStep(source: Source, sourceId: string, from: number, to: number) {
   updateBitriseYmlDocument(({ doc }) => {
-    const step = getStepOrThrowError(source, sourceId, from, doc);
-    const steps = YmlUtils.getSeqIn(doc, [source, sourceId, 'steps'], true);
+    getStepOrThrowError(source, sourceId, from, doc);
 
-    steps.items.splice(from, 1);
-    steps.items.splice(to, 0, step);
+    const steps = YmlUtils.getSeqIn(doc, [source, sourceId, 'steps'], true);
+    const [item] = steps.items.splice(from, 1);
+    steps.items.splice(to, 0, item);
 
     return doc;
   });
@@ -452,10 +456,13 @@ function moveStep(source: Source, sourceId: string, from: number, to: number) {
 
 function cloneStep(source: Source, sourceId: string, index: number) {
   updateBitriseYmlDocument(({ doc }) => {
-    const step = getStepOrThrowError(source, sourceId, index, doc);
-    const steps = YmlUtils.getSeqIn(doc, [source, sourceId, 'steps'], true);
+    getStepOrThrowError(source, sourceId, index, doc);
 
-    steps.items.splice(index + 1, 0, step.clone());
+    const steps = YmlUtils.getSeqIn(doc, [source, sourceId, 'steps'], true);
+    const item = steps.items[index];
+
+    // Cloning an alias yields another alias, so the clone stays a reference to the same anchor.
+    steps.items.splice(index + 1, 0, isNode(item) ? item.clone() : item);
 
     return doc;
   });

--- a/source/javascripts/core/services/StepService.ts
+++ b/source/javascripts/core/services/StepService.ts
@@ -400,10 +400,13 @@ export const moveStepIndices = (
   }
 };
 
+// Reads go through `getIn` rather than `getMapIn` so that a node of an unexpected shape (a scalar,
+// or an alias whose anchor is missing) surfaces as this domain-level "not found" instead of the
+// low-level "Expected a YAMLMap at path ..." — every caller below already handles "not found".
 function getSourceOrThrowError(source: Source, sourceId: string, doc: Document) {
-  const entity = YmlUtils.getMapIn(doc, [source, sourceId]);
+  const entity = YmlUtils.getIn(doc, [source, sourceId], true);
 
-  if (!entity) {
+  if (!isMap(entity)) {
     throw new Error(`${source}.${sourceId} not found`);
   }
 
@@ -411,10 +414,13 @@ function getSourceOrThrowError(source: Source, sourceId: string, doc: Document) 
 }
 
 function getStepOrThrowError(source: Source, sourceId: string, stepIndex: number, doc: Document) {
-  const entity = getSourceOrThrowError(source, sourceId, doc);
-  const step = YmlUtils.getMapIn(entity, ['steps', stepIndex]);
+  getSourceOrThrowError(source, sourceId, doc);
 
-  if (!step || !isMap(step)) {
+  // Rooted at the document, not at the workflow map, so an aliased step (`- *some_step`) resolves
+  // against anchors declared anywhere in the file.
+  const step = YmlUtils.getIn(doc, [source, sourceId, 'steps', stepIndex], true);
+
+  if (!isMap(step)) {
     throw new Error(`Step at index ${stepIndex} not found in ${source}.${sourceId}`);
   }
 

--- a/source/javascripts/core/services/TriggerService.spec.ts
+++ b/source/javascripts/core/services/TriggerService.spec.ts
@@ -4,6 +4,31 @@ import { getYmlString, updateBitriseYmlDocumentByString } from '../stores/Bitris
 import TriggerService from './TriggerService';
 
 describe('TriggerService', () => {
+  describe('aliased triggers', () => {
+    it('should add enabled to the anchored triggers instead of dropping the trigger list', () => {
+      updateBitriseYmlDocumentByString(yaml`
+        _triggers: &common_triggers
+          push:
+          - branch: main
+        workflows:
+          wf3:
+            triggers: *common_triggers
+      `);
+
+      TriggerService.updateEnabled(false, { source: 'workflows' as TriggerSource, sourceId: 'wf3' });
+
+      expect(getYmlString()).toEqual(yaml`
+        _triggers: &common_triggers
+          push:
+          - branch: main
+          enabled: false
+        workflows:
+          wf3:
+            triggers: *common_triggers
+      `);
+    });
+  });
+
   describe('Legacy Triggers', () => {
     describe('toLegacyTriggers', () => {
       it('should convert trigger map to legacy triggers', () => {

--- a/source/javascripts/core/services/WorkflowService.spec.ts
+++ b/source/javascripts/core/services/WorkflowService.spec.ts
@@ -4,6 +4,61 @@ import { bitriseYmlStore, getYmlString, updateBitriseYmlDocumentByString } from 
 import WorkflowService from './WorkflowService';
 
 describe('WorkflowService', () => {
+  describe('aliased workflow chains', () => {
+    const source = yaml`
+      _chain: &common_chain
+      - prep
+      workflows:
+        prep: {}
+        extra: {}
+        wf:
+          before_run: *common_chain
+    `;
+
+    it('should read a chain written as an alias rather than treating it as absent', () => {
+      updateBitriseYmlDocumentByString(yaml`
+        _chain: &common_chain
+        - prep
+        - extra
+        workflows:
+          prep: {}
+          extra: {}
+          wf:
+            before_run: *common_chain
+      `);
+
+      // `removeChainedWorkflow` reads the chain first and throws if it looks absent.
+      WorkflowService.removeChainedWorkflow('wf', 'before_run', 'prep', 0);
+
+      expect(getYmlString()).toEqual(yaml`
+        _chain: &common_chain
+          - extra
+        workflows:
+          prep: {}
+          extra: {}
+          wf:
+            before_run: *common_chain
+      `);
+    });
+
+    it('should extend the anchored chain instead of overwriting the alias', () => {
+      updateBitriseYmlDocumentByString(source);
+
+      WorkflowService.setChainedWorkflows('wf', 'before_run', ['prep', 'extra']);
+
+      expect(getYmlString()).toEqual(yaml`
+        _chain: &common_chain
+          - prep
+          - extra
+        workflows:
+          prep: {}
+          extra: {}
+          wf:
+            before_run: *common_chain
+      `);
+    });
+  });
+
   describe('validateName', () => {
     describe('when the initial name is empty', () => {
       it('returns true if workflow name is valid and unique', () => {

--- a/source/javascripts/core/utils/YmlUtils.spec.ts
+++ b/source/javascripts/core/utils/YmlUtils.spec.ts
@@ -885,6 +885,43 @@ describe('YmlUtils', () => {
         'Expected a YAMLSeq at path "workflows.wf1.steps.0", but found YAMLMap',
       );
     });
+
+    it('should resolve an aliased YAMLSeq instead of throwing on the Alias node', () => {
+      const root = YmlUtils.toDoc(yaml`
+        _steps: &common_steps
+        - script@1: {}
+        workflows:
+          wf1:
+            steps: *common_steps
+      `);
+
+      expect(YmlUtils.getSeqIn(root, ['workflows', 'wf1', 'steps'])?.toJSON()).toEqual([{ 'script@1': {} }]);
+    });
+
+    it('should return undefined for a key written without a value', () => {
+      const root = YmlUtils.toDoc(yaml`
+        workflows:
+          wf1:
+            steps:
+      `);
+
+      expect(YmlUtils.getSeqIn(root, ['workflows', 'wf1', 'steps'])).toBeUndefined();
+    });
+
+    it('should create a YAMLSeq over a key written without a value when createIfNotExists is true', () => {
+      const root = YmlUtils.toDoc(yaml`
+        workflows:
+          wf1:
+            steps:
+      `);
+
+      expect(YmlUtils.getSeqIn(root, ['workflows', 'wf1', 'steps'], true)).toBeInstanceOf(YAMLSeq);
+      expect(YmlUtils.toYml(root)).toEqual(yaml`
+        workflows:
+          wf1:
+            steps: []
+      `);
+    });
   });
 
   describe('getMapIn', () => {
@@ -934,6 +971,80 @@ describe('YmlUtils', () => {
       expect(() => YmlUtils.getMapIn(root, ['workflows', 'wf1', 'steps', 0, 'script', 'inputs', 0, 'key'])).toThrow(
         'Expected a YAMLMap at path "workflows.wf1.steps.0.script.inputs.0.key", but found Scalar',
       );
+    });
+
+    it('should resolve an aliased YAMLMap instead of throwing on the Alias node', () => {
+      const root = YmlUtils.toDoc(yaml`
+        _step: &common_step
+          script@1:
+            inputs:
+            - content: echo hi
+        workflows:
+          wf1:
+            steps:
+            - activate-ssh-key@4: {}
+            - *common_step
+      `);
+
+      expect(YmlUtils.getMapIn(root, ['workflows', 'wf1', 'steps', 1])?.toJSON()).toEqual({
+        'script@1': { inputs: [{ content: 'echo hi' }] },
+      });
+    });
+
+    it('should resolve aliases in the middle of the path', () => {
+      const root = YmlUtils.toDoc(yaml`
+        _meta: &common_meta
+          bitrise.io:
+            stack: linux-docker-android-22.04
+        workflows:
+          wf1:
+            meta: *common_meta
+      `);
+
+      expect(YmlUtils.getMapIn(root, ['workflows', 'wf1', 'meta', 'bitrise.io'])?.toJSON()).toEqual({
+        stack: 'linux-docker-android-22.04',
+      });
+    });
+
+    it('should return undefined for an alias whose anchor is missing', () => {
+      const root = YmlUtils.toDoc(yaml`
+        workflows:
+          wf1:
+            meta: *missing_anchor
+      `);
+
+      expect(YmlUtils.getMapIn(root, ['workflows', 'wf1', 'meta'])).toBeUndefined();
+    });
+
+    it('should return undefined for a key written without a value', () => {
+      const root = YmlUtils.toDoc(yaml`
+        workflows:
+          wf1:
+            meta:
+              bitrise.io:
+      `);
+
+      expect(YmlUtils.getMapIn(root, ['workflows', 'wf1', 'meta', 'bitrise.io'])).toBeUndefined();
+    });
+
+    it('should create a YAMLMap over a key written without a value when createIfNotExists is true', () => {
+      const root = YmlUtils.toDoc(yaml`
+        workflows:
+          wf1:
+            meta:
+              bitrise.io:
+      `);
+
+      const meta = YmlUtils.getMapIn(root, ['workflows', 'wf1', 'meta', 'bitrise.io'], true);
+      YmlUtils.setIn(meta, ['stack'], 'linux-docker-android-22.04');
+
+      expect(YmlUtils.toYml(root)).toEqual(yaml`
+        workflows:
+          wf1:
+            meta:
+              bitrise.io:
+                stack: linux-docker-android-22.04
+      `);
     });
   });
 

--- a/source/javascripts/core/utils/YmlUtils.spec.ts
+++ b/source/javascripts/core/utils/YmlUtils.spec.ts
@@ -922,6 +922,46 @@ describe('YmlUtils', () => {
             steps: []
       `);
     });
+
+    it('should create a YAMLSeq inside an anchored parent reached through an alias', () => {
+      const root = YmlUtils.toDoc(yaml`
+        _step: &common_step
+          script@1: {}
+        workflows:
+          wf1:
+            steps:
+            - *common_step
+      `);
+
+      const inputs = YmlUtils.getSeqIn(root, ['workflows', 'wf1', 'steps', 0, 'script@1', 'inputs'], true);
+      YmlUtils.addIn(inputs, [], { content: 'echo hi' });
+
+      // Written into the anchored node, and the `*common_step` reference is left intact.
+      expect(YmlUtils.toYml(root)).toEqual(yaml`
+        _step: &common_step
+          script@1:
+            inputs:
+            - content: echo hi
+        workflows:
+          wf1:
+            steps:
+            - *common_step
+      `);
+    });
+
+    // An anchor pointing at an empty node carries no shared data, so the reference is replaced
+    // locally rather than materialising a collection at the anchor's own location.
+    it('should replace a final-segment alias to an empty node when createIfNotExists is true', () => {
+      const root = YmlUtils.toDoc(yaml`
+        _steps: &common_steps
+        workflows:
+          wf1:
+            steps: *common_steps
+      `);
+
+      expect(YmlUtils.getSeqIn(root, ['workflows', 'wf1', 'steps'], true)).toBeInstanceOf(YAMLSeq);
+      expect(YmlUtils.toJSON(root)).toEqual({ _steps: null, workflows: { wf1: { steps: [] } } });
+    });
   });
 
   describe('getMapIn', () => {
@@ -1044,6 +1084,51 @@ describe('YmlUtils', () => {
             meta:
               bitrise.io:
                 stack: linux-docker-android-22.04
+      `);
+    });
+
+    it('should create a missing key inside an anchored map reached through an alias', () => {
+      const root = YmlUtils.toDoc(yaml`
+        _meta: &common_meta
+          other: 1
+        workflows:
+          wf1:
+            meta: *common_meta
+      `);
+
+      const meta = YmlUtils.getMapIn(root, ['workflows', 'wf1', 'meta', 'bitrise.io'], true);
+      YmlUtils.setIn(meta, ['stack'], 'linux-docker-android-22.04');
+
+      expect(YmlUtils.toYml(root)).toEqual(yaml`
+        _meta: &common_meta
+          other: 1
+          bitrise.io:
+            stack: linux-docker-android-22.04
+        workflows:
+          wf1:
+            meta: *common_meta
+      `);
+    });
+
+    it('should fill in an empty key inside an anchored map reached through an alias', () => {
+      const root = YmlUtils.toDoc(yaml`
+        _meta: &common_meta
+          bitrise.io:
+        workflows:
+          wf1:
+            meta: *common_meta
+      `);
+
+      const meta = YmlUtils.getMapIn(root, ['workflows', 'wf1', 'meta', 'bitrise.io'], true);
+      YmlUtils.setIn(meta, ['stack'], 'linux-docker-android-22.04');
+
+      expect(YmlUtils.toYml(root)).toEqual(yaml`
+        _meta: &common_meta
+          bitrise.io:
+            stack: linux-docker-android-22.04
+        workflows:
+          wf1:
+            meta: *common_meta
       `);
     });
   });
@@ -1251,6 +1336,26 @@ describe('YmlUtils', () => {
           wf1: {}
           wf2: {}
       `);
+    });
+
+    it('should delete through an alias instead of throwing on the native walk', () => {
+      const root = YmlUtils.toDoc(yaml`
+        _steps: &common_steps
+        - script: {}
+        - clone: {}
+        workflows:
+          wf1:
+            steps: *common_steps
+      `);
+
+      YmlUtils.deleteByPath(root, ['workflows', 'wf1', 'steps', 0], ['workflows', 'wf1']);
+
+      // Deleted from the anchored sequence, with the `*common_steps` reference kept.
+      expect(YmlUtils.toJSON(root)).toEqual({
+        _steps: [{ clone: {} }],
+        workflows: { wf1: { steps: [{ clone: {} }] } },
+      });
+      expect(YmlUtils.toYml(root)).toContain('steps: *common_steps');
     });
   });
 

--- a/source/javascripts/core/utils/YmlUtils.spec.ts
+++ b/source/javascripts/core/utils/YmlUtils.spec.ts
@@ -1,4 +1,4 @@
-import { isMap, Scalar, YAMLMap, YAMLSeq } from 'yaml';
+import { isAlias, isMap, Scalar, YAMLMap, YAMLSeq } from 'yaml';
 
 import YmlUtils from './YmlUtils';
 
@@ -698,6 +698,121 @@ describe('YmlUtils', () => {
       `);
 
       expect(() => YmlUtils.setIn(root, [], {})).toThrow('Path cannot be empty when setting a value');
+    });
+  });
+
+  describe('setIn through aliases', () => {
+    it('should replace a last-segment alias locally instead of writing into its anchor', () => {
+      const root = YmlUtils.toDoc(yaml`
+        app:
+          envs:
+          - FOO: &v "x"
+          - BAR: *v
+      `);
+
+      YmlUtils.setIn(root, ['app', 'envs', 1, 'BAR'], 'changed');
+
+      // The anchor keeps its own value and is still declared exactly once.
+      expect(YmlUtils.toYml(root)).toEqual(yaml`
+        app:
+          envs:
+          - FOO: &v "x"
+          - BAR: changed
+      `);
+    });
+
+    it('should write through an alias that is an interior hop of the path', () => {
+      const root = YmlUtils.toDoc(yaml`
+        _meta: &common_meta
+          stack: old
+        workflows:
+          wf1:
+            meta: *common_meta
+      `);
+
+      YmlUtils.setIn(root, ['workflows', 'wf1', 'meta', 'stack'], 'new');
+
+      expect(YmlUtils.toYml(root)).toEqual(yaml`
+        _meta: &common_meta
+          stack: new
+        workflows:
+          wf1:
+            meta: *common_meta
+      `);
+    });
+  });
+
+  describe('nested roots', () => {
+    it('should resolve an alias against the document the nested root came from', () => {
+      const root = YmlUtils.toDoc(yaml`
+        _inputs: &common_inputs
+        - content: echo hi
+        - other: 1
+        workflows:
+          wf1:
+            steps:
+            - script@1:
+                inputs: *common_inputs
+      `);
+
+      // The anchor lives outside this subtree, so resolving against it alone would find nothing.
+      const stepData = YmlUtils.getIn(root, ['workflows', 'wf1', 'steps', 0, 'script@1'], true) as never;
+
+      expect(YmlUtils.getSeqIn(stepData, ['inputs'])?.toJSON()).toEqual([{ content: 'echo hi' }, { other: 1 }]);
+    });
+
+    it('should not replace an aliased collection when createIfNotExists is used on a nested root', () => {
+      const root = YmlUtils.toDoc(yaml`
+        _inputs: &common_inputs
+        - content: echo hi
+        - other: 1
+        workflows:
+          wf1:
+            steps:
+            - script@1:
+                inputs: *common_inputs
+      `);
+
+      const stepData = YmlUtils.getIn(root, ['workflows', 'wf1', 'steps', 0, 'script@1'], true) as never;
+      const inputs = YmlUtils.getSeqIn(stepData, ['inputs'], true);
+
+      // The anchored sequence itself, not a fresh empty one written over the reference.
+      expect(inputs.toJSON()).toEqual([{ content: 'echo hi' }, { other: 1 }]);
+      expect(YmlUtils.toYml(root)).toContain('inputs: *common_inputs');
+    });
+
+    it('should refuse to create over an alias it cannot resolve rather than dropping it', () => {
+      const root = YmlUtils.toDoc(yaml`
+        workflows:
+          wf1:
+            steps:
+            - script@1:
+                inputs: *missing_anchor
+      `);
+
+      const stepData = YmlUtils.getIn(root, ['workflows', 'wf1', 'steps', 0, 'script@1'], true) as never;
+
+      expect(() => YmlUtils.getSeqIn(stepData, ['inputs'], true)).toThrow(
+        'Cannot resolve alias "*missing_anchor" at path "inputs"',
+      );
+
+      // Nothing was written over the reference. Asserted on the node: a document holding a dangling
+      // alias cannot be serialized at all (yaml throws `Unresolved alias`).
+      expect(isAlias(root.getIn(['workflows', 'wf1', 'steps', 0, 'script@1', 'inputs'], true))).toBe(true);
+    });
+
+    it('should stay lenient on the read path for an alias it cannot resolve', () => {
+      const root = YmlUtils.toDoc(yaml`
+        workflows:
+          wf1:
+            steps:
+            - script@1:
+                inputs: *missing_anchor
+      `);
+
+      const stepData = YmlUtils.getIn(root, ['workflows', 'wf1', 'steps', 0, 'script@1'], true) as never;
+
+      expect(YmlUtils.getSeqIn(stepData, ['inputs'])).toBeUndefined();
     });
   });
 

--- a/source/javascripts/core/utils/YmlUtils.ts
+++ b/source/javascripts/core/utils/YmlUtils.ts
@@ -287,6 +287,51 @@ function getIn(root: Root, path: Path, keepScalar = false) {
   return !keepScalar && isScalar(node) ? node.value : node;
 }
 
+/**
+ * yaml's own `setIn`/`deleteIn` walk the path with native traversal, which stops at an alias node:
+ * writing to or deleting a path that passes *through* `*anchor` throws "Expected YAML collection at
+ * <key>". This finds the anchored collection that blocks such a walk and returns it as a new root
+ * plus the rest of the path, so the caller can retry against a path that is alias-free at that hop.
+ * Writing there is writing to the anchored node — the same node the CLI and `toJSON()` see through
+ * the alias, and shared with every other alias pointing at it.
+ *
+ * Returns `undefined` when the path needs no re-rooting: no alias blocks it, or the alias resolves
+ * to something that isn't a collection (left to the native call to report).
+ */
+function rebaseThroughAlias(root: Root, path: Path) {
+  let current: unknown = isDocument(root) ? root.contents : root;
+
+  // Only interior segments matter; the final segment is assigned/deleted on its parent, and an
+  // alias sitting there is simply the value being replaced.
+  for (let i = 0; i < path.length - 1; i += 1) {
+    if (!isCollection(current)) {
+      return undefined;
+    }
+
+    const child = current.get(path[i], true);
+
+    if (isAlias(child)) {
+      const resolved = resolveAlias(root, child);
+      return isCollection(resolved) ? { root: resolved, path: path.slice(i + 1) } : undefined;
+    }
+
+    current = child;
+  }
+
+  return undefined;
+}
+
+/** `Collection.deleteIn`, retried through any alias that blocks the native walk. */
+function deleteIn(root: Root, path: Path): boolean {
+  const rebased = rebaseThroughAlias(root, path);
+
+  if (rebased) {
+    return deleteIn(rebased.root, rebased.path);
+  }
+
+  return (isDocument(root) || isCollection(root)) && root.deleteIn(path);
+}
+
 function setIn(root: Root, path: Path, value: unknown, stringToTypedValue = true) {
   if (!isDocument(root) && !isCollection(root)) {
     throw new Error('Root node must be a YAML Document or YAML Collection');
@@ -298,6 +343,12 @@ function setIn(root: Root, path: Path, value: unknown, stringToTypedValue = true
 
   if (isEmpty(path)) {
     throw new Error('Path cannot be empty when setting a value');
+  }
+
+  const rebased = rebaseThroughAlias(root, path);
+  if (rebased) {
+    setIn(rebased.root, rebased.path, value, stringToTypedValue);
+    return;
   }
 
   // An empty document has no usable root collection, so a nested `setIn` throws "Expected a YAML
@@ -573,7 +624,7 @@ function deleteByPath(root: Root, path: WildcardPath, keep: WildcardPath = [], c
   }
 
   const deletedNode = getIn(root, path, true);
-  if (isNode(deletedNode) && root.deleteIn(path)) {
+  if (isNode(deletedNode) && deleteIn(root, path)) {
     cb?.(deletedNode, path);
   }
 

--- a/source/javascripts/core/utils/YmlUtils.ts
+++ b/source/javascripts/core/utils/YmlUtils.ts
@@ -219,6 +219,47 @@ function unflowEmptyCollection(node: unknown) {
 // document before mutating it, and nothing in the editor creates or moves an anchor.
 const anchorLookupCache = new WeakMap<Root, Node[]>();
 
+// Most callers hand these helpers a nested collection (a workflow, a step's option map) rather than
+// the document, but an anchor is declared at the document level — outside that subtree. Resolving
+// against the subtree alone would report a perfectly valid `*anchor` as absent, and on a
+// `createIfNotExists` path that means overwriting the alias and dropping the data it points at.
+//
+// So remember which document a node came from. A nested root is always obtained by reading from the
+// document first (there is no other way to get hold of it), so indexing a document the first time it
+// is used as a root always happens before any nested call that needs it.
+const documentByNode = new WeakMap<Node, Document>();
+const indexedDocuments = new WeakSet<Document>();
+
+// One walk per document version, seeding both indexes at once. On a 12k-line config that is ~20ms,
+// paid once when the document is first read from — reads after it are unaffected.
+function trackDocument(root: Root) {
+  if (!isDocument(root) || indexedDocuments.has(root)) {
+    return;
+  }
+
+  indexedDocuments.add(root);
+
+  const anchored: Node[] = [];
+  visit(root, {
+    Node(_, node) {
+      documentByNode.set(node, root);
+      if (isAlias(node) || node.anchor) {
+        anchored.push(node);
+      }
+    },
+  });
+  anchorLookupCache.set(root, anchored);
+}
+
+/** The document `root` belongs to, falling back to `root` itself when the owner isn't known. */
+function aliasScope(root: Root): Root {
+  if (isDocument(root)) {
+    return root;
+  }
+
+  return documentByNode.get(root) ?? root;
+}
+
 function anchorLookupNodes(root: Root) {
   const cached = anchorLookupCache.get(root);
   if (cached) {
@@ -250,7 +291,7 @@ function resolveAlias(root: Root, node: unknown) {
   }
 
   let resolved: unknown;
-  for (const candidate of anchorLookupNodes(root)) {
+  for (const candidate of anchorLookupNodes(aliasScope(root))) {
     if (candidate === node) {
       break;
     }
@@ -262,6 +303,10 @@ function resolveAlias(root: Root, node: unknown) {
   return resolved;
 }
 
+function rootCollection(root: Root) {
+  return resolveAlias(root, isDocument(root) ? root.contents : root);
+}
+
 function getIn(root: Root, path: Path, keepScalar = false) {
   if (!isDocument(root) && !isCollection(root)) {
     throw new Error('Root node must be a YAML Document or YAML Collection');
@@ -271,11 +316,13 @@ function getIn(root: Root, path: Path, keepScalar = false) {
     throw new Error('Path cannot contain wildcards when getting a value');
   }
 
+  trackDocument(root);
+
   if (isEmpty(path)) {
     return root;
   }
 
-  let node = resolveAlias(root, isDocument(root) ? root.contents : root);
+  let node = rootCollection(root);
 
   for (let i = 0; i < path.length; i += 1) {
     if (!isCollection(node)) {
@@ -285,6 +332,18 @@ function getIn(root: Root, path: Path, keepScalar = false) {
   }
 
   return !keepScalar && isScalar(node) ? node.value : node;
+}
+
+/**
+ * The node stored at `path`, with an alias in the *final* segment left unresolved — `getIn` resolves
+ * it, which is what reading a value wants, but not what "what is written here?" wants. A last-segment
+ * alias is the value being replaced or refused, never a hop on the way to a deeper key.
+ */
+function getRawIn(root: Root, path: Path) {
+  const parentPath = path.slice(0, -1);
+  const parent = isEmpty(parentPath) ? rootCollection(root) : getIn(root, parentPath, true);
+
+  return isCollection(parent) ? parent.get(path[path.length - 1], true) : undefined;
 }
 
 /**
@@ -299,7 +358,7 @@ function getIn(root: Root, path: Path, keepScalar = false) {
  * to something that isn't a collection (left to the native call to report).
  */
 function rebaseThroughAlias(root: Root, path: Path) {
-  let current: unknown = isDocument(root) ? root.contents : root;
+  let current: unknown = rootCollection(root);
 
   // Only interior segments matter; the final segment is assigned/deleted on its parent, and an
   // alias sitting there is simply the value being replaced.
@@ -381,7 +440,12 @@ function setIn(root: Root, path: Path, value: unknown, stringToTypedValue = true
 
   unflowEmptyCollection(getIn(root, parentPath));
 
-  const existingNode = getIn(root, path, true);
+  // Read alias-blind: `toScalar` reuses the node it is handed by mutating it in place, so reusing
+  // the node an alias resolves to would rewrite the anchor's own value — corrupting every other
+  // reference to it — and then seat that same node at the alias position, declaring the anchor
+  // twice. A last-segment alias is the value being replaced; there is nothing here to carry over.
+  const rawNode = getRawIn(root, path);
+  const existingNode = isAlias(rawNode) ? undefined : rawNode;
   const valueToWrite = stringToTypedValue ? toTypedValue(value) : value;
 
   if (isPrimitive(valueToWrite)) {
@@ -533,6 +597,25 @@ function isEmptyNode(node: unknown) {
   return isNil(node) || (isScalar(node) && isNil(node.value));
 }
 
+/**
+ * Guards the `createIfNotExists` branch. An alias whose anchor cannot be found reads as "absent", but
+ * creating a collection over it would delete whatever that anchor points at — silent data loss, and a
+ * far worse outcome than the error the caller used to get. "Can't handle" is not "absent", so say so.
+ *
+ * An alias that *does* resolve, to an empty node, is a different story: there is no data behind it to
+ * lose, so it falls through and the reference is replaced locally.
+ *
+ * Reads stay lenient (`undefined`) because they run during render, where throwing takes down the
+ * page. Only the write path refuses, and it always runs inside a mutation.
+ */
+function assertResolvableBeforeCreate(root: Root, path: Path) {
+  const rawNode = getRawIn(root, path);
+
+  if (isAlias(rawNode) && resolveAlias(root, rawNode) === undefined) {
+    throw new Error(`Cannot resolve alias "*${rawNode.source}" at path "${path.join('.')}"`);
+  }
+}
+
 function getSeqIn(root: Root, path: Path): YAMLSeq | undefined;
 function getSeqIn(root: Root, path: Path, createIfNotExists: true): YAMLSeq;
 function getSeqIn(root: Root, path: Path, createIfNotExists?: boolean): YAMLSeq | undefined;
@@ -552,6 +635,7 @@ function getSeqIn(root: Root, path: Path, createIfNotExists = false) {
       return undefined;
     }
 
+    assertResolvableBeforeCreate(root, path);
     setIn(root, path, new YAMLSeq());
     node = getIn(root, path, true);
   }
@@ -582,6 +666,7 @@ function getMapIn(root: Root, path: Path, createIfNotExists = false) {
       return undefined;
     }
 
+    assertResolvableBeforeCreate(root, path);
     setIn(root, path, new YAMLMap());
     node = getIn(root, path, true);
   }

--- a/source/javascripts/core/utils/YmlUtils.ts
+++ b/source/javascripts/core/utils/YmlUtils.ts
@@ -4,6 +4,7 @@ import { isEqual, isNil, isPrimitive } from 'es-toolkit';
 import { isEmpty } from 'es-toolkit/compat';
 import {
   Document,
+  isAlias,
   isCollection,
   isDocument,
   isMap,
@@ -208,6 +209,59 @@ function unflowEmptyCollection(node: unknown) {
   }
 }
 
+// yaml's own `getIn`/`hasIn` stop at an alias node (`*anchor`) because an alias is not a collection,
+// while `toJSON()` — what the UI renders from — expands aliases. The two views of the same document
+// then disagree: the UI shows the aliased workflow/step/meta block, but every document-level read of
+// it hands back the raw `Alias`, so callers expecting a map or a seq blow up on YAML the CLI accepts.
+// Resolving aliases while walking a path keeps both views on the same data.
+//
+// Cached per root object, like `collectPaths`: safe because `updateBitriseYmlDocument` clones the
+// document before mutating it, and nothing in the editor creates or moves an anchor.
+const anchorLookupCache = new WeakMap<Root, Node[]>();
+
+function anchorLookupNodes(root: Root) {
+  const cached = anchorLookupCache.get(root);
+  if (cached) {
+    return cached;
+  }
+
+  const nodes: Node[] = [];
+  visit(root, {
+    Node(_, node) {
+      if (isAlias(node) || node.anchor) {
+        nodes.push(node);
+      }
+    },
+  });
+  anchorLookupCache.set(root, nodes);
+
+  return nodes;
+}
+
+/**
+ * Resolves an alias node to the node its anchor is declared on — the last matching anchor before the
+ * alias, as YAML defines it. Returns `node` unchanged when it isn't an alias, and `undefined` when
+ * the anchor isn't reachable from `root`: a dangling alias, or an anchor declared outside `root`
+ * when `root` is a nested collection rather than the whole document.
+ */
+function resolveAlias(root: Root, node: unknown) {
+  if (!isAlias(node)) {
+    return node;
+  }
+
+  let resolved: unknown;
+  for (const candidate of anchorLookupNodes(root)) {
+    if (candidate === node) {
+      break;
+    }
+    if (candidate.anchor === node.source) {
+      resolved = candidate;
+    }
+  }
+
+  return resolved;
+}
+
 function getIn(root: Root, path: Path, keepScalar = false) {
   if (!isDocument(root) && !isCollection(root)) {
     throw new Error('Root node must be a YAML Document or YAML Collection');
@@ -221,23 +275,16 @@ function getIn(root: Root, path: Path, keepScalar = false) {
     return root;
   }
 
-  return root.getIn(path, keepScalar);
-}
+  let node = resolveAlias(root, isDocument(root) ? root.contents : root);
 
-function hasIn(root: Root, path: Path) {
-  if (!isDocument(root) && !isCollection(root)) {
-    throw new Error('Root node must be a YAML Document or YAML Collection');
+  for (let i = 0; i < path.length; i += 1) {
+    if (!isCollection(node)) {
+      return undefined;
+    }
+    node = resolveAlias(root, node.get(path[i], true));
   }
 
-  if (isWildcardPath(path)) {
-    throw new Error('Path cannot contain wildcards when checking for existence');
-  }
-
-  if (isEmpty(path)) {
-    return true;
-  }
-
-  return root.hasIn(path);
+  return !keepScalar && isScalar(node) ? node.value : node;
 }
 
 function setIn(root: Root, path: Path, value: unknown, stringToTypedValue = true) {
@@ -426,6 +473,15 @@ function isEqualValues(a: unknown, b: unknown) {
   return isEqual(isNode(a) ? toJSON(a) : a, isNode(b) ? toJSON(b) : b);
 }
 
+/**
+ * Whether a path holds nothing to read. A key written without a value (`meta:` on its own line, or a
+ * bare `-` seq item) parses to a null scalar rather than to a missing key, so the key looks present
+ * while there is no collection there. Both shapes mean "absent" to the collection getters.
+ */
+function isEmptyNode(node: unknown) {
+  return isNil(node) || (isScalar(node) && isNil(node.value));
+}
+
 function getSeqIn(root: Root, path: Path): YAMLSeq | undefined;
 function getSeqIn(root: Root, path: Path, createIfNotExists: true): YAMLSeq;
 function getSeqIn(root: Root, path: Path, createIfNotExists?: boolean): YAMLSeq | undefined;
@@ -438,15 +494,16 @@ function getSeqIn(root: Root, path: Path, createIfNotExists = false) {
     throw new Error('Path cannot contain wildcards when getting a YAMLSeq');
   }
 
-  if (!hasIn(root, path) && !createIfNotExists) {
-    return undefined;
-  }
+  let node = getIn(root, path, true);
 
-  if (!hasIn(root, path) && createIfNotExists) {
+  if (isEmptyNode(node)) {
+    if (!createIfNotExists) {
+      return undefined;
+    }
+
     setIn(root, path, new YAMLSeq());
+    node = getIn(root, path, true);
   }
-
-  const node = getIn(root, path, true);
 
   if (!isSeq(node)) {
     throw new Error(`Expected a YAMLSeq at path "${path.join('.')}", but found ${node?.constructor.name}`);
@@ -467,15 +524,16 @@ function getMapIn(root: Root, path: Path, createIfNotExists = false) {
     throw new Error('Path cannot contain wildcards when getting a YAMLMap');
   }
 
-  if (!root.hasIn(path) && !createIfNotExists) {
-    return undefined;
-  }
+  let node = getIn(root, path, true);
 
-  if (!root.hasIn(path) && createIfNotExists) {
+  if (isEmptyNode(node)) {
+    if (!createIfNotExists) {
+      return undefined;
+    }
+
     setIn(root, path, new YAMLMap());
+    node = getIn(root, path, true);
   }
-
-  const node = getIn(root, path, true);
 
   if (!isMap(node)) {
     throw new Error(`Expected a YAMLMap at path "${path.join('.')}", but found ${node?.constructor.name}`);
@@ -668,8 +726,10 @@ export default {
   isEqualValues,
   addIn,
   setIn,
+  getIn,
   getSeqIn,
   getMapIn,
+  resolveAlias,
   isInSeq,
   deleteByPath,
   deleteByValue,

--- a/source/javascripts/main.tsx
+++ b/source/javascripts/main.tsx
@@ -65,8 +65,29 @@ const DefaultQueryClient = new QueryClient({
   },
 });
 
+// The fallback resets the boundary so a transient render error doesn't leave the whole editor
+// blanked out. A *deterministic* one re-throws on the very next render though, and resetting again
+// spins that into an unbounded render loop that re-reports the same error to RUM thousands of times
+// in a single session. Give up after a few immediate retries and stay in the fallback instead; the
+// errors still reach RUM, but once per occurrence rather than as a storm.
+const MAX_IMMEDIATE_RESETS = 3;
+const IMMEDIATE_RESET_WINDOW_MS = 1000;
+
+// Module scope on purpose: the fallback unmounts on every successful reset, so component state
+// cannot see how many times it has already retried.
+let immediateResets = 0;
+let lastResetAt = 0;
+
 const PassThroughFallback: ComponentProps<typeof ErrorBoundary>['fallback'] = ({ resetError }) => {
   useEffect(() => {
+    const now = Date.now();
+    immediateResets = now - lastResetAt < IMMEDIATE_RESET_WINDOW_MS ? immediateResets + 1 : 1;
+    lastResetAt = now;
+
+    if (immediateResets > MAX_IMMEDIATE_RESETS) {
+      return;
+    }
+
     resetError();
   }, [resetError]);
 


### PR DESCRIPTION
### Root cause

`YmlUtils.getMapIn`/`getSeqIn` threw `Expected a YAMLMap/YAMLSeq at path "..."` for two shapes of perfectly loadable `bitrise.yml`. Both reported message variants reproduce exactly:

1. **YAML anchors/aliases.** `Document.getIn`/`hasIn` stop at an `Alias` node because an alias is not a collection, while `toJSON()` — what the UI renders from — expands aliases. So the UI renders a step written as `- *common_step`, but every document-level read of it hands back the raw `Alias`, which the collection getters reject. Reproduces `Expected a YAMLMap at path "steps.2", but found Alias`.
2. **A key written with no value** (`meta:` / `bitrise.io:` on its own line, a bare `-` seq item) parses to a *null scalar*, not to a missing key — so `hasIn` said "present" while there was nothing to return, and even `createIfNotExists: true` threw instead of filling it in. Reproduces `Expected a YAMLMap at path "workflows.<wf>.meta.bitrise.io", but found Scalar` (from `StackAndMachineService.updateFieldValue`).

The throw happens on a render path (`StepCard` → `useContainerReferences` → `ContainerService` → `StepService.getStepOrThrowError` → `getMapIn`), so it took the whole editor down instead of degrading one card.

**Why one session produced ~27.8k occurrences:** the root `ErrorBoundary`'s `PassThroughFallback` called `resetError()` unconditionally in an effect. A *deterministic* render error re-throws on the very next render, gets caught, resets again — an unbounded reset/render loop, each iteration re-reporting to RUM. That is the amplifier, and it would amplify any future render-time throw.

### Fix

- `YmlUtils.getIn` resolves aliases at every hop of the path (last matching anchor declared before the alias — YAML's own rule). Anchor list cached per root object, same pattern/caveat as `collectPaths`. Zero cost when no alias is present.
- `getMapIn`/`getSeqIn` treat a null-valued key as absent: `undefined` on a plain read; with `createIfNotExists` they fill the collection in rather than throwing.
- `StepService.getSourceOrThrowError`/`getStepOrThrowError` read via `getIn` and raise their own "not found" instead of surfacing the low-level YAML shape error. The step lookup is rooted at the document so an aliased step resolves against anchors anywhere in the file.
- `ContainerService.getContainerReferenceFromInstance` uses a new read-only `findStepData` — neither throws nor materializes a missing option map (the old path mutated the store's document during render). `parseContainerReference` returns `undefined` for a reference naming no container; a non-sequence `service_containers` is skipped instead of thrown on. Reporting malformed YAML is the validator's job, not a render read's.
- `PassThroughFallback` gives up after 3 resets inside a 1s window. Terminal state is the same blank fallback the loop already produced, minus the storm.

### Tests

+24 tests across `YmlUtils.spec`, `StepService.spec`, `ContainerService.spec`, `StackAndMachineService.spec`: alias-at-step / alias-at-workflow / alias mid-path / dangling alias / empty node (read + create) / plain-string step / empty container reference / non-sequence `service_containers`. Full suite green: **1512 passed, 40 suites**; `tsc --noEmit` clean; eslint clean (only 7 pre-existing warnings); `knip` output byte-identical to master.

Two existing `ContainerService` tests that asserted `getContainerReferenceFromInstance` **throws** for a missing step index now assert it returns `undefined` — that function runs during render and must not throw. That is the one intentional behavior change to flag for review.

### Assumptions / decisions worth a reviewer's eye

- **Writing through an alias mutates the anchor target** (shared by every other alias user). That is what YAML means, and it round-trips losslessly (there is a test asserting the `*common_meta` alias survives a stack change). The alternative — deep-copying on write — is a bigger product decision I did not make unilaterally.
- **Out of scope, flagged not fixed:** an alias with *no matching anchor* makes the document unserializable — `doc.toString()` and `doc.toJSON()` both throw `ReferenceError: Unresolved alias`, so `YmlUtils.toYml`/`isEquals`/`toJSON` and the store subscriber crash. Different error signature, different Datadog issue, and the backend rejects such a config anyway; typing `*foo` before `&foo` in the YML editor would hit it. Worth a follow-up ticket.