### PR TITLE
fix(env vars): address sortable env var rows by id, not a stale render index

### DIFF
--- a/source/javascripts/components/SortableEnvVars/SortableEnvVars.tsx
+++ b/source/javascripts/components/SortableEnvVars/SortableEnvVars.tsx
@@ -67,14 +67,14 @@ const SortableEnvVars = ({
         modifiers={[restrictToVerticalAxis, restrictToParentElement]}
       >
         <SortableContext items={envs.map(({ uniqueId }) => uniqueId)} strategy={verticalListSortingStrategy}>
-          {envs.map((env, index) => (
+          {envs.map((env) => (
             <SortableEnvVarItem
               key={env.uniqueId}
               env={env}
-              onRemove={onRemove(index)}
-              onKeyChange={onKeyChange(index)}
-              onValueChange={onValueChange(index)}
-              onIsExpandChange={onIsExpandChange(index)}
+              onRemove={onRemove(env.uniqueId)}
+              onKeyChange={onKeyChange(env.uniqueId)}
+              onValueChange={onValueChange(env.uniqueId)}
+              onIsExpandChange={onIsExpandChange(env.uniqueId)}
               jumpButton={isReadOnlyView ? renderJumpButton?.(env) : undefined}
             />
           ))}

--- a/source/javascripts/components/SortableEnvVars/useSortableEnvVars.spec.tsx
+++ b/source/javascripts/components/SortableEnvVars/useSortableEnvVars.spec.tsx
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment jsdom
+ */
+import { act, renderHook } from '@testing-library/react';
+
+import { EnvVarSource } from '@/core/models/EnvVar';
+import { getYmlString, initializeBitriseYmlDocument } from '@/core/stores/BitriseYmlStore';
+
+import { useSortableEnvVars } from './useSortableEnvVars';
+
+const WORKFLOW_ENVS = [
+  'workflows:',
+  '  wf1:',
+  '    envs:',
+  '    - NODE_VERSION: lts',
+  '    - PROJECT_NAME: Mando',
+  '    - ENVIRONMENT: production',
+  '',
+].join('\n');
+
+const renderSortableEnvVars = () => {
+  initializeBitriseYmlDocument({ ymlString: WORKFLOW_ENVS, version: '1' });
+  return renderHook(() => useSortableEnvVars({ source: EnvVarSource.Workflows, sourceId: 'wf1' }));
+};
+
+describe('useSortableEnvVars', () => {
+  it('seeds the list from the document', () => {
+    const { result } = renderSortableEnvVars();
+
+    expect(result.current.envs.map((env) => env.key)).toEqual(['NODE_VERSION', 'PROJECT_NAME', 'ENVIRONMENT']);
+  });
+
+  it('removes the clicked row from the document', () => {
+    const { result } = renderSortableEnvVars();
+    const [, projectName] = result.current.envs;
+
+    act(() => result.current.onRemove(projectName.uniqueId)());
+
+    expect(result.current.envs.map((env) => env.key)).toEqual(['NODE_VERSION', 'ENVIRONMENT']);
+    expect(getYmlString()).toBe(
+      ['workflows:', '  wf1:', '    envs:', '    - NODE_VERSION: lts', '    - ENVIRONMENT: production', ''].join('\n'),
+    );
+  });
+
+  it('removes the right rows when two removals land before a re-render', () => {
+    const { result } = renderSortableEnvVars();
+    const [nodeVersion, , environment] = result.current.envs;
+
+    // Both handlers run against the list as it was rendered, so the second one has to resolve
+    // `environment` at its new position (1) instead of the one it was rendered at (2).
+    act(() => {
+      result.current.onRemove(nodeVersion.uniqueId)();
+      result.current.onRemove(environment.uniqueId)();
+    });
+
+    expect(result.current.envs.map((env) => env.key)).toEqual(['PROJECT_NAME']);
+    expect(getYmlString()).toBe(['workflows:', '  wf1:', '    envs:', '    - PROJECT_NAME: Mando', ''].join('\n'));
+  });
+
+  it('ignores a repeated removal of the same row', () => {
+    const { result } = renderSortableEnvVars();
+    const [, projectName] = result.current.envs;
+    const removeProjectName = result.current.onRemove(projectName.uniqueId);
+
+    act(() => {
+      removeProjectName();
+      removeProjectName();
+    });
+
+    expect(result.current.envs.map((env) => env.key)).toEqual(['NODE_VERSION', 'ENVIRONMENT']);
+    expect(getYmlString()).toBe(
+      ['workflows:', '  wf1:', '    envs:', '    - NODE_VERSION: lts', '    - ENVIRONMENT: production', ''].join('\n'),
+    );
+  });
+
+  it('applies is_expand to the row it was toggled on after a preceding row is removed', () => {
+    const { result } = renderSortableEnvVars();
+    const [nodeVersion, , environment] = result.current.envs;
+
+    act(() => {
+      result.current.onRemove(nodeVersion.uniqueId)();
+      result.current.onIsExpandChange(environment.uniqueId)(false);
+    });
+
+    expect(getYmlString()).toBe(
+      [
+        'workflows:',
+        '  wf1:',
+        '    envs:',
+        '    - PROJECT_NAME: Mando',
+        '    - ENVIRONMENT: production',
+        '      opts:',
+        '        is_expand: false',
+        '',
+      ].join('\n'),
+    );
+  });
+});

--- a/source/javascripts/components/SortableEnvVars/useSortableEnvVars.spec.tsx
+++ b/source/javascripts/components/SortableEnvVars/useSortableEnvVars.spec.tsx
@@ -73,6 +73,57 @@ describe('useSortableEnvVars', () => {
     );
   });
 
+  describe('debounced key and value writes', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    const flushDebounce = () => act(() => jest.advanceTimersByTime(250));
+
+    it('writes a value to the row it was typed in after a preceding row is removed', () => {
+      const { result } = renderSortableEnvVars();
+      const [nodeVersion, , environment] = result.current.envs;
+
+      act(() => result.current.onValueChange(environment.uniqueId)('staging'));
+      act(() => result.current.onRemove(nodeVersion.uniqueId)());
+      flushDebounce();
+
+      expect(getYmlString()).toBe(
+        ['workflows:', '  wf1:', '    envs:', '    - PROJECT_NAME: Mando', '    - ENVIRONMENT: staging', ''].join('\n'),
+      );
+    });
+
+    it('writes a key to the row it was typed in after a preceding row is removed', () => {
+      const { result } = renderSortableEnvVars();
+      const [nodeVersion, , environment] = result.current.envs;
+
+      act(() => result.current.onKeyChange(environment.uniqueId)('STAGE'));
+      act(() => result.current.onRemove(nodeVersion.uniqueId)());
+      flushDebounce();
+
+      expect(getYmlString()).toBe(
+        ['workflows:', '  wf1:', '    envs:', '    - PROJECT_NAME: Mando', '    - STAGE: production', ''].join('\n'),
+      );
+    });
+
+    it('drops a pending write for a row that is removed before it flushes', () => {
+      const { result } = renderSortableEnvVars();
+      const [, , environment] = result.current.envs;
+
+      act(() => result.current.onValueChange(environment.uniqueId)('staging'));
+      act(() => result.current.onRemove(environment.uniqueId)());
+
+      expect(flushDebounce).not.toThrow();
+      expect(getYmlString()).toBe(
+        ['workflows:', '  wf1:', '    envs:', '    - NODE_VERSION: lts', '    - PROJECT_NAME: Mando', ''].join('\n'),
+      );
+    });
+  });
+
   it('applies is_expand to the row it was toggled on after a preceding row is removed', () => {
     const { result } = renderSortableEnvVars();
     const [nodeVersion, , environment] = result.current.envs;

--- a/source/javascripts/components/SortableEnvVars/useSortableEnvVars.spec.tsx
+++ b/source/javascripts/components/SortableEnvVars/useSortableEnvVars.spec.tsx
@@ -4,7 +4,14 @@
 import { act, renderHook } from '@testing-library/react';
 
 import { EnvVarSource } from '@/core/models/EnvVar';
-import { getYmlString, initializeBitriseYmlDocument } from '@/core/stores/BitriseYmlStore';
+import { TreeNode } from '@/core/models/Tree';
+import {
+  getFileYmlString,
+  getYmlString,
+  initializeBitriseYmlDocument,
+  initializeModularConfig,
+  selectNode,
+} from '@/core/stores/BitriseYmlStore';
 
 import { useSortableEnvVars } from './useSortableEnvVars';
 
@@ -110,6 +117,41 @@ describe('useSortableEnvVars', () => {
       );
     });
 
+    it('lands every keystroke of a burst, because each rename builds on the previous one', () => {
+      const { result } = renderSortableEnvVars();
+      const [nodeVersion] = result.current.envs;
+
+      act(() => result.current.onKeyChange(nodeVersion.uniqueId)('N'));
+      act(() => jest.advanceTimersByTime(100));
+      act(() => result.current.onKeyChange(nodeVersion.uniqueId)('NO'));
+      flushDebounce();
+
+      expect(getYmlString()).toBe(
+        [
+          'workflows:',
+          '  wf1:',
+          '    envs:',
+          '    - NO: lts',
+          '    - PROJECT_NAME: Mando',
+          '    - ENVIRONMENT: production',
+          '',
+        ].join('\n'),
+      );
+    });
+
+    it('drops a pending write once the list is unmounted', () => {
+      const { result, unmount } = renderSortableEnvVars();
+      const [nodeVersion] = result.current.envs;
+
+      // `useDebounceCallback` cancels a different debounce instance than the one it hands back, so
+      // the timer fires after unmount regardless — the write itself has to decline to land.
+      act(() => result.current.onValueChange(nodeVersion.uniqueId)('changed'));
+      unmount();
+
+      expect(flushDebounce).not.toThrow();
+      expect(getYmlString()).toBe(WORKFLOW_ENVS);
+    });
+
     it('drops a pending write for a row that is removed before it flushes', () => {
       const { result } = renderSortableEnvVars();
       const [, , environment] = result.current.envs;
@@ -145,5 +187,94 @@ describe('useSortableEnvVars', () => {
         '',
       ].join('\n'),
     );
+  });
+
+  describe('modular config', () => {
+    const SHA = 'a1b2c3d4e5f6789012345678901234567890abcd';
+
+    // Both files define `workflows.wf1.envs`, and the second entry carries the same key in each —
+    // so a write that leaked across the file boundary would apply cleanly and silently.
+    const ROOT_YML = ['workflows:', '  wf1:', '    envs:', '    - ROOT_A: 1', '    - SHARED: root', ''].join('\n');
+    const CHILD_YML = ['workflows:', '  wf1:', '    envs:', '    - CHILD_A: 1', '    - SHARED: child', ''].join('\n');
+
+    const renderOnRoot = () => {
+      const child: TreeNode = {
+        nodeId: 'n_child',
+        path: 'child-a.yml',
+        contents: CHILD_YML,
+        source: { path: 'child-a.yml', repository: null, branch: null, tag: null, commit: null },
+        commitSha: SHA,
+        editable: true,
+        includes: [],
+      };
+      const root: TreeNode = {
+        nodeId: 'root',
+        path: 'bitrise.yml',
+        contents: ROOT_YML,
+        source: null,
+        commitSha: SHA,
+        editable: true,
+        includes: [child],
+      };
+
+      // initializeModularConfig selects the root file, so the list renders against `bitrise.yml`.
+      initializeModularConfig({ root, branch: 'main', commitSha: SHA });
+
+      return renderHook(() => useSortableEnvVars({ source: EnvVarSource.Workflows, sourceId: 'wf1' }));
+    };
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('drops a pending write when the active file changes before it flushes', () => {
+      const { result } = renderOnRoot();
+      const shared = result.current.envs.find((env) => env.key === 'SHARED');
+
+      act(() => result.current.onKeyChange(shared?.uniqueId ?? '')('RENAMED'));
+      act(() => selectNode('n_child'));
+
+      expect(() => act(() => jest.advanceTimersByTime(250))).not.toThrow();
+
+      // Neither file is touched: the edit is dropped rather than redirected into `child-a.yml`.
+      expect(getFileYmlString('root')).toBe(ROOT_YML);
+      expect(getFileYmlString('n_child')).toBe(CHILD_YML);
+    });
+
+    // Deliberately NOT wrapped in `act`: this is the case where the file switch has reached the
+    // store but React has not re-rendered yet, so neither the re-seeded list nor any effect-updated
+    // ref knows about it — only reading the store at flush time catches it. Wrapping this in `act`
+    // would test the easy path instead (see the case above).
+    it('drops a pending write when the file switch has not reached React yet', () => {
+      const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const { result } = renderOnRoot();
+      const shared = result.current.envs.find((env) => env.key === 'SHARED');
+
+      act(() => result.current.onKeyChange(shared?.uniqueId ?? '')('RENAMED'));
+      selectNode('n_child');
+
+      expect(() => act(() => jest.advanceTimersByTime(250))).not.toThrow();
+
+      expect(getFileYmlString('root')).toBe(ROOT_YML);
+      expect(getFileYmlString('n_child')).toBe(CHILD_YML);
+      consoleError.mockRestore();
+    });
+
+    it('writes to the active file when it has not changed', () => {
+      const { result } = renderOnRoot();
+      const shared = result.current.envs.find((env) => env.key === 'SHARED');
+
+      act(() => result.current.onKeyChange(shared?.uniqueId ?? '')('RENAMED'));
+      act(() => jest.advanceTimersByTime(250));
+
+      expect(getFileYmlString('root')).toBe(
+        ['workflows:', '  wf1:', '    envs:', '    - ROOT_A: 1', '    - RENAMED: root', ''].join('\n'),
+      );
+      expect(getFileYmlString('n_child')).toBe(CHILD_YML);
+    });
   });
 });

--- a/source/javascripts/components/SortableEnvVars/useSortableEnvVars.ts
+++ b/source/javascripts/components/SortableEnvVars/useSortableEnvVars.ts
@@ -1,14 +1,25 @@
 import { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { useDebounceCallback } from 'usehooks-ts';
+import { useDebounceCallback, useUnmount } from 'usehooks-ts';
 
 import { SortableEnvVar } from '@/components/SortableEnvVars/SortableEnvVarItem';
 import { EnvVar, EnvVarSource } from '@/core/models/EnvVar';
 import EnvVarService from '@/core/services/EnvVarService';
+import { bitriseYmlStore } from '@/core/stores/BitriseYmlStore';
 import useBitriseYmlStore from '@/hooks/useBitriseYmlStore';
 
 import { listenToEnvVarCreated } from './SortableEnvVars.events';
+
+/**
+ * The file a write lands in. `updateBitriseYmlDocument` reads exactly this when the mutator runs, so
+ * it is read from the store — not from a rendered value or a ref an effect maintains — at both ends
+ * of a debounced write: a file switch reaches the store before React re-renders, and the debounce
+ * timer can fire in between.
+ */
+function activeWriteTarget() {
+  return bitriseYmlStore.getState().selectedNodeId;
+}
 
 type UseSortableEnvVarsProps = {
   source: EnvVarSource;
@@ -48,14 +59,44 @@ export const useSortableEnvVars = ({
     return envsRef.current.findIndex((env) => env.uniqueId === uniqueId);
   }, []);
 
-  // The debounced writes carry the row's `uniqueId` rather than its index, and resolve the position
-  // only when they actually run: the row can move or go away during the delay (a preceding row
-  // removed, a reorder), and a position captured before the delay would write to whatever ended up
-  // there. `oldKey`/`key` describe the row itself, so those are still captured at call time — they
-  // are what the caller knows the document holds for that row, whatever position it is at.
+  const isMountedRef = useRef(true);
+
+  useUnmount(() => {
+    isMountedRef.current = false;
+  });
+
+  /**
+   * Where a pending write is still allowed to land: the row's current position, or -1 when it may
+   * not be applied at all.
+   *
+   * A debounce timer outlives the interaction that scheduled it, and the write resolves both its
+   * row and its target document only when it runs:
+   *
+   * - The row moves when a preceding row is removed or the list is reordered, so a position
+   *   captured before the delay would write to whatever ended up there.
+   * - `updateBitriseYmlDocument` picks the file from the active tab as the mutator runs. In modular
+   *   mode the same `sourceId` can live in several files, so a file switch inside the window would
+   *   redirect the write into a document it was never meant for — silently, when that file happens
+   *   to hold a matching key. See `activeWriteTarget` for why the store is read directly here.
+   * - After unmount there is nothing left to write for. (`useDebounceCallback`'s own unmount cancel
+   *   targets a different debounce instance than the one it hands back, so the timer still fires.)
+   */
+  const resolvePendingRow = useCallback(
+    (at: { uniqueId: string; fileId?: string }) => {
+      if (!isMountedRef.current || at.fileId !== activeWriteTarget()) {
+        return -1;
+      }
+
+      return indexOf(at.uniqueId);
+    },
+    [indexOf],
+  );
+
+  // `oldKey`/`key` stay captured at call time: they describe the row itself — what the caller knows
+  // the document holds for it — not where it sits, so they survive the row moving.
   const flushKeyUpdate = useCallback(
-    (newKey: string, at: { uniqueId: string; oldKey: string }) => {
-      const index = indexOf(at.uniqueId);
+    (newKey: string, at: { uniqueId: string; fileId?: string; oldKey: string }) => {
+      const index = resolvePendingRow(at);
 
       if (index === -1) {
         return;
@@ -63,12 +104,12 @@ export const useSortableEnvVars = ({
 
       EnvVarService.updateKey(newKey, { source, sourceId, index, oldKey: at.oldKey });
     },
-    [indexOf, source, sourceId],
+    [resolvePendingRow, source, sourceId],
   );
 
   const flushValueUpdate = useCallback(
-    (value: string, at: { uniqueId: string; key: string }) => {
-      const index = indexOf(at.uniqueId);
+    (value: string, at: { uniqueId: string; fileId?: string; key: string }) => {
+      const index = resolvePendingRow(at);
 
       if (index === -1) {
         return;
@@ -76,7 +117,7 @@ export const useSortableEnvVars = ({
 
       EnvVarService.updateValue(value, { source, sourceId, index, key: at.key });
     },
-    [indexOf, source, sourceId],
+    [resolvePendingRow, source, sourceId],
   );
 
   const updateKeyDebounced = useDebounceCallback(flushKeyUpdate, 250, { leading: false });
@@ -161,7 +202,7 @@ export const useSortableEnvVars = ({
 
     const oldKey = envsRef.current[index].key;
     updateEnvs((current) => current.map((env, i) => (i === index ? { ...env, key } : env)));
-    updateKeyDebounced(key, { uniqueId, oldKey });
+    updateKeyDebounced(key, { uniqueId, fileId: activeWriteTarget(), oldKey });
   };
 
   const onValueChange = (uniqueId: string) => (value: string) => {
@@ -173,7 +214,7 @@ export const useSortableEnvVars = ({
 
     const { key } = envsRef.current[index];
     updateEnvs((current) => current.map((env, i) => (i === index ? { ...env, value } : env)));
-    updateValueDebounced(value, { uniqueId, key });
+    updateValueDebounced(value, { uniqueId, fileId: activeWriteTarget(), key });
   };
 
   const onIsExpandChange = (uniqueId: string) => (isExpand: boolean) => {

--- a/source/javascripts/components/SortableEnvVars/useSortableEnvVars.ts
+++ b/source/javascripts/components/SortableEnvVars/useSortableEnvVars.ts
@@ -48,8 +48,39 @@ export const useSortableEnvVars = ({
     return envsRef.current.findIndex((env) => env.uniqueId === uniqueId);
   }, []);
 
-  const updateKeyDebounced = useDebounceCallback(EnvVarService.updateKey, 250, { leading: false });
-  const updateValueDebounced = useDebounceCallback(EnvVarService.updateValue, 250, { leading: false });
+  // The debounced writes carry the row's `uniqueId` rather than its index, and resolve the position
+  // only when they actually run: the row can move or go away during the delay (a preceding row
+  // removed, a reorder), and a position captured before the delay would write to whatever ended up
+  // there. `oldKey`/`key` describe the row itself, so those are still captured at call time — they
+  // are what the caller knows the document holds for that row, whatever position it is at.
+  const flushKeyUpdate = useCallback(
+    (newKey: string, at: { uniqueId: string; oldKey: string }) => {
+      const index = indexOf(at.uniqueId);
+
+      if (index === -1) {
+        return;
+      }
+
+      EnvVarService.updateKey(newKey, { source, sourceId, index, oldKey: at.oldKey });
+    },
+    [indexOf, source, sourceId],
+  );
+
+  const flushValueUpdate = useCallback(
+    (value: string, at: { uniqueId: string; key: string }) => {
+      const index = indexOf(at.uniqueId);
+
+      if (index === -1) {
+        return;
+      }
+
+      EnvVarService.updateValue(value, { source, sourceId, index, key: at.key });
+    },
+    [indexOf, source, sourceId],
+  );
+
+  const updateKeyDebounced = useDebounceCallback(flushKeyUpdate, 250, { leading: false });
+  const updateValueDebounced = useDebounceCallback(flushValueUpdate, 250, { leading: false });
 
   // `initialEnvs` is fixed to a specific file, so the active-file change must not re-seed it;
   // only re-seed on active-file changes when the list is read from the store.
@@ -130,7 +161,7 @@ export const useSortableEnvVars = ({
 
     const oldKey = envsRef.current[index].key;
     updateEnvs((current) => current.map((env, i) => (i === index ? { ...env, key } : env)));
-    updateKeyDebounced(key, { source, sourceId, index, oldKey });
+    updateKeyDebounced(key, { uniqueId, oldKey });
   };
 
   const onValueChange = (uniqueId: string) => (value: string) => {
@@ -142,7 +173,7 @@ export const useSortableEnvVars = ({
 
     const { key } = envsRef.current[index];
     updateEnvs((current) => current.map((env, i) => (i === index ? { ...env, value } : env)));
-    updateValueDebounced(value, { source, sourceId, index, key });
+    updateValueDebounced(value, { uniqueId, key });
   };
 
   const onIsExpandChange = (uniqueId: string) => (isExpand: boolean) => {

--- a/source/javascripts/components/SortableEnvVars/useSortableEnvVars.ts
+++ b/source/javascripts/components/SortableEnvVars/useSortableEnvVars.ts
@@ -1,6 +1,6 @@
 import { DragEndEvent, DragStartEvent } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useDebounceCallback } from 'usehooks-ts';
 
 import { SortableEnvVar } from '@/components/SortableEnvVars/SortableEnvVarItem';
@@ -31,6 +31,23 @@ export const useSortableEnvVars = ({
   // file is part of the identity of the env var list — re-seed when it changes.
   const activeFileId = useBitriseYmlStore((s) => s.selectedNodeId);
 
+  // The document addresses env vars by position, so every mutation has to resolve the row's index
+  // at the moment it runs. `envs` catches up only on re-render, so two handler calls landing in the
+  // same React batch (a double click on Remove, a click on a row while a drag settles) would both
+  // resolve against the pre-update list and send the same — by then out-of-bounds — index to the
+  // document. This ref carries the up-to-date list between renders.
+  const envsRef = useRef<SortableEnvVar[]>([]);
+
+  const updateEnvs = useCallback((updater: (current: SortableEnvVar[]) => SortableEnvVar[]) => {
+    envsRef.current = updater(envsRef.current);
+    setEnvs(envsRef.current);
+  }, []);
+
+  /** Current position of a row, or -1 once it is gone from the list. */
+  const indexOf = useCallback((uniqueId: string) => {
+    return envsRef.current.findIndex((env) => env.uniqueId === uniqueId);
+  }, []);
+
   const updateKeyDebounced = useDebounceCallback(EnvVarService.updateKey, 250, { leading: false });
   const updateValueDebounced = useDebounceCallback(EnvVarService.updateValue, 250, { leading: false });
 
@@ -40,23 +57,23 @@ export const useSortableEnvVars = ({
 
   useEffect(() => {
     const base = initialEnvs ?? EnvVarService.getAll(source, sourceId || '');
-    setEnvs(
+    updateEnvs(() =>
       base.map((env) => ({
         ...env,
         uniqueId: crypto.randomUUID(),
       })),
     );
-  }, [source, sourceId, reseedFileId, initialEnvs]);
+  }, [source, sourceId, reseedFileId, initialEnvs, updateEnvs]);
 
   useEffect(() => {
     if (!listenForExternalChanges) return;
 
     return listenToEnvVarCreated((event) => {
       if (event.detail.source === source && event.detail.sourceId === sourceId) {
-        setEnvs((oldEnvVars) => [...oldEnvVars, { uniqueId: crypto.randomUUID(), ...event.detail.envVar }]);
+        updateEnvs((oldEnvVars) => [...oldEnvVars, { uniqueId: crypto.randomUUID(), ...event.detail.envVar }]);
       }
     });
-  }, [listenForExternalChanges, source, sourceId]);
+  }, [listenForExternalChanges, source, sourceId, updateEnvs]);
 
   const onDragStart = (event: DragStartEvent) => {
     setActiveItem(event.active.data.current as SortableEnvVar);
@@ -65,19 +82,19 @@ export const useSortableEnvVars = ({
   const onDragEnd = (event: DragEndEvent) => {
     const overId = event.over?.id.toString();
     const activeId = event.active.id.toString();
+    const currentEnvs = envsRef.current;
+    const currentOverIndex = overId ? indexOf(overId) : -1;
+    const currentActiveIndex = activeId ? indexOf(activeId) : -1;
 
-    if (activeId && overId) {
-      const currentOverIndex = envs.findIndex(({ uniqueId }) => uniqueId === overId);
-      const currentActiveIndex = envs.findIndex(({ uniqueId }) => uniqueId === activeId);
-      const reorderedEnvs = arrayMove(envs, currentActiveIndex, currentOverIndex);
+    // Either row may already be gone (the list re-seeded, or the row was removed mid-drag).
+    // `arrayMove` treats a -1 as an offset from the end, which would reorder unrelated rows.
+    if (currentOverIndex !== -1 && currentActiveIndex !== -1) {
+      const reorderedEnvs = arrayMove(currentEnvs, currentActiveIndex, currentOverIndex);
+      const newIndices = reorderedEnvs.map((newEnvVar) =>
+        currentEnvs.findIndex((oldEnvVar) => newEnvVar.uniqueId === oldEnvVar.uniqueId),
+      );
 
-      const newIndices: number[] = [];
-      reorderedEnvs.forEach((newEnvVar) => {
-        const newIndex = envs.findIndex((oldEnvVar) => newEnvVar.uniqueId === oldEnvVar.uniqueId);
-        newIndices.push(newIndex);
-      });
-
-      setEnvs(reorderedEnvs);
+      updateEnvs(() => reorderedEnvs);
       EnvVarService.reorder(newIndices, { source, sourceId });
     }
 
@@ -89,27 +106,53 @@ export const useSortableEnvVars = ({
   };
 
   const onAdd = () => {
-    setEnvs([...envs, { uniqueId: crypto.randomUUID(), ...EnvVarService.EMPTY_ENV_VAR }]);
+    updateEnvs((current) => [...current, { uniqueId: crypto.randomUUID(), ...EnvVarService.EMPTY_ENV_VAR }]);
     EnvVarService.create({ source, sourceId });
   };
 
-  const onRemove = (index: number) => () => {
-    setEnvs(envs.filter((_, i) => i !== index));
+  const onRemove = (uniqueId: string) => () => {
+    const index = indexOf(uniqueId);
+
+    if (index === -1) {
+      return;
+    }
+
+    updateEnvs((current) => current.filter((_, i) => i !== index));
     EnvVarService.remove({ source, sourceId, index });
   };
 
-  const onKeyChange = (index: number) => (key: string) => {
-    setEnvs(envs.map((env, i) => (i === index ? { ...env, key } : env)));
-    updateKeyDebounced(key, { source, sourceId, index, oldKey: envs[index].key });
+  const onKeyChange = (uniqueId: string) => (key: string) => {
+    const index = indexOf(uniqueId);
+
+    if (index === -1) {
+      return;
+    }
+
+    const oldKey = envsRef.current[index].key;
+    updateEnvs((current) => current.map((env, i) => (i === index ? { ...env, key } : env)));
+    updateKeyDebounced(key, { source, sourceId, index, oldKey });
   };
 
-  const onValueChange = (index: number) => (value: string) => {
-    setEnvs(envs.map((env, i) => (i === index ? { ...env, value } : env)));
-    updateValueDebounced(value, { source, sourceId, index, key: envs[index].key });
+  const onValueChange = (uniqueId: string) => (value: string) => {
+    const index = indexOf(uniqueId);
+
+    if (index === -1) {
+      return;
+    }
+
+    const { key } = envsRef.current[index];
+    updateEnvs((current) => current.map((env, i) => (i === index ? { ...env, value } : env)));
+    updateValueDebounced(value, { source, sourceId, index, key });
   };
 
-  const onIsExpandChange = (index: number) => (isExpand: boolean) => {
-    setEnvs(envs.map((env, i) => (i === index ? { ...env, isExpand } : env)));
+  const onIsExpandChange = (uniqueId: string) => (isExpand: boolean) => {
+    const index = indexOf(uniqueId);
+
+    if (index === -1) {
+      return;
+    }
+
+    updateEnvs((current) => current.map((env, i) => (i === index ? { ...env, isExpand } : env)));
     EnvVarService.updateIsExpand(isExpand, { source, sourceId, index });
   };
 

--- a/source/javascripts/core/services/EnvVarService.spec.ts
+++ b/source/javascripts/core/services/EnvVarService.spec.ts
@@ -495,7 +495,7 @@ describe('EnvVarService', () => {
         `);
       });
 
-      it('is idempotent when the same index is removed twice', () => {
+      it('ignores a repeated index once it is past the end', () => {
         updateBitriseYmlDocumentByString(
           yaml`
             app:
@@ -511,6 +511,29 @@ describe('EnvVarService', () => {
           app:
             envs:
             - SERVICE_VERSION: 1.2.3
+        `);
+      });
+
+      // Removal is positional, not identity-based: a repeated index that is still in bounds removes
+      // whatever moved into that position. Callers that need to remove one specific row must track
+      // that row themselves — `useSortableEnvVars` does, keyed by the row's `uniqueId`.
+      it('removes a second entry when a still-valid index is repeated', () => {
+        updateBitriseYmlDocumentByString(
+          yaml`
+            app:
+              envs:
+              - SERVICE_VERSION: 1.2.3
+              - PROJECT_NAME: Mando
+              - ENVIRONMENT: production`,
+        );
+
+        EnvVarService.remove({ source: EnvVarSource.App, index: 0 });
+        EnvVarService.remove({ source: EnvVarSource.App, index: 0 });
+
+        expect(getYmlString()).toBe(yaml`
+          app:
+            envs:
+            - ENVIRONMENT: production
         `);
       });
     });
@@ -596,7 +619,7 @@ describe('EnvVarService', () => {
         `);
       });
 
-      it('is idempotent when the same index is removed twice', () => {
+      it('ignores a repeated index once it is past the end', () => {
         updateBitriseYmlDocumentByString(
           yaml`
             workflows:
@@ -686,7 +709,12 @@ describe('EnvVarService', () => {
         }).toThrow('The number of indices (3) should match the number of environment variables (2)');
       });
 
-      it('leaves app.envs untouched when an index is out of bounds', () => {
+      it.each([
+        ['an index is out of bounds', [0, 2]],
+        ['an index is repeated', [0, 0]],
+        ['an index is negative', [-1, 1]],
+        ['an index is not an integer', [0.5, 1]],
+      ])('leaves app.envs untouched when %s', (_, indices) => {
         updateBitriseYmlDocumentByString(
           yaml`
             app:
@@ -696,8 +724,8 @@ describe('EnvVarService', () => {
         );
 
         expect(() => {
-          EnvVarService.reorder([0, 2], { source: EnvVarSource.App });
-        }).toThrow(`The indices (0, 2) don't address every environment variable exactly once`);
+          EnvVarService.reorder(indices, { source: EnvVarSource.App });
+        }).toThrow(`The indices (${indices.join(', ')}) don't address every environment variable exactly once`);
 
         expect(getYmlString()).toBe(yaml`
           app:

--- a/source/javascripts/core/services/EnvVarService.spec.ts
+++ b/source/javascripts/core/services/EnvVarService.spec.ts
@@ -453,7 +453,7 @@ describe('EnvVarService', () => {
         `);
       });
 
-      it('throws an error when env_var is not found at index', () => {
+      it('leaves app.envs untouched when the index is out of bounds', () => {
         updateBitriseYmlDocumentByString(
           yaml`
             app:
@@ -464,7 +464,54 @@ describe('EnvVarService', () => {
 
         expect(() => {
           EnvVarService.remove({ source: EnvVarSource.App, index: 3 });
-        }).toThrow('Project-level environment variable not found, index 3 is out of bounds');
+        }).not.toThrow();
+
+        expect(getYmlString()).toBe(yaml`
+          app:
+            envs:
+            - SERVICE_VERSION: 1.2.3
+            - PROJECT_NAME: Mando
+        `);
+      });
+
+      it('leaves app.envs untouched when the index is negative', () => {
+        updateBitriseYmlDocumentByString(
+          yaml`
+            app:
+              envs:
+              - SERVICE_VERSION: 1.2.3
+              - PROJECT_NAME: Mando`,
+        );
+
+        expect(() => {
+          EnvVarService.remove({ source: EnvVarSource.App, index: -1 });
+        }).not.toThrow();
+
+        expect(getYmlString()).toBe(yaml`
+          app:
+            envs:
+            - SERVICE_VERSION: 1.2.3
+            - PROJECT_NAME: Mando
+        `);
+      });
+
+      it('is idempotent when the same index is removed twice', () => {
+        updateBitriseYmlDocumentByString(
+          yaml`
+            app:
+              envs:
+              - SERVICE_VERSION: 1.2.3
+              - PROJECT_NAME: Mando`,
+        );
+
+        EnvVarService.remove({ source: EnvVarSource.App, index: 1 });
+        EnvVarService.remove({ source: EnvVarSource.App, index: 1 });
+
+        expect(getYmlString()).toBe(yaml`
+          app:
+            envs:
+            - SERVICE_VERSION: 1.2.3
+        `);
       });
     });
 
@@ -520,7 +567,7 @@ describe('EnvVarService', () => {
         `);
       });
 
-      it('throws an error when env_var is not found at index', () => {
+      it('leaves workflows.[id].envs untouched when the index is out of bounds', () => {
         updateBitriseYmlDocumentByString(
           yaml`
             workflows:
@@ -535,7 +582,39 @@ describe('EnvVarService', () => {
 
         expect(() => {
           EnvVarService.remove({ source: EnvVarSource.Workflows, sourceId: 'wf1', index: 3 });
-        }).toThrow("Environment variable not found in Workflow 'wf1', index 3 is out of bounds");
+        }).not.toThrow();
+
+        expect(getYmlString()).toBe(yaml`
+          workflows:
+            wf1:
+              envs:
+              - NODE_VERSION: lts
+              - PROJECT_NAME: Mando
+            wf2:
+              envs:
+              - PARALLEL: 4
+        `);
+      });
+
+      it('is idempotent when the same index is removed twice', () => {
+        updateBitriseYmlDocumentByString(
+          yaml`
+            workflows:
+              wf1:
+                envs:
+                - NODE_VERSION: lts
+                - PROJECT_NAME: Mando`,
+        );
+
+        EnvVarService.remove({ source: EnvVarSource.Workflows, sourceId: 'wf1', index: 1 });
+        EnvVarService.remove({ source: EnvVarSource.Workflows, sourceId: 'wf1', index: 1 });
+
+        expect(getYmlString()).toBe(yaml`
+          workflows:
+            wf1:
+              envs:
+              - NODE_VERSION: lts
+        `);
       });
 
       it('throws an error when source is Workflow and sourceId is not provided', () => {
@@ -605,6 +684,27 @@ describe('EnvVarService', () => {
         expect(() => {
           EnvVarService.reorder([0, 1, 2], { source: EnvVarSource.App });
         }).toThrow('The number of indices (3) should match the number of environment variables (2)');
+      });
+
+      it('leaves app.envs untouched when an index is out of bounds', () => {
+        updateBitriseYmlDocumentByString(
+          yaml`
+            app:
+              envs:
+              - SERVICE_VERSION: 1.2.3
+              - PROJECT_NAME: Mando`,
+        );
+
+        expect(() => {
+          EnvVarService.reorder([0, 2], { source: EnvVarSource.App });
+        }).toThrow(`The indices (0, 2) don't address every environment variable exactly once`);
+
+        expect(getYmlString()).toBe(yaml`
+          app:
+            envs:
+            - SERVICE_VERSION: 1.2.3
+            - PROJECT_NAME: Mando
+        `);
       });
     });
 

--- a/source/javascripts/core/services/EnvVarService.ts
+++ b/source/javascripts/core/services/EnvVarService.ts
@@ -200,10 +200,14 @@ function remove(at: { source: EnvVarSource; sourceId?: string; index: number }) 
   updateBitriseYmlDocument(({ doc }) => {
     const envs = getEnvVarSeqOrThrowError(doc, at);
 
-    // Removing an entry that isn't there any more already produces the requested end state, so an
-    // out-of-bounds index is not an error here. The index comes from a list rendered in the UI,
-    // which can be a render ahead of the document (two remove clicks batched together, a change
-    // from elsewhere) — and throwing would take the whole editor down with the user's unsaved work.
+    // An index past the end already describes the requested end state, so it is not an error here:
+    // the index comes from a list rendered in the UI, which can be a render ahead of the document
+    // (two remove clicks batched together, a change from elsewhere).
+    //
+    // This makes an out-of-bounds index a no-op; it does NOT make removal idempotent. Addressing is
+    // positional, so repeating a still-valid index removes whatever sits there now — with [A, B],
+    // `remove(0)` twice removes both. A caller that needs to remove one specific row has to track
+    // that row's identity itself, the way `useSortableEnvVars` does.
     if (at.index < 0 || at.index >= envs.items.length) {
       return doc;
     }
@@ -228,15 +232,19 @@ function reorder(newIndices: number[], at: { source: EnvVarSource; sourceId?: st
       );
     }
 
-    const reordered = newIndices.map((i) => envs.get(i));
+    // A reorder has to be a permutation of the existing entries. Matching lengths alone don't make
+    // it one: an index out of range reads as undefined, and a repeated index copies one entry over
+    // another and drops whatever the missing index pointed at. Both silently rewrite the user's env
+    // vars, so validate before building the new sequence rather than after touching the document.
+    const isPermutation =
+      new Set(newIndices).size === newIndices.length &&
+      newIndices.every((i) => Number.isInteger(i) && i >= 0 && i < envs.items.length);
 
-    // `envs.get()` yields undefined for an index past the end, and assigning that into the sequence
-    // would write empty entries over the user's env vars. Bail out before touching the document.
-    if (reordered.some((env) => env === undefined)) {
+    if (!isPermutation) {
       throw new Error(`The indices (${newIndices.join(', ')}) don't address every environment variable exactly once`);
     }
 
-    envs.items = reordered;
+    envs.items = newIndices.map((i) => envs.get(i));
     return doc;
   });
 }

--- a/source/javascripts/core/services/EnvVarService.ts
+++ b/source/javascripts/core/services/EnvVarService.ts
@@ -198,7 +198,15 @@ function create(at: { source: EnvVarSource; sourceId?: string }): void {
 
 function remove(at: { source: EnvVarSource; sourceId?: string; index: number }) {
   updateBitriseYmlDocument(({ doc }) => {
-    getEnvVarOrThrowError(doc, at);
+    const envs = getEnvVarSeqOrThrowError(doc, at);
+
+    // Removing an entry that isn't there any more already produces the requested end state, so an
+    // out-of-bounds index is not an error here. The index comes from a list rendered in the UI,
+    // which can be a render ahead of the document (two remove clicks batched together, a change
+    // from elsewhere) — and throwing would take the whole editor down with the user's unsaved work.
+    if (at.index < 0 || at.index >= envs.items.length) {
+      return doc;
+    }
 
     YmlUtils.deleteByPath(
       doc,
@@ -220,7 +228,15 @@ function reorder(newIndices: number[], at: { source: EnvVarSource; sourceId?: st
       );
     }
 
-    envs.items = newIndices.map((i) => envs.get(i));
+    const reordered = newIndices.map((i) => envs.get(i));
+
+    // `envs.get()` yields undefined for an index past the end, and assigning that into the sequence
+    // would write empty entries over the user's env vars. Bail out before touching the document.
+    if (reordered.some((env) => env === undefined)) {
+      throw new Error(`The indices (${newIndices.join(', ')}) don't address every environment variable exactly once`);
+    }
+
+    envs.items = reordered;
     return doc;
   });
 }


### PR DESCRIPTION
## Summary

Removing an environment variable — on a Workflow's **Env Vars** tab or the project-level list — could throw:

```
Error: Environment variable not found in Workflow '<workflow_id>', index <N> is out of bounds
```

The index a row's handlers used was captured when the row was rendered, and stopped being valid the moment the list changed. This PR makes every mutation resolve the row's *current* position from its stable row id — including across the 250 ms debounce on key/value edits — and tightens the bounds validation in `EnvVarService` so a stale or malformed index can no longer surface an error or corrupt the document.

## Root cause

`EnvVarService` addresses env vars by their position in the YAML sequence (`workflows.<id>.envs.<N>`), so `useSortableEnvVars` has to hand it an index. It did that by baking the render-time index into each row's handlers:

```tsx
{envs.map((env, index) => (
  <SortableEnvVarItem onRemove={onRemove(index)} ... />
))}
```

```ts
const onRemove = (index: number) => () => {
  setEnvs(envs.filter((_, i) => i !== index));   // non-functional: reads the render-time list
  EnvVarService.remove({ source, sourceId, index });
};
```

Both the local list and the YAML document are mutated straight from the handler, but `envs` only catches up on the next render. So two handler calls that land in the same React batch both resolve against the pre-update list:

1. Rows are `[A, B, C]`. The user clicks Remove on `A`, then on `C` before React re-renders (a double click on one row does the same thing, and so does a click while a drag settles — the reported traces come from the sortable list).
2. The first call removes document index `0`. The document is now `[B, C]`.
3. The second call still carries the index `C` was *rendered* at — `2` — which is now past the end.
4. `getEnvVarOrThrowError` throws, out of a click handler where nothing catches it.

The same staleness applies over a longer window to key and value edits, which are debounced by 250 ms: a row removed or reordered inside that window meant the flushed write carried the row's old position.

`onDragEnd` had a related weakness: it passed raw `findIndex` results into `arrayMove`, and `arrayMove` reads a `-1` as an offset from the end, so a row that had gone missing would silently reorder unrelated rows.

## Changes

**`useSortableEnvVars` — identity instead of position**

- Handlers are keyed by the row's `uniqueId` and resolve its index at call time. A row that is already gone resolves to `-1` and the handler is a no-op.
- The list is mirrored in a ref that is updated synchronously alongside `setEnvs`, so a handler sees the effect of an earlier call in the same batch instead of the last rendered list. This also fixes a latent lost-update bug: two edits to different rows in one batch previously kept only one.
- **The debounced key and value writes carry the `uniqueId` across the debounce boundary** and resolve the position when they actually run, dropping the write if the row is gone by then. `oldKey` / `key` are still captured at call time on purpose: they describe the row itself — what the caller knows the document holds for it — not where it sits.
- **A pending write also re-checks the file it was scheduled against, and whether the list is still mounted**, and declines to land otherwise. See the next section.
- `onDragEnd` bails out when either dragged row is no longer in the list.

**`EnvVarService` — validate at the boundary**

- `remove` validates the index and returns the document untouched when it is out of bounds, instead of throwing. An index past the end already describes the requested end state. The genuine errors (missing `sourceId`, unknown Workflow, no `envs` section) still throw as before.
- `reorder` now requires the index set to be an actual permutation: matching length, unique, and every entry an in-range integer. Length alone didn't make it one — `[0, 0]` on a two-entry list passed the previous check, copied the first entry over the second and dropped it. It throws *before* the new sequence is built, so a malformed set can't touch the document.

## Where a pending write is allowed to land

Two findings from review, both pre-existing on `master` and both about the debounce window rather than the index inside it.

**The write can end up in the wrong file.** `EnvVarService.updateKey`/`updateValue` → `updateBitriseYmlDocument` → `editableActiveSlice()`, which reads `selectedNodeId` *when the mutator runs*. In modular mode the same `sourceId` can live in several files, so a file-tab switch inside the 250 ms window redirects the write. I reproduced it: with `bitrise.yml` and an included `child-a.yml` both defining `workflows.wf1.envs` with a matching key at the same index, a rename scheduled against the root landed in `child-a.yml` and left `bitrise.yml` untouched — no error, no sign anything went wrong.

Worth being precise about what fixes it, because I got this wrong once on the way: reading the active file from a rendered value, or from a ref an effect keeps up to date, is **not** enough. A file switch reaches the store before React re-renders, and the timer can fire in that gap — that's exactly the shape of the reproduction above. The pending write now records the active file by reading the store, and re-reads the store when it flushes, so the check doesn't depend on React having caught up. There's a test for each side of that: one where the switch has been through a render, and one where it hasn't.

**The write can outlive the list.** The debounce timer survives unmount, because `useDebounceCallback`'s unmount cancel targets a debounce instance built in its own `useEffect` — not the one it hands back and that actually gets called. So closing the drawer within 250 ms of a keystroke still wrote, and if the Workflow was gone by then `getWorkflowOrThrowError` threw from inside a `setTimeout`, where no error boundary is listening. A pending write now checks it is still mounted before doing anything, which holds regardless of how many debounce instances have live timers.

## The debounce does not actually coalesce — and hoisting the options object is not a safe fix alone

The review is right about the mechanism: `{ leading: false }` is a fresh object every render, `useDebounceCallback` memoises on `[func, delay, options]`, and the `Input` is controlled by `env.key`, so every keystroke builds a new debounce instance. Nothing is coalesced; each keystroke schedules its own 250 ms write.

I did not hoist the options object to a module constant, because on its own it makes things worse, and I checked rather than assumed. With one stable instance the second keystroke of a burst cancels the first, and the surviving write carries an `oldKey` captured from local state — the *first* keystroke's value, which was never written to the document. `updateKey`'s `has(oldKey)` check then fails:

```
Environment variable key is not matching "N"
```

That is the throw the review itself names as evidence that coalescing isn't happening today. There's now a test pinning this (`lands every keystroke of a burst, because each rename builds on the previous one`) so the coupling is executable rather than folklore — it fails the moment someone hoists the constant.

Making coalescing correct needs two more things, and together they're a redesign of this write path rather than a line move:

1. **Burst-scoped `oldKey`** — the surviving write has to carry the key the document held *before* the burst, not the previous keystroke's local value.
2. **Per-row debouncing** — one shared debounced function coalesces *across* rows too, so typing in row A and then row B inside the window cancels A's write and silently loses that edit. Today's broken memoisation is what hides this.

I'd rather do that as its own PR, with its own write-volume before/after, than fold it in here — the writes-per-keystroke behaviour is unchanged by this PR either way, and the harms the review identified (wrong file, post-unmount write, uncaught `setTimeout` throw) are fixed directly above and don't depend on the debounce topology. Happy to be overruled on the sequencing.

## What `remove`'s bounds check does and does not promise

An earlier revision of this description called `remove` "idempotent". That was wrong, and the review was right to push on it. Addressing is positional, so repeating a *still-valid* index removes whatever moved into that position — with `[A, B]`, `remove(0)` twice removes both entries.

The narrowed, accurate contract: **an out-of-bounds index is a no-op** — which is exactly the crash this PR fixes — and nothing more. Removing one specific row is the caller's responsibility, which is what the `uniqueId` addressing in `useSortableEnvVars` provides. Both the code comment and the tests now say this, and there's a test pinning the positional behaviour so nobody infers idempotence from the no-op case.

Making the service resolve rows by identity itself was the alternative, and I don't think it's available: the YAML document has no stable per-entry id to resolve against, and keys can repeat and are empty on a freshly added row (`{"": ""}`), so they can't stand in for one.

## Correction on the failure mode

An earlier revision of this description said the throw took the editor down "along with every unsaved change on the page". That was also wrong. The app's top-level error boundary renders a pass-through fallback that immediately calls `resetError()`, and the YAML document lives in a Zustand store outside React — so the tree recovers and unsaved work survives. The user-visible effect is a failed operation and a surfaced error, not a lost session. Worth fixing either way, but the severity claim was overstated and the code comment that repeated it has been reworded.

## Testing

- `EnvVarService.spec.ts`: the two "throws when the index is out of bounds" cases for `remove` are replaced with cases asserting the document is left untouched (out-of-bounds and negative index, project- and Workflow-level); a repeated-index case renamed to say what it actually covers (a repeat that has gone past the end); a new case pinning the positional semantics of a repeated still-valid index; and `reorder` cases for out-of-bounds, **duplicate**, negative and non-integer index sets, each asserting it throws and leaves the document unchanged.
- `useSortableEnvVars.spec.tsx` covers the production sequence directly: two removals in one `act()` remove exactly the two intended rows; a repeated removal of the same row is ignored; an `is_expand` toggle still lands on the row it was toggled on after a preceding row is removed; and eight fake-timer cases for the debounce window — a value and a key write landing on the right row after a preceding row is removed, a pending write dropped for a row removed before it flushes, a pending write dropped after unmount, the burst invariant above, and three modular-config cases (a file switch that has been through a render, a file switch that has only reached the store, and a positive control confirming a write still lands when the file *hasn't* changed).
- Each new case was checked against the pre-fix code: the three debounce cases and the duplicate `reorder` case fail without these changes and pass with them. The other three `reorder` cases were already caught by the previous check, so the new validation is a strict superset.
- `npm test` (1504 tests) and `npx tsc --noEmit` pass. `npm run lint` reports 0 errors, and one *fewer* warning than `master`: the seeding effect now sets state through `updateEnvs`, which `react-hooks/set-state-in-effect` no longer flags. That's incidental indirection, not a deliberate silencing — the effect still seeds the list on mount, as it must.

## Remaining known limitations

- The local list still isn't re-seeded when the document changes from elsewhere (e.g. an edit on the YAML tab while an env var list is mounted). That desync can misaddress a row that is still in bounds, which no amount of index validation can catch — it needs the list to re-seed on external document changes, and doing that without clobbering in-flight debounced edits is its own piece of work.
- The debounce still doesn't coalesce, for the reasons set out above. Fixing that properly (per-row debouncing plus burst-scoped `oldKey`) is the follow-up I'd like to do separately.

Neither affects the reported crash, which is fully covered.

---
_Found via a routine Datadog FE error-log check (service:wfe, last 24h). Fixed by an RDE coding agent, orchestrated by Kolega._