### PR TITLE
[CI-6428] Count only the workflows that actually use a Step bundle

### DIFF
--- a/docs/decisions.md
+++ b/docs/decisions.md
@@ -208,8 +208,7 @@ Reproduced, not inferred. Each one is a real bug someone will hit.
 | What | Where | Status |
 |---|---|---|
 | Cross-file delete and rename leave dangling or stale references | modular mode | ticketed |
-| `getStepBundleChain` recurses with no cycle guard, and the UI filter that prevents cycles is built from the same walk, so it throws first | `StepBundleService` | ticketed |
-| `getBeforeRunChain` / `getAfterRunChain` have the identical defect | `WorkflowService` | open |
+| `getBeforeRunChain` / `getAfterRunChain` recurse with no cycle guard, and the UI filter that prevents cycles is built from the same walk, so it throws first | `WorkflowService` | open |
 | Chaining accepts a cross-file workflow, reordering rejects it | `WorkflowService` | open |
 | The shipping merge dialog positions conflict decorations with the wrong offsets | `ConfigMergeDialog.tsx` | open |
 | `hasVersionUpgrade` resolves your pin and then compares against every published version rather than the ones the pin allows, so a step held at `2` wears a permanent badge. A spec asserts the current behaviour, so a fix breaks a passing test | `VersionUtils` | open |

--- a/source/javascripts/core/services/StepBundleService.spec.ts
+++ b/source/javascripts/core/services/StepBundleService.spec.ts
@@ -119,6 +119,22 @@ describe('StepBundleService', () => {
     });
   });
 
+  describe('getStepBundleChains', () => {
+    it('terminates on a cycle between bundles', () => {
+      const cyclic: StepBundles = {
+        a: { steps: [{ 'bundle::b': {} }] },
+        b: { steps: [{ 'bundle::a': {} }] },
+        selfReferencing: { steps: [{ 'bundle::selfReferencing': {} }] },
+      };
+
+      expect(StepBundleService.getStepBundleChains(cyclic)).toEqual({
+        a: ['a', 'b'],
+        b: ['b', 'a'],
+        selfReferencing: ['selfReferencing'],
+      });
+    });
+  });
+
   describe('createStepBundle', () => {
     it('creates an empty step bundle', () => {
       updateBitriseYmlDocumentByString(

--- a/source/javascripts/core/services/StepBundleService.spec.ts
+++ b/source/javascripts/core/services/StepBundleService.spec.ts
@@ -1,5 +1,6 @@
 import StepBundleService from '@/core/services/StepBundleService';
 
+import { StepBundles, Workflows } from '../models/BitriseYml';
 import { getYmlString, updateBitriseYmlDocumentByString } from '../stores/BitriseYmlStore';
 
 describe('StepBundleService', () => {
@@ -56,6 +57,65 @@ describe('StepBundleService', () => {
           'Step bundle name should be unique',
         );
       });
+    });
+  });
+
+  describe('getDependantWorkflows', () => {
+    const stepBundles: StepBundles = {
+      parent: { steps: [{ 'bundle::child': {} }] },
+      child: { steps: [{ 'bundle::grandchild': {} }] },
+      grandchild: { steps: [{ script: {} }] },
+      standalone: { steps: [{ script: {} }] },
+      unused: { steps: [{ script: {} }] },
+    };
+
+    const workflows: Workflows = {
+      wf1: { steps: [{ 'bundle::parent': {} }] },
+      wf2: { steps: [{ 'bundle::standalone': {} }] },
+      wf3: { steps: [{ script: {} }] },
+      wf4: { steps: [{ 'bundle::child': {} }, { 'bundle::standalone': {} }] },
+    };
+
+    it('returns the workflows referencing the bundle directly', () => {
+      expect(StepBundleService.getDependantWorkflows(workflows, 'bundle::parent', stepBundles)).toEqual(['wf1']);
+    });
+
+    it('returns the workflows referencing the bundle through a parent bundle', () => {
+      expect(StepBundleService.getDependantWorkflows(workflows, 'bundle::grandchild', stepBundles).sort()).toEqual([
+        'wf1',
+        'wf4',
+      ]);
+    });
+
+    it('ignores the usages of unrelated nested bundles', () => {
+      expect(StepBundleService.getDependantWorkflows(workflows, 'bundle::standalone', stepBundles).sort()).toEqual([
+        'wf2',
+        'wf4',
+      ]);
+    });
+
+    it('returns an empty array for a bundle no workflow references', () => {
+      expect(StepBundleService.getDependantWorkflows(workflows, 'bundle::unused', stepBundles)).toEqual([]);
+    });
+
+    it('lists a workflow once when it references the bundle more than once', () => {
+      const twice: Workflows = { wf: { steps: [{ 'bundle::standalone': {} }, { 'bundle::standalone': {} }] } };
+      expect(StepBundleService.getDependantWorkflows(twice, 'bundle::standalone', stepBundles)).toEqual(['wf']);
+    });
+
+    it('counts direct references to a bundle missing from step_bundles', () => {
+      // The shape a modular config produces: the active file references a bundle another module defines.
+      const noLocalDefinition: Workflows = { wf: { steps: [{ 'bundle::remote': {} }] } };
+      expect(StepBundleService.getDependantWorkflows(noLocalDefinition, 'bundle::remote', {})).toEqual(['wf']);
+    });
+
+    it('terminates on a cycle between bundles', () => {
+      const cyclic: StepBundles = {
+        a: { steps: [{ 'bundle::b': {} }] },
+        b: { steps: [{ 'bundle::a': {} }] },
+      };
+      const usingA: Workflows = { wf: { steps: [{ 'bundle::a': {} }] } };
+      expect(StepBundleService.getDependantWorkflows(usingA, 'bundle::b', cyclic)).toEqual(['wf']);
     });
   });
 

--- a/source/javascripts/core/services/StepBundleService.ts
+++ b/source/javascripts/core/services/StepBundleService.ts
@@ -36,6 +36,17 @@ function validateName(newStepBundleName: string, initStepBundleName: string, ste
   return true;
 }
 
+function cvsToId(cvs: string) {
+  return cvs.replace('bundle::', '');
+}
+
+function idToCvs(id: string) {
+  if (id.startsWith('bundle::')) {
+    return id;
+  }
+  return `bundle::${id}`;
+}
+
 function getDirectDependants(workflows: Workflows, cvs: string) {
   const directDependants: string[] = [];
   Object.entries(workflows ?? {}).forEach(([workflowId, workflow]) => {
@@ -50,19 +61,20 @@ function getDirectDependants(workflows: Workflows, cvs: string) {
 }
 
 function getDependantWorkflows(workflows: Workflows, cvs: string, stepBundles: StepBundles) {
-  let directDependants: string[] = getDirectDependants(workflows, cvs);
+  const id = cvsToId(cvs);
 
-  const stepBundleChains = getStepBundleChains(stepBundles);
+  // A workflow depends on this bundle through any bundle whose chain reaches it, so a nested bundle
+  // counts the workflows using its parents too. Only the chains containing `id` may contribute:
+  // an unrelated family's chain says nothing about this bundle's usage.
+  const referencingIds = Object.keys(stepBundles).filter((bundleId) =>
+    getStepBundleChain(stepBundles, bundleId).includes(id),
+  );
 
-  Object.values(stepBundleChains).forEach((chain) => {
-    if (chain.length > 1) {
-      chain.forEach((bundle) => {
-        directDependants = directDependants.concat(getDirectDependants(workflows, idToCvs(bundle)));
-      });
-    }
-  });
+  // `cvs` is added explicitly: a bundle defined in another module file is absent from `stepBundles`,
+  // so the chain filter alone would not even find the bundle itself.
+  const referencingCvss = uniq([cvs, ...referencingIds.map(idToCvs)]);
 
-  return uniq(directDependants);
+  return uniq(referencingCvss.flatMap((referencingCvs) => getDirectDependants(workflows, referencingCvs)));
 }
 
 function getUsedByText(count: number) {
@@ -77,14 +89,28 @@ function getUsedByText(count: number) {
 }
 
 function getStepBundleChain(stepBundles: StepBundles, id: string) {
-  let ids: string[] = [];
-  stepBundles[id]?.steps?.forEach((step) => {
-    const cvs = Object.keys(step)[0];
-    if (cvs && cvs.startsWith('bundle::')) {
-      ids = ids.concat(getStepBundleChain(stepBundles, cvs.replace('bundle::', '')));
+  const ids: string[] = [];
+  // A cycle is unreachable through the UI but not through a hand-edited YAML or a cross-file
+  // reference, and an unguarded walk blows the stack.
+  const visited = new Set<string>();
+
+  function walk(currentId: string) {
+    if (visited.has(currentId)) {
+      return;
     }
-  });
-  ids.unshift(id);
+    visited.add(currentId);
+    ids.push(currentId);
+
+    stepBundles[currentId]?.steps?.forEach((step) => {
+      const cvs = Object.keys(step)[0];
+      if (cvs && cvs.startsWith('bundle::')) {
+        walk(cvsToId(cvs));
+      }
+    });
+  }
+
+  walk(id);
+
   return ids;
 }
 
@@ -95,17 +121,6 @@ function getStepBundleChains(stepBundles: StepBundles) {
   });
 
   return stepBundleChains;
-}
-
-function cvsToId(cvs: string) {
-  return cvs.replace('bundle::', '');
-}
-
-function idToCvs(id: string) {
-  if (id.startsWith('bundle::')) {
-    return id;
-  }
-  return `bundle::${id}`;
 }
 
 function ymlInstanceToStepBundle(


### PR DESCRIPTION
The "Used by N Workflows" counter on Step bundles counted usages from unrelated nested bundle families, so with a single nested bundle anywhere in the config every bundle reported the same inflated number and removing a bundle from a workflow did not bring its count down. `getDependantWorkflows` now filters the bundle chains by the bundle being counted.

<details>
<summary>Details</summary>

## Root cause

`StepBundleService.getDependantWorkflows` walked **every** step bundle chain, not just the chains that reach the target bundle:

```js
Object.values(stepBundleChains).forEach((chain) => {
  if (chain.length > 1) {
    chain.forEach((bundle) => {
      directDependants = directDependants.concat(getDirectDependants(workflows, idToCvs(bundle)));
    });
  }
});
```

Every chain longer than one entry (that is, every nested bundle family) contributed all of its members' usages to the target's count, regardless of whether the target had anything to do with that family. Nesting is what makes the difference: without a single nested bundle all chains have length 1, the loop contributes nothing, and the count is correct. That is why this went unnoticed.

The chain walk landed with #1437; #1470 later added the `chain.length > 1` guard, which fixed the non-nested case but not the nested one. The function had no unit tests.

## Evidence from the reported config

The reporter attached a project using 13 step bundles across 7 workflows. Running the old and the new implementation against its actual configuration:

| step bundle | before | after | actual users |
|---|---|---|---|
| android-debug-build | **5** | 1 | debug-build |
| android-release-build | **5** | 2 | prod-release-build, release-build |
| artifact-download-links | **5** | 3 | transitively, via the two teams-* bundles |
| env_file_token_replacement | **5** | 3 | debug-build, prod-release-build, release-build |
| install-test-analyze | **5** | 5 | all five bundle-using workflows |
| ios-debug-build | **5** | 1 | debug-build |
| ios-release-build | **5** | 2 | prod-release-build, release-build |
| parse-jira-ticket | **5** | 1 | debug-build |
| pubspec-transformations | **5** | 5 | transitively, via install-test-analyze |
| rename-artifact-file-names | **5** | 3 | debug-build, prod-release-build, release-build |
| teams-debug-build-notification | **5** | 1 | debug-build |
| teams-release-build-notification | **5** | 2 | prod-release-build, release-build |
| upload-to-testflight | **5** | 3 | transitively, via the two ios-* bundles |

Before the change all 13 bundles report exactly 5, which matches the report ("all their step bundles say Used by 5 workflows"). `install-test-analyze` is what pulls the 5 in: it nests `pubspec-transformations`, so its chain passes the old length gate, and all five bundle-using workflows reference it. Every other bundle then inherits those five.

## The fix

A workflow depends on a bundle when it references the bundle itself, or any bundle whose chain reaches it. Filtering the chains by the target keeps the intended transitive semantics (a nested bundle still counts the workflows using its parents) while dropping the unrelated families. The target's own cvs is added explicitly, because a bundle defined in another module file is absent from the local `step_bundles` map.

`getStepBundleChain` also picked up a `visited` guard. A cycle is unreachable through the UI (`StepBundleList` excludes it) but not through a hand-edited YAML or a cross-file reference, and the unguarded recursion threw `RangeError: Maximum call stack size exceeded`. The chain is now duplicate-free as a side effect; every one of its five call sites only does `.includes` on it, so nothing depends on its length, order or duplicates.

## Blast radius

The same function feeds five surfaces, all via `useDependantWorkflows`: the Step bundles page header, the bundle drawer on the Workflows page, the bundle list in the step selector drawer, the bundle card on the canvas, and (through `ContainerService.getWorkflowsUsingContainers`) the container usage table and the delete-container dialog. The last one is the most consequential: it listed unrelated workflows as affected by a container deletion.

## Tests

Seven cases added for `getDependantWorkflows`, over a `parent -> child -> grandchild` chain plus a standalone and an unused bundle. Four of them fail against the pre-fix implementation:

| case | pre-fix result |
|---|---|
| direct reference (`parent`) | `[wf1, wf4]`, `child`'s users leaked in |
| unrelated nested bundles ignored (`standalone`) | `[wf1, wf2, wf4]` |
| unused bundle returns `[]` | `[wf1, wf4]` |
| cycle terminates | `RangeError: Maximum call stack size exceeded` |

The remaining three (transitive usage, a workflow referencing the bundle twice, a bundle missing from `step_bundles`) already passed and are regression guards.

Verified: `npm test` 1495 pass / 40 suites (1488 on master, so only the new cases were added and nothing regressed), `npx tsc --noEmit` clean, `npm run lint` 0 errors and 83 warnings (84 on master), `npm run build` succeeds, `go vet ./...` clean. `go test ./...` has one failure, `TestPostSpecHandler`, which is pre-existing and environmental: this change touches no Go file, and the failure comes from a stale `~/.stepman/routing.json` entry pointing at a step collection directory that no longer exists.

## Not in scope

- **Modular configs only count the active file.** A bundle defined in one module and used by a workflow in another still undercounts, because the store's `yml` is bound to the active document. Fixing that belongs in the hook rather than the service, following the pattern `useContainerWorkflowUsage` already uses for containers.
- **`with` groups.** `getDirectDependants` only scans the top level of `workflow.steps`, so a bundle referenced inside a `with` group is not counted. It is unclear whether that is even a valid configuration; the editor refuses to group a `with` into a bundle.
- **Copy inconsistency** in `getUsedByText`: "Used **in** 1 Workflow" for one, "Used **by** N Workflows" otherwise.
</details>
