### PR TITLE
fix(config-merge): position conflict markers by merged-output line

### DIFF
--- a/source/javascripts/components/ConfigMergeDialog/ConfigMergeDialog.tsx
+++ b/source/javascripts/components/ConfigMergeDialog/ConfigMergeDialog.tsx
@@ -11,12 +11,10 @@ import {
   Text,
   Tooltip,
 } from '@bitrise/bitkit';
-import { DiffEditor, DiffEditorProps, MonacoDiffEditor } from '@monaco-editor/react';
+import { DiffEditor, MonacoDiffEditor } from '@monaco-editor/react';
 import { useQuery } from '@tanstack/react-query';
 import { ModalCloseButton, ModalHeader } from 'chakra-ui-2--react';
 import { toMerged } from 'es-toolkit';
-import type { editor } from 'monaco-editor';
-import { diff3Merge } from 'node-diff3';
 import { useRef, useState } from 'react';
 import { useEventListener } from 'usehooks-ts';
 
@@ -34,85 +32,12 @@ import useCurrentPage from '@/hooks/useCurrentPage';
 import useModelValidationStatus from '@/hooks/useModelValidationStatus';
 
 import YmlValidationBadge from '../YmlValidationBadge';
+import { diffEditorOptions, mergeYamls, readOnlyDiffEditorOptions } from './mergeYamls';
 
 type Props = Omit<DialogProps, 'title'> & {
   targetBranch: string;
   isNewTargetBranch: boolean;
 };
-
-const diffEditorOptions: DiffEditorProps['options'] = {
-  diffWordWrap: 'off',
-  automaticLayout: true,
-  roundedSelection: false,
-  renderSideBySide: false,
-  renderGutterMenu: false,
-  renderWhitespace: 'all',
-  ignoreTrimWhitespace: false,
-  padding: {
-    top: 16,
-    bottom: 16,
-  },
-  hideUnchangedRegions: {
-    enabled: true,
-  },
-};
-
-const readOnlyDiffEditorOptions: DiffEditorProps['options'] = {
-  ...diffEditorOptions,
-  readOnly: true,
-};
-
-function mergeYamls(yourYaml: string, baseYaml: string, remoteYaml: string) {
-  const rows: string[] = [];
-  const decorations: editor.IModelDeltaDecoration[] = [];
-
-  diff3Merge<string>(yourYaml, baseYaml, remoteYaml, {
-    stringSeparator: '\n',
-  }).forEach((region) => {
-    if (region.ok) {
-      rows.push(...region.ok);
-    } else if (region.conflict) {
-      rows.push(...region.conflict.b);
-
-      const remoteChangeIsADeletion = region.conflict.b.length === 0;
-
-      if (remoteChangeIsADeletion) {
-        decorations.push({
-          options: {
-            isWholeLine: false,
-            blockClassName: 'conflict',
-          },
-          range: {
-            startLineNumber: region.conflict.oIndex + 1,
-            startColumn: 1,
-            endLineNumber: region.conflict.oIndex + 1,
-            endColumn: 1,
-          },
-        });
-      }
-
-      if (!remoteChangeIsADeletion) {
-        decorations.push({
-          options: {
-            isWholeLine: true,
-            blockClassName: 'conflict',
-          },
-          range: {
-            startLineNumber: region.conflict.bIndex + 1,
-            startColumn: 1,
-            endLineNumber: region.conflict.bIndex + region.conflict.b.length,
-            endColumn: 1,
-          },
-        });
-      }
-    }
-  });
-
-  return {
-    decorations,
-    mergedYml: rows.join('\n'),
-  };
-}
 
 function useInitialCiConfigs() {
   const projectSlug = PageProps.appSlug();

--- a/source/javascripts/components/ConfigMergeDialog/mergeYamls.spec.ts
+++ b/source/javascripts/components/ConfigMergeDialog/mergeYamls.spec.ts
@@ -26,13 +26,10 @@ describe('mergeYamls', () => {
   });
 
   it('positions each conflict decoration by merged-output line, not input index', () => {
-    // Two overlapping changes with a clean local insertion between them. The
-    // insertion is what makes this bite: it pushes the merged output past the
-    // remote input, so `bIndex` and the output line stop agreeing. With
-    // equal-length inputs they coincide and the bug hides.
-    // Merged output is 6 lines and the second conflict is on line 6 ('dR'); the
-    // old bIndex-based code marked line 4, which is 'NEW2' — your own text — and
-    // left the real conflict unmarked.
+    // The clean local insertion is what makes this bite: it pushes the merged output past
+    // the remote input, so `bIndex` and the output line stop agreeing (with equal-length
+    // inputs they coincide and the bug hides). Second conflict is output line 6, 'dR';
+    // `bIndex` marked line 4 — 'NEW2', your own text — and left the real one unmarked.
     const base = 'a\nb\nc\nd\n';
     const yours = 'aY\nb\nNEW1\nNEW2\nc\ndY\n';
     const remote = 'aR\nb\nc\ndR\n';
@@ -45,12 +42,9 @@ describe('mergeYamls', () => {
   });
 
   it('marks the gap a remote deletion left, positioned by merged-output line', () => {
-    // Remote drops the line you changed, so the conflict resolves to an empty region:
-    // no output line to outline, only the gap it left. A clean local insertion above it
-    // pushes the output past the base, so an input-index anchor drifts.
-    // Merged output is 6 lines and 'c' was removed from between 'b' (line 4) and 'd'
-    // (line 5), so the gap is the top edge of line 5. Anchoring a line earlier gives 4,
-    // a full line too high; anchoring on oIndex gives 3, which is 'NEW2' — your text.
+    // Remote drops the line you changed: no output line to outline, only the gap it left.
+    // 'c' went from between 'b' (line 4) and 'd' (line 5), so the gap is line 5's top edge.
+    // A line earlier gives 4, a full line too high; `oIndex` gives 3 — 'NEW2', your text.
     const base = 'a\nb\nc\nd\n';
     const yours = 'a\nNEW1\nNEW2\nb\ncY\nd\n';
     const remote = 'a\nb\nd\n';
@@ -65,25 +59,10 @@ describe('mergeYamls', () => {
     expect(decorations[0].range.endLineNumber).toBe(5);
   });
 
-  it('anchors a deletion at the top of the file to line 1', () => {
-    // The gap sits above the first output line, and the top edge of line 1 is that
-    // gap — the lower bound falls out of the anchor, with nothing left to clamp.
-    const base = 'a\nb\n';
-    const yours = 'aY\nb\n';
-    const remote = 'b\n';
-
-    const { decorations } = mergeYamls(yours, base, remote);
-
-    expect(decorations).toHaveLength(1);
-    expect(decorations[0].range.startLineNumber).toBe(1);
-    expect(decorations[0].range.endLineNumber).toBe(1);
-  });
-
   it('renders a trailing deletion after the last line, not above it', () => {
-    // Nothing follows the removed tail, so the gap is below the 1-line output. Left as an
-    // out-of-range line 2, Monaco would pull the range back to line 1 and — block decorations
-    // positioning from `startLineNumber` alone — draw it at that line's TOP edge, above the
-    // surviving 'a' rather than after it. `blockIsAfterEnd` on the last line is the bottom edge.
+    // Nothing follows the removed tail, so the gap is below the 1-line output. Left at the
+    // out-of-range line 2, Monaco pulls it back to line 1 and draws it at that line's TOP
+    // edge — above the surviving 'a'. `blockIsAfterEnd` is the bottom edge instead.
     const base = 'a\nb';
     const yours = 'a\nbY';
     const remote = 'a';

--- a/source/javascripts/components/ConfigMergeDialog/mergeYamls.spec.ts
+++ b/source/javascripts/components/ConfigMergeDialog/mergeYamls.spec.ts
@@ -79,10 +79,11 @@ describe('mergeYamls', () => {
     expect(decorations[0].range.endLineNumber).toBe(1);
   });
 
-  it('anchors a trailing deletion past the last line when there is no final newline', () => {
-    // Nothing follows the removed tail, so the gap is one line past the 1-line output.
-    // Monaco clamps an out-of-range decoration to the model's last line rather than
-    // dropping it, landing the marker at the end of the file — where the tail was.
+  it('renders a trailing deletion after the last line, not above it', () => {
+    // Nothing follows the removed tail, so the gap is below the 1-line output. Left as an
+    // out-of-range line 2, Monaco would pull the range back to line 1 and — block decorations
+    // positioning from `startLineNumber` alone — draw it at that line's TOP edge, above the
+    // surviving 'a' rather than after it. `blockIsAfterEnd` on the last line is the bottom edge.
     const base = 'a\nb';
     const yours = 'a\nbY';
     const remote = 'a';
@@ -91,6 +92,22 @@ describe('mergeYamls', () => {
 
     expect(mergedYml).toBe('a');
     expect(decorations).toHaveLength(1);
+    expect(decorations[0].options.blockIsAfterEnd).toBe(true);
+    expect(decorations[0].range.startLineNumber).toBe(1);
+    expect(decorations[0].range.endLineNumber).toBe(1);
+  });
+
+  it('keeps a mid-file deletion on the top edge, without blockIsAfterEnd', () => {
+    // The counterpart to the case above: a gap with output lines after it is the top edge of
+    // the following line, so the bottom-edge opt-in must NOT leak onto every deletion.
+    const base = 'a\nb\nc\n';
+    const yours = 'a\nbY\nc\n';
+    const remote = 'a\nc\n';
+
+    const { decorations } = mergeYamls(yours, base, remote);
+
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].options.blockIsAfterEnd).toBeUndefined();
     expect(decorations[0].range.startLineNumber).toBe(2);
   });
 

--- a/source/javascripts/components/ConfigMergeDialog/mergeYamls.spec.ts
+++ b/source/javascripts/components/ConfigMergeDialog/mergeYamls.spec.ts
@@ -41,6 +41,36 @@ describe('mergeYamls', () => {
     expect(startLines).toEqual([1, 3]);
   });
 
+  it('marks the boundary line when the remote deleted lines you had edited', () => {
+    // Remote drops the middle line you changed, so the conflict resolves to an
+    // empty region: there is no output line to outline, only the gap it left.
+    const base = 'a\nb\nc\n';
+    const yours = 'a\nbY\nc\n';
+    const remote = 'a\nc\n';
+
+    const { mergedYml, decorations } = mergeYamls(yours, base, remote);
+
+    expect(mergedYml).toBe('a\nc\n');
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].options.isWholeLine).toBe(false);
+    expect(decorations[0].options.blockClassName).toBe('conflict');
+    expect(decorations[0].range.startLineNumber).toBe(1);
+  });
+
+  it('clamps a deletion at the top of the file to line 1', () => {
+    // The gap sits above the first output line, so the unclamped boundary would
+    // be line 0 — not a line Monaco can decorate.
+    const base = 'a\nb\n';
+    const yours = 'aY\nb\n';
+    const remote = 'b\n';
+
+    const { decorations } = mergeYamls(yours, base, remote);
+
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].range.startLineNumber).toBe(1);
+    expect(decorations[0].range.endLineNumber).toBe(1);
+  });
+
   it('returns the input unchanged when nothing differs', () => {
     const yaml = 'a: 1\nb: 2\n';
     const { mergedYml, decorations } = mergeYamls(yaml, yaml, yaml);

--- a/source/javascripts/components/ConfigMergeDialog/mergeYamls.spec.ts
+++ b/source/javascripts/components/ConfigMergeDialog/mergeYamls.spec.ts
@@ -26,19 +26,22 @@ describe('mergeYamls', () => {
   });
 
   it('positions each conflict decoration by merged-output line, not input index', () => {
-    // Two separate overlapping changes with an unchanged line between them, so the
-    // merge emits: conflict(line 1), ok(line 2), conflict(line 3). The second
-    // conflict must be marked at output line 3 — the old bIndex-based code put it
-    // elsewhere.
-    const base = 'a\nKEEP\nd\n';
-    const yours = 'aY\nKEEP\ndY\n';
-    const remote = 'aR\nKEEP\ndR\n';
+    // Two overlapping changes with a clean local insertion between them. The
+    // insertion is what makes this bite: it pushes the merged output past the
+    // remote input, so `bIndex` and the output line stop agreeing. With
+    // equal-length inputs they coincide and the bug hides.
+    // Merged output is 6 lines and the second conflict is on line 6 ('dR'); the
+    // old bIndex-based code marked line 4, which is 'NEW2' — your own text — and
+    // left the real conflict unmarked.
+    const base = 'a\nb\nc\nd\n';
+    const yours = 'aY\nb\nNEW1\nNEW2\nc\ndY\n';
+    const remote = 'aR\nb\nc\ndR\n';
 
     const { mergedYml, decorations } = mergeYamls(yours, base, remote);
 
-    expect(mergedYml).toBe('aR\nKEEP\ndR\n');
+    expect(mergedYml).toBe('aR\nb\nNEW1\nNEW2\nc\ndR\n');
     const startLines = decorations.map((d) => d.range.startLineNumber).sort((x, y) => x - y);
-    expect(startLines).toEqual([1, 3]);
+    expect(startLines).toEqual([1, 6]);
   });
 
   it('marks the boundary line when the remote deleted lines you had edited', () => {

--- a/source/javascripts/components/ConfigMergeDialog/mergeYamls.spec.ts
+++ b/source/javascripts/components/ConfigMergeDialog/mergeYamls.spec.ts
@@ -44,25 +44,30 @@ describe('mergeYamls', () => {
     expect(startLines).toEqual([1, 6]);
   });
 
-  it('marks the boundary line when the remote deleted lines you had edited', () => {
-    // Remote drops the middle line you changed, so the conflict resolves to an
-    // empty region: there is no output line to outline, only the gap it left.
-    const base = 'a\nb\nc\n';
-    const yours = 'a\nbY\nc\n';
-    const remote = 'a\nc\n';
+  it('marks the gap a remote deletion left, positioned by merged-output line', () => {
+    // Remote drops the line you changed, so the conflict resolves to an empty region:
+    // no output line to outline, only the gap it left. A clean local insertion above it
+    // pushes the output past the base, so an input-index anchor drifts.
+    // Merged output is 6 lines and 'c' was removed from between 'b' (line 4) and 'd'
+    // (line 5), so the gap is the top edge of line 5. Anchoring a line earlier gives 4,
+    // a full line too high; anchoring on oIndex gives 3, which is 'NEW2' — your text.
+    const base = 'a\nb\nc\nd\n';
+    const yours = 'a\nNEW1\nNEW2\nb\ncY\nd\n';
+    const remote = 'a\nb\nd\n';
 
     const { mergedYml, decorations } = mergeYamls(yours, base, remote);
 
-    expect(mergedYml).toBe('a\nc\n');
+    expect(mergedYml).toBe('a\nNEW1\nNEW2\nb\nd\n');
     expect(decorations).toHaveLength(1);
     expect(decorations[0].options.isWholeLine).toBe(false);
     expect(decorations[0].options.blockClassName).toBe('conflict');
-    expect(decorations[0].range.startLineNumber).toBe(1);
+    expect(decorations[0].range.startLineNumber).toBe(5);
+    expect(decorations[0].range.endLineNumber).toBe(5);
   });
 
-  it('clamps a deletion at the top of the file to line 1', () => {
-    // The gap sits above the first output line, so the unclamped boundary would
-    // be line 0 — not a line Monaco can decorate.
+  it('anchors a deletion at the top of the file to line 1', () => {
+    // The gap sits above the first output line, and the top edge of line 1 is that
+    // gap — the lower bound falls out of the anchor, with nothing left to clamp.
     const base = 'a\nb\n';
     const yours = 'aY\nb\n';
     const remote = 'b\n';
@@ -72,6 +77,21 @@ describe('mergeYamls', () => {
     expect(decorations).toHaveLength(1);
     expect(decorations[0].range.startLineNumber).toBe(1);
     expect(decorations[0].range.endLineNumber).toBe(1);
+  });
+
+  it('anchors a trailing deletion past the last line when there is no final newline', () => {
+    // Nothing follows the removed tail, so the gap is one line past the 1-line output.
+    // Monaco clamps an out-of-range decoration to the model's last line rather than
+    // dropping it, landing the marker at the end of the file — where the tail was.
+    const base = 'a\nb';
+    const yours = 'a\nbY';
+    const remote = 'a';
+
+    const { mergedYml, decorations } = mergeYamls(yours, base, remote);
+
+    expect(mergedYml).toBe('a');
+    expect(decorations).toHaveLength(1);
+    expect(decorations[0].range.startLineNumber).toBe(2);
   });
 
   it('returns the input unchanged when nothing differs', () => {

--- a/source/javascripts/components/ConfigMergeDialog/mergeYamls.ts
+++ b/source/javascripts/components/ConfigMergeDialog/mergeYamls.ts
@@ -58,7 +58,8 @@ export function mergeYamls(yourYaml: string, baseYaml: string, remoteYaml: strin
   // Only a deletion with nothing after it can anchor past the last line. Monaco pulls that
   // range back and — block decorations positioning from `startLineNumber` alone — would draw
   // the marker above the surviving text; `blockIsAfterEnd` is its opt-in for the bottom edge.
-  // Reachable only without a trailing newline, and it can only ever be the last decoration.
+  // Reachable only without a trailing newline, and — diff3 coalescing adjacent conflicts — in
+  // practice that is the last decoration, so the last one is the only one worth re-checking.
   const lineCount = Math.max(rows.length, 1);
   const last = decorations[decorations.length - 1];
 

--- a/source/javascripts/components/ConfigMergeDialog/mergeYamls.ts
+++ b/source/javascripts/components/ConfigMergeDialog/mergeYamls.ts
@@ -14,8 +14,6 @@ import { diff3Merge } from 'node-diff3';
 export function mergeYamls(yourYaml: string, baseYaml: string, remoteYaml: string) {
   const rows: string[] = [];
   const decorations: editor.IModelDeltaDecoration[] = [];
-  // Deletion markers can only be finalised once the total output length is known — see below.
-  const deletionMarkers: { index: number; gapLine: number }[] = [];
 
   diff3Merge<string>(yourYaml, baseYaml, remoteYaml, {
     stringSeparator: '\n',
@@ -29,28 +27,20 @@ export function mergeYamls(yourYaml: string, baseYaml: string, remoteYaml: strin
       return;
     }
 
-    // Decorations must be positioned by the running line count of the MERGED
-    // OUTPUT, not by diff3's `bIndex`/`oIndex` — those are offsets into the
-    // remote/base inputs and don't map onto the concatenated merged result, so
-    // with more than one conflict region they land on the wrong line.
+    // Position by the running line count of the MERGED OUTPUT. diff3's `bIndex`/`oIndex`
+    // are offsets into the remote/base inputs, so past the first conflict they drift.
     const conflictStartLine = rows.length + 1; // 1-based line where conflict.b begins
     rows.push(...region.conflict.b);
 
     const remoteChangeIsADeletion = region.conflict.b.length === 0;
 
     if (remoteChangeIsADeletion) {
-      // No output lines to outline, only the gap the removal left. Monaco draws an empty-range
-      // block decoration at the TOP edge of `startLineNumber`, and the top of `conflictStartLine`
-      // IS that gap. Anchoring a line earlier drew it a full line too high.
-      deletionMarkers.push({ index: decorations.length, gapLine: conflictStartLine });
+      // No output lines to outline, only the gap the removal left. Monaco anchors an
+      // empty-range block decoration at the TOP edge of `startLineNumber`, and the top of
+      // `conflictStartLine` IS that gap — a line earlier draws it a full line too high.
       decorations.push({
         options: { isWholeLine: false, blockClassName: 'conflict' },
-        range: {
-          startLineNumber: conflictStartLine,
-          startColumn: 1,
-          endLineNumber: conflictStartLine,
-          endColumn: 1,
-        },
+        range: { startLineNumber: conflictStartLine, startColumn: 1, endLineNumber: conflictStartLine, endColumn: 1 },
       });
     } else {
       decorations.push({
@@ -65,23 +55,17 @@ export function mergeYamls(yourYaml: string, baseYaml: string, remoteYaml: strin
     }
   });
 
-  // A deletion with nothing after it leaves its gap BELOW the last line, so `gapLine` is one
-  // past the end. Monaco would not drop that range, it would pull it back to the last line —
-  // and since block decorations position from `startLineNumber` alone, the marker would then
-  // render at that line's TOP edge, above the surviving text instead of after it.
-  // `blockIsAfterEnd` is the documented opt-in for the bottom edge: an empty range on the last
-  // line, rendered after it. Reachable only without a trailing newline; YAML usually has one.
+  // Only a deletion with nothing after it can anchor past the last line. Monaco pulls that
+  // range back and — block decorations positioning from `startLineNumber` alone — would draw
+  // the marker above the surviving text; `blockIsAfterEnd` is its opt-in for the bottom edge.
+  // Reachable only without a trailing newline, and it can only ever be the last decoration.
   const lineCount = Math.max(rows.length, 1);
-  deletionMarkers.forEach(({ index, gapLine }) => {
-    if (gapLine <= lineCount) {
-      return;
-    }
+  const last = decorations[decorations.length - 1];
 
-    decorations[index] = {
-      options: { isWholeLine: false, blockClassName: 'conflict', blockIsAfterEnd: true },
-      range: { startLineNumber: lineCount, startColumn: 1, endLineNumber: lineCount, endColumn: 1 },
-    };
-  });
+  if (last && last.range.startLineNumber > lineCount) {
+    last.options = { ...last.options, blockIsAfterEnd: true };
+    last.range = { startLineNumber: lineCount, startColumn: 1, endLineNumber: lineCount, endColumn: 1 };
+  }
 
   return {
     decorations,

--- a/source/javascripts/components/ConfigMergeDialog/mergeYamls.ts
+++ b/source/javascripts/components/ConfigMergeDialog/mergeYamls.ts
@@ -14,6 +14,8 @@ import { diff3Merge } from 'node-diff3';
 export function mergeYamls(yourYaml: string, baseYaml: string, remoteYaml: string) {
   const rows: string[] = [];
   const decorations: editor.IModelDeltaDecoration[] = [];
+  // Deletion markers can only be finalised once the total output length is known — see below.
+  const deletionMarkers: { index: number; gapLine: number }[] = [];
 
   diff3Merge<string>(yourYaml, baseYaml, remoteYaml, {
     stringSeparator: '\n',
@@ -37,12 +39,10 @@ export function mergeYamls(yourYaml: string, baseYaml: string, remoteYaml: strin
     const remoteChangeIsADeletion = region.conflict.b.length === 0;
 
     if (remoteChangeIsADeletion) {
-      // No output lines to outline, only the gap the removal left. Monaco draws an
-      // empty-range block decoration at the TOP edge of `startLineNumber` — the
-      // `blockIsAfterEnd` option exists precisely to opt into the other edge — and the
-      // top of `conflictStartLine` IS that gap. Anchoring a line earlier drew it a full
-      // line too high. A trailing deletion in a file with no final newline puts this one
-      // past the last line; Monaco clamps such a range to the model instead of dropping it.
+      // No output lines to outline, only the gap the removal left. Monaco draws an empty-range
+      // block decoration at the TOP edge of `startLineNumber`, and the top of `conflictStartLine`
+      // IS that gap. Anchoring a line earlier drew it a full line too high.
+      deletionMarkers.push({ index: decorations.length, gapLine: conflictStartLine });
       decorations.push({
         options: { isWholeLine: false, blockClassName: 'conflict' },
         range: {
@@ -63,6 +63,24 @@ export function mergeYamls(yourYaml: string, baseYaml: string, remoteYaml: strin
         },
       });
     }
+  });
+
+  // A deletion with nothing after it leaves its gap BELOW the last line, so `gapLine` is one
+  // past the end. Monaco would not drop that range, it would pull it back to the last line —
+  // and since block decorations position from `startLineNumber` alone, the marker would then
+  // render at that line's TOP edge, above the surviving text instead of after it.
+  // `blockIsAfterEnd` is the documented opt-in for the bottom edge: an empty range on the last
+  // line, rendered after it. Reachable only without a trailing newline; YAML usually has one.
+  const lineCount = Math.max(rows.length, 1);
+  deletionMarkers.forEach(({ index, gapLine }) => {
+    if (gapLine <= lineCount) {
+      return;
+    }
+
+    decorations[index] = {
+      options: { isWholeLine: false, blockClassName: 'conflict', blockIsAfterEnd: true },
+      range: { startLineNumber: lineCount, startColumn: 1, endLineNumber: lineCount, endColumn: 1 },
+    };
   });
 
   return {

--- a/source/javascripts/components/ConfigMergeDialog/mergeYamls.ts
+++ b/source/javascripts/components/ConfigMergeDialog/mergeYamls.ts
@@ -37,12 +37,20 @@ export function mergeYamls(yourYaml: string, baseYaml: string, remoteYaml: strin
     const remoteChangeIsADeletion = region.conflict.b.length === 0;
 
     if (remoteChangeIsADeletion) {
-      // The remote removed lines you had — there are no output lines to mark, so
-      // flag the boundary (the line now sitting in the gap, clamped to line 1).
-      const boundaryLine = Math.max(conflictStartLine - 1, 1);
+      // No output lines to outline, only the gap the removal left. Monaco draws an
+      // empty-range block decoration at the TOP edge of `startLineNumber` — the
+      // `blockIsAfterEnd` option exists precisely to opt into the other edge — and the
+      // top of `conflictStartLine` IS that gap. Anchoring a line earlier drew it a full
+      // line too high. A trailing deletion in a file with no final newline puts this one
+      // past the last line; Monaco clamps such a range to the model instead of dropping it.
       decorations.push({
         options: { isWholeLine: false, blockClassName: 'conflict' },
-        range: { startLineNumber: boundaryLine, startColumn: 1, endLineNumber: boundaryLine, endColumn: 1 },
+        range: {
+          startLineNumber: conflictStartLine,
+          startColumn: 1,
+          endLineNumber: conflictStartLine,
+          endColumn: 1,
+        },
       });
     } else {
       decorations.push({

--- a/source/javascripts/components/ConfigMergeDialog/mergeYamls.ts
+++ b/source/javascripts/components/ConfigMergeDialog/mergeYamls.ts
@@ -8,8 +8,8 @@ import { diff3Merge } from 'node-diff3';
  * auto-resolved to the remote side and reported as decorations so the UI can mark
  * them red — the user edits the merged result to recover their own changes.
  *
- * Shared by the modular per-file conflict dialog. (The legacy single-file dialog
- * keeps its own copy until the modular-editing flag graduates and it is removed.)
+ * Shared by both conflict dialogs — the modular per-file one and the legacy
+ * single-file one, which is removed when the modular-editing flag graduates.
  */
 export function mergeYamls(yourYaml: string, baseYaml: string, remoteYaml: string) {
   const rows: string[] = [];


### PR DESCRIPTION
The legacy merge dialog kept its own copy of `mergeYamls`. That copy positioned Monaco
decorations from diff3's `bIndex` and `oIndex`, which index the inputs rather than the
merged output, so they drift once an earlier region changes length. This deletes the
duplicate, imports the shared `mergeYamls.ts`, and fixes a second off-by-one in the shared module.

Not cosmetic. Conflicts auto-resolve to the remote side, so the user's text is dropped and the
red marker is the only record their edit existed. A wrong line means a lost edit.
`Header.tsx` renders this dialog unconditionally, so it is the copy users hit.

## Two bugs

`bIndex` indexes the remote input. One clean local insertion earlier in the file pushes the
merged output past it, and the marker lands on your own inserted text while the real
conflict stays unmarked.

Deletion conflicts sat a line too high. Monaco anchors an empty-range block decoration at the
top edge of `startLineNumber`, and that top edge is the gap the deletion left, so
`Math.max(S - 1, 1)` drew it one line up. Broken since #1828. A deletion with nothing after it
anchors past the last line, so it gets `blockIsAfterEnd` instead.

## Tests

The old fixture kept all three inputs the same length, so `bIndex + 1` matched the output and hid the bug. I retargeted both fixtures, added end-of-file and mid-file cases, and
mutation-verified each anchor.

`npm test` 1499 passed, `tsc` and lint clean, CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
