### PR TITLE
fix(yml editor): recover from a broken Monaco marker navigation session

### DIFF
--- a/source/javascripts/core/utils/MonacoUtils.spec.ts
+++ b/source/javascripts/core/utils/MonacoUtils.spec.ts
@@ -66,7 +66,7 @@ function createBrokenController(brokenAttempts: number) {
   return { controller, attempts };
 }
 
-function guard(controller: MarkerController | null, { onCreate = false } = {}) {
+function guard(controller: object | null, { onCreate = false } = {}) {
   const editor = {
     getContribution: (id: string) => (id === MARKER_NAVIGATION_CONTROLLER_ID ? controller : null),
   };
@@ -164,6 +164,44 @@ describe('MonacoUtils.configureMarkerNavigationGuard', () => {
     expect(() => controller.showAtMarker({})).toThrow("Cannot read properties of undefined (reading 'showAtMarker')");
     expect(attempts.showAtMarker).toBe(2);
     expect(controller.close).toHaveBeenCalledTimes(1);
+  });
+
+  // The type argument to `getContribution` is erased at build time, so only a runtime check keeps a
+  // renamed or removed method from throwing while an editor is being created.
+  it.each(['showAtMarker', 'navigate', 'close'])('leaves a contribution alone when %s is missing', (missing) => {
+    const complete: Record<string, unknown> = {
+      showAtMarker: () => {},
+      navigate: async () => {},
+      close: () => {},
+    };
+    const controller: Record<string, unknown> = { ...complete };
+    delete controller[missing];
+
+    expect(() => guard(controller)).not.toThrow();
+
+    // Nothing was replaced: the guard behaves as if it had never been installed.
+    Object.keys(controller).forEach((name) => {
+      expect(controller[name]).toBe(complete[name]);
+    });
+  });
+
+  it('leaves a contribution alone when an expected method is not callable', () => {
+    const controller = { showAtMarker: 'not a function', navigate: async () => {}, close: () => {} };
+    const { navigate, close } = controller;
+
+    expect(() => guard(controller)).not.toThrow();
+
+    expect(controller.navigate).toBe(navigate);
+    expect(controller.close).toBe(close);
+  });
+
+  it('wraps a contribution that has all of the expected methods', () => {
+    const { controller } = createBrokenController(0);
+    const original = controller.showAtMarker;
+
+    guard(controller);
+
+    expect(controller.showAtMarker).not.toBe(original);
   });
 
   it('tolerates an editor without a marker navigation controller', () => {

--- a/source/javascripts/core/utils/MonacoUtils.spec.ts
+++ b/source/javascripts/core/utils/MonacoUtils.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * @jest-environment jsdom
+ */
+// `monaco-editor` and friends are browser-only ESM bundles jest can't even resolve, and the guard
+// under test needs none of them — it only ever touches the editor object it is handed.
+jest.mock('monaco-editor', () => ({ editor: {}, MarkerSeverity: { Error: 8, Warning: 4 } }), { virtual: true });
+jest.mock('monaco-yaml', () => ({ configureMonacoYaml: jest.fn() }), { virtual: true });
+jest.mock('@bitrise/languageserver/monaco', () => ({ configureBitriseYaml: jest.fn() }), { virtual: true });
+jest.mock('@monaco-editor/react', () => ({ loader: { config: jest.fn() } }), { virtual: true });
+
+const MARKER_NAVIGATION_CONTROLLER_ID = 'editor.contrib.markerController';
+
+type MarkerController = {
+  showAtMarker: (marker: unknown) => void;
+  navigate: (next: boolean, multiFile?: boolean) => Promise<void>;
+  close: jest.Mock<void, [boolean?]>;
+};
+
+type MonacoUtilsModule = {
+  configureMarkerNavigationGuard: (monacoInstance: unknown) => void;
+};
+
+/**
+ * A fresh module instance per test — `configureMarkerNavigationGuard` is guarded by a module-level
+ * "already configured" flag, like the other `configure*` helpers.
+ */
+function loadMonacoUtils(): MonacoUtilsModule {
+  let loaded: MonacoUtilsModule | undefined;
+
+  jest.isolateModules(() => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    loaded = require('./MonacoUtils').default;
+  });
+
+  if (!loaded) {
+    throw new Error('MonacoUtils failed to load');
+  }
+
+  return loaded;
+}
+
+/**
+ * A controller whose session is broken for the first `brokenAttempts` calls and healthy afterwards,
+ * mirroring Monaco's own state: a marker list without its peek widget throws until the session is
+ * closed and rebuilt.
+ */
+function createBrokenController(brokenAttempts: number) {
+  const attempts = { showAtMarker: 0, navigate: 0 };
+
+  const controller: MarkerController = {
+    showAtMarker: () => {
+      attempts.showAtMarker += 1;
+      if (attempts.showAtMarker <= brokenAttempts) {
+        throw new TypeError("Cannot read properties of undefined (reading 'showAtMarker')");
+      }
+    },
+    navigate: async () => {
+      attempts.navigate += 1;
+      if (attempts.navigate <= brokenAttempts) {
+        throw new TypeError("Cannot read properties of undefined (reading 'showAtMarker')");
+      }
+    },
+    close: jest.fn(),
+  };
+
+  return { controller, attempts };
+}
+
+function guard(controller: MarkerController | null, { onCreate = false } = {}) {
+  const editor = {
+    getContribution: (id: string) => (id === MARKER_NAVIGATION_CONTROLLER_ID ? controller : null),
+  };
+
+  loadMonacoUtils().configureMarkerNavigationGuard({
+    editor: {
+      getEditors: () => (onCreate ? [] : [editor]),
+      onDidCreateEditor: (listener: (created: typeof editor) => void) => {
+        if (onCreate) {
+          listener(editor);
+        }
+        return { dispose: () => {} };
+      },
+    },
+  });
+
+  return editor;
+}
+
+describe('MonacoUtils.configureMarkerNavigationGuard', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('rebuilds the session and retries when showAtMarker fails', () => {
+    const { controller, attempts } = createBrokenController(1);
+    guard(controller);
+
+    expect(() => controller.showAtMarker({})).not.toThrow();
+
+    expect(controller.close).toHaveBeenCalledWith(false);
+    expect(attempts.showAtMarker).toBe(2);
+  });
+
+  it('rebuilds the session and retries when navigate fails', async () => {
+    const { controller, attempts } = createBrokenController(1);
+    guard(controller);
+
+    await expect(controller.navigate(true)).resolves.toBeUndefined();
+
+    expect(controller.close).toHaveBeenCalledWith(false);
+    expect(attempts.navigate).toBe(2);
+  });
+
+  it('leaves a healthy session alone', () => {
+    const { controller, attempts } = createBrokenController(0);
+    guard(controller);
+
+    controller.showAtMarker({});
+
+    expect(controller.close).not.toHaveBeenCalled();
+    expect(attempts.showAtMarker).toBe(1);
+  });
+
+  it('lets a failure on the rebuilt session propagate', () => {
+    const { controller, attempts } = createBrokenController(2);
+    guard(controller);
+
+    expect(() => controller.showAtMarker({})).toThrow("Cannot read properties of undefined (reading 'showAtMarker')");
+    expect(attempts.showAtMarker).toBe(2);
+  });
+
+  it('guards editors created after it is configured', () => {
+    const { controller, attempts } = createBrokenController(1);
+    guard(controller, { onCreate: true });
+
+    expect(() => controller.showAtMarker({})).not.toThrow();
+    expect(attempts.showAtMarker).toBe(2);
+  });
+
+  it('does not wrap the same controller twice', () => {
+    // Two broken attempts, so one layer of wrapping gives up and rethrows. A second layer would
+    // catch that rethrow and buy the call a third attempt — which this controller survives.
+    const { controller, attempts } = createBrokenController(2);
+    const editor = {
+      getContribution: (id: string) => (id === MARKER_NAVIGATION_CONTROLLER_ID ? controller : null),
+    };
+    const listeners: ((created: typeof editor) => void)[] = [];
+
+    loadMonacoUtils().configureMarkerNavigationGuard({
+      editor: {
+        getEditors: () => [editor, editor],
+        onDidCreateEditor: (listener: (created: typeof editor) => void) => {
+          listeners.push(listener);
+          return { dispose: () => {} };
+        },
+      },
+    });
+    listeners.forEach((listener) => listener(editor));
+
+    expect(() => controller.showAtMarker({})).toThrow("Cannot read properties of undefined (reading 'showAtMarker')");
+    expect(attempts.showAtMarker).toBe(2);
+    expect(controller.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('tolerates an editor without a marker navigation controller', () => {
+    expect(() => guard(null)).not.toThrow();
+  });
+});

--- a/source/javascripts/core/utils/MonacoUtils.ts
+++ b/source/javascripts/core/utils/MonacoUtils.ts
@@ -247,7 +247,24 @@ type MarkerNavigationController = monaco.editor.IEditorContribution & {
   close(focusEditor?: boolean): void;
 };
 
-const guardedMarkerControllers = new WeakSet<MarkerNavigationController>();
+const guardedMarkerControllers = new WeakSet<monaco.editor.IEditorContribution>();
+
+/**
+ * Whether the contribution really exposes the three methods the guard wraps and calls. The type
+ * argument to `getContribution` is erased at build time, so this check is the only thing standing
+ * between a renamed method and a `.bind` of undefined thrown while an editor is being created.
+ */
+function hasMarkerNavigationApi(
+  contribution: monaco.editor.IEditorContribution,
+): contribution is MarkerNavigationController {
+  const candidate = contribution as Partial<MarkerNavigationController>;
+
+  return (
+    typeof candidate.showAtMarker === 'function' &&
+    typeof candidate.navigate === 'function' &&
+    typeof candidate.close === 'function'
+  );
+}
 
 function warnBrokenMarkerSession(error: unknown) {
   // eslint-disable-next-line no-console
@@ -273,9 +290,17 @@ function warnBrokenMarkerSession(error: unknown) {
  * a different fault on a freshly built session and is deliberately left to propagate.
  */
 function guardMarkerNavigation(editor: monaco.editor.ICodeEditor) {
-  const controller = editor.getContribution<MarkerNavigationController>(MARKER_NAVIGATION_CONTROLLER_ID);
+  const controller = editor.getContribution<monaco.editor.IEditorContribution>(MARKER_NAVIGATION_CONTROLLER_ID);
 
   if (!controller || guardedMarkerControllers.has(controller)) {
+    return;
+  }
+
+  // Checked before the controller is marked or touched, so an upgrade that renames or drops any of
+  // these leaves the guard inert instead of failing editor creation, and never half-wraps. A shape
+  // this doesn't recognise likely doesn't keep the session invariant below either, so such a
+  // controller is left completely alone.
+  if (!hasMarkerNavigationApi(controller)) {
     return;
   }
 

--- a/source/javascripts/core/utils/MonacoUtils.ts
+++ b/source/javascripts/core/utils/MonacoUtils.ts
@@ -238,6 +238,87 @@ const configureBitriseLanguageServer: BeforeMountHandler = (monacoInstance) => {
   isConfiguredForBitriseLanguageServer = true;
 };
 
+const MARKER_NAVIGATION_CONTROLLER_ID = 'editor.contrib.markerController';
+
+/** The parts of Monaco's (internal) marker-navigation controller the guard below touches. */
+type MarkerNavigationController = monaco.editor.IEditorContribution & {
+  showAtMarker(marker: monaco.editor.IMarker): void;
+  navigate(next: boolean, multiFile?: boolean): Promise<void>;
+  close(focusEditor?: boolean): void;
+};
+
+const guardedMarkerControllers = new WeakSet<MarkerNavigationController>();
+
+function warnBrokenMarkerSession(error: unknown) {
+  // eslint-disable-next-line no-console
+  console.warn('Rebuilding the marker navigation session after a failed attempt to open it:', error);
+}
+
+/**
+ * Monaco's marker-navigation controller — the "View Problem" action in a marker hover, and the
+ * next/previous problem commands — keeps its peek widget and its marker list as one session, and
+ * assumes that a session holding a marker list also holds a widget:
+ *
+ *     const model = this._getOrCreateModel(textModel.uri);  // returns an existing list untouched
+ *     ...
+ *     this._widget.showAtMarker(...)                        // undefined if the widget is gone
+ *
+ * A session that ends up with only half of that therefore raises `Cannot read properties of
+ * undefined (reading 'showAtMarker')` from inside Monaco's own hover click handler and marker
+ * commands, where the editor has nowhere to catch it. The dereference is still unguarded upstream
+ * in monaco-editor 0.56.0, so a version bump doesn't help.
+ *
+ * Closing the controller drops the stale session, which makes the retry rebuild both halves — so
+ * the user gets the peek widget they asked for instead of a dead click. A retry that fails again is
+ * a different fault on a freshly built session and is deliberately left to propagate.
+ */
+function guardMarkerNavigation(editor: monaco.editor.ICodeEditor) {
+  const controller = editor.getContribution<MarkerNavigationController>(MARKER_NAVIGATION_CONTROLLER_ID);
+
+  if (!controller || guardedMarkerControllers.has(controller)) {
+    return;
+  }
+
+  guardedMarkerControllers.add(controller);
+
+  const showAtMarker = controller.showAtMarker.bind(controller);
+  const navigate = controller.navigate.bind(controller);
+
+  controller.showAtMarker = (marker) => {
+    try {
+      showAtMarker(marker);
+    } catch (error) {
+      warnBrokenMarkerSession(error);
+      controller.close(false);
+      showAtMarker(marker);
+    }
+  };
+
+  controller.navigate = async (next, multiFile) => {
+    try {
+      await navigate(next, multiFile);
+    } catch (error) {
+      warnBrokenMarkerSession(error);
+      controller.close(false);
+      await navigate(next, multiFile);
+    }
+  };
+}
+
+let isConfiguredForMarkerNavigationGuard = false;
+const configureMarkerNavigationGuard: BeforeMountHandler = (monacoInstance) => {
+  if (isConfiguredForMarkerNavigationGuard) {
+    return;
+  }
+
+  // Editors that already exist are covered too, so the guard doesn't depend on this running before
+  // the first editor is created.
+  monacoInstance.editor.getEditors().forEach(guardMarkerNavigation);
+  monacoInstance.editor.onDidCreateEditor(guardMarkerNavigation);
+
+  isConfiguredForMarkerNavigationGuard = true;
+};
+
 export type ValidationStatus = 'valid' | 'invalid' | 'warnings';
 
 /**
@@ -308,6 +389,7 @@ export default {
   configureForYaml,
   configureBitriseLanguageServer,
   configureEnvVarsCompletionProvider,
+  configureMarkerNavigationGuard,
   onModelMarkerStatusChange,
   onWorkspaceMarkerStatusChange,
 };

--- a/source/javascripts/hooks/useYmlLanguageServices.ts
+++ b/source/javascripts/hooks/useYmlLanguageServices.ts
@@ -107,6 +107,9 @@ function useYmlLanguageServices() {
     // Configure Monaco language services (idempotent — safe to call multiple times)
     MonacoUtils.configureForYaml(monaco);
     MonacoUtils.configureEnvVarsCompletionProvider(monaco);
+    // Marker navigation is reachable from every editor that shows diagnostics, so the guard is
+    // installed with the language services rather than per editor component.
+    MonacoUtils.configureMarkerNavigationGuard(monaco);
     // The Bitrise LSP integration runs a Monaco worker that queries Algolia (steplib_steps)
     // on every document change for diagnostics/completion/hover. Gate it behind a flag so it
     // can be disabled without a deploy. When off, editing falls back to plain monaco-yaml.

--- a/source/javascripts/pages/YmlPage/components/YmlEditor.tsx
+++ b/source/javascripts/pages/YmlPage/components/YmlEditor.tsx
@@ -1,6 +1,5 @@
 import Editor, { OnMount } from '@monaco-editor/react';
 import { useRef } from 'react';
-import { useUnmount } from 'usehooks-ts';
 
 import LoadingState from '@/components/LoadingState';
 import { getYmlString, updateBitriseYmlDocumentByString } from '@/core/stores/BitriseYmlStore';
@@ -13,12 +12,10 @@ const YmlEditor = () => {
   const enableBranchSwitching = useFeatureFlag('enable-branch-switching');
   const { data: ymlSettings, isLoading: isLoadingSetting } = useCiConfigSettings();
 
-  useUnmount(() => {
-    if (monacoEditorRef.current) {
-      monacoEditorRef.current.dispose();
-      monacoEditorRef.current = undefined;
-    }
-  });
+  // NOTE: The editor is NOT disposed here. `<Editor>` created it and disposes it on unmount itself,
+  // after saving its view state (`keepCurrentModel` leaves the model — shared with the language
+  // service — alone). Disposing it first ran that teardown against an already-disposed widget,
+  // which both lost the view state and tore the editor's contributions down out of order.
 
   if (isLoadingSetting) {
     return <LoadingState />;


### PR DESCRIPTION
## Summary

On the YAML tab (`#!/yml`), clicking **View Problem** in a marker (error/warning) hover could throw:

```
TypeError: Cannot read properties of undefined (reading 'showAtMarker')
```

The throw is inside `monaco-editor`, raised from Monaco's own hover click handler, so nothing in our code was in a position to catch it. This PR makes our integration recover from the broken state instead of letting it surface as an unhandled error, and fixes a genuine editor-disposal bug we own that sits in the same area.

## Where the error actually comes from

The reported stack is entirely inside the library:

```
node_modules/monaco-editor/esm/vs/editor/contrib/gotoError/browser/gotoError.js:117:26
  ← .../contrib/hover/browser/markerHoverParticipant.js:176:42
  ← .../base/browser/ui/hover/hoverWidget.js:74:13
```

Against the pinned `monaco-editor@0.53.0` those three positions map exactly:

- `hoverWidget.js:74` — `run(container)`: the user clicked an action in the hover's status bar.
- `markerHoverParticipant.js:176` — `markerController.showAtMarker(markerHover.marker)`: the **View Problem** action. Monaco null-checks `markerController` here, so the controller exists.
- `gotoError.js:117` — `this._widget.showAtMarker(...)` inside `MarkerController.showAtMarker`. **`this._widget` is what's undefined.**

`MarkerController` keeps its peek widget and its marker list as one session:

```js
showAtMarker(marker) {
  if (!this._editor.hasModel()) return;
  const textModel = this._editor.getModel();
  const model = this._getOrCreateModel(textModel.uri);  // returns an existing list untouched
  model.resetIndex();
  model.move(true, textModel, new Position(...));
  if (model.selected) {
    this._widget.showAtMarker(...);                     // never checked
  }
}
```

`_getOrCreateModel` returns early when it already holds a matching marker list, and only builds a widget when it doesn't. `_cleanUp()` is supposed to clear both halves together, so a session with a list but no widget is an invariant violation inside Monaco — and once a controller is in that state it stays there, throwing on *every* View Problem click, until something clears the session (a model change on that editor, or the editor being disposed). That matches the reported shape: bursts of the same error rather than isolated one-offs.

I could not pin down the exact transition that drops the widget while keeping the list from reading the source, and it isn't reproducible on demand. What is certain is that Monaco guards `markerController` at the call site but never guards `this._widget`, and **`monaco-editor@0.56.0` (the current latest) is unchanged at that line** — so this cannot be fixed by a version bump.

## Was there a regression on our side?

Checked, and no — not in the release this resurfaced in. The only functional commit between the previous release and that one touches the Stacks & Machines tab (`StackAndMachine.tsx`, `StacksAndMachinesApi`, `StackAndMachine` model, a story). No Monaco, editor, hover, or diagnostics code changed, so there is nothing editor-side to revert.

**Assumption, stated so a reviewer can overrule it:** the resurfacing lines up with a release boundary but not with any editor-side code change, so the likeliest trigger is a rollout that put more editors and more diagnostics in front of users — modular YAML file tabs (several Monaco instances alive at once, models swapping between them) and the Bitrise language service, both behind feature flags that can change exposure without a deploy. That's consistent with the earlier occurrence window too, but it's inference from the release contents, not something I can prove from the repository. If someone can correlate the dates with a flag rollout, that would confirm it.

Because there is no regression to revert, this PR takes the documented fallbacks: a guard in our integration code, plus a real disposal fix we own.

## Changes

**1. `MonacoUtils.configureMarkerNavigationGuard` — recover instead of crashing**

Wraps `showAtMarker` and `navigate` on each editor's marker-navigation controller. On failure it calls `controller.close(false)`, which drops the stale session, then retries once — so `_getOrCreateModel` rebuilds both the list *and* the widget and the peek widget the user asked for actually opens. This is a recovery, not just a swallow.

Deliberate boundaries:

- **The healthy path is untouched.** No extra work, no behaviour change when nothing throws.
- **A second failure propagates.** A fresh session that also fails is a different fault, and hiding it would turn the editor into a place where errors disappear. One `console.warn` records each recovery so the underlying race stays visible while debugging.
- **Both entry points are guarded.** `navigate` (next/previous problem, F8) dereferences the same unchecked `this._widget` on `gotoError.js:144`; leaving it would keep an identical hole open.
- Installed with the other language-service setup rather than per editor component, because marker navigation is reachable from any editor showing diagnostics. Already-created editors are swept as well as future ones, so it doesn't depend on setup ordering, and a `WeakSet` keeps a controller from being wrapped twice.

It reaches for `getContribution('editor.contrib.markerController')` — a public API, but the contribution it returns is internal, so the three method names it uses (`showAtMarker`, `navigate`, `close`) are the coupling to watch. All three have been stable from 0.53 through 0.56.

An earlier revision of this description claimed that a future bump renaming them would leave the guard inert, and the review correctly pointed out the code did not back that: the type argument to `getContribution` is erased at build time, so a renamed method meant `.bind` on `undefined` — thrown during language-service setup, while the editor was being created. That would have broken *every* editor rather than one hover action, which is worse than the bug being fixed. The three methods are now verified with a runtime `typeof` check before the controller is marked or touched, so an unrecognised shape really is inert; a controller that has drifted that far probably doesn't keep the session invariant this recovers from either, so it's left completely alone rather than half-wrapped.

**Delete this once upstream guards the dereference.**

**2. `YmlEditor` — the editor's owner disposes it**

`YmlEditor` disposed the Monaco editor in a `useUnmount`, but `<Editor>` from `@monaco-editor/react` created that instance and disposes it on unmount itself:

```js
// @monaco-editor/react cleanup
keepCurrentModel ? saveViewState && viewStates.set(path, editor.saveViewState()) : editor.getModel()?.dispose();
editor.dispose();
```

React runs a parent's effect cleanup before its children's on unmount, so our dispose went first and the library's teardown then ran against an already-disposed widget. Two consequences: `saveViewState()` returns `null` on a disposed editor, so the scroll and cursor position were lost every time the user left the YAML tab; and the editor's contributions were torn down out of the order `CodeEditorWidget.dispose()` intends (it detaches the model *before* disposing contributions). Removed the manual dispose — ownership belongs to the component that created the instance.

To be straight about it: I could not prove this double dispose is what breaks the marker session, and I'm not claiming it is. It is a real defect in exactly the code the fix goal points at ("how our code sets up or disposes the Monaco editor instance"), it makes the teardown well-defined, and it fixes a small user-visible bug of its own.

## Testing

- New `MonacoUtils.spec.ts` (12 cases) covers the guard against a controller that throws the reported `TypeError`: recovery and retry for both `showAtMarker` and `navigate`, a healthy session left alone, a failure on the rebuilt session propagating, editors created after setup being guarded, no double wrapping, and an editor with no marker controller. Plus the compatibility check: a contribution missing any one of the three methods, or carrying a non-callable in their place, is left byte-identical (asserted by function identity), and a complete contribution is confirmed to actually be wrapped. Monaco itself is mocked — the guard only ever touches the editor object it is handed, and `monaco-editor` is a browser-only ESM bundle Jest can't resolve.
- The four compatibility cases were checked against the pre-fix guard: each fails there with `Cannot read properties of undefined (reading 'bind')`, which is the failure mode the review described.
- `npm test` (1495 tests) and `npx tsc --noEmit` pass; `npm run lint` reports 0 errors and the exact same warning set as `master` (verified by diffing the two).
- Not verified in a browser: reproducing the broken session requires the Monaco state this PR can't trigger on demand. The guard's recovery path is covered by the unit tests above; the disposal change is worth a manual check that switching away from and back to the YAML tab now restores the scroll position.

---
_Found via a routine Datadog FE error-log check (service:wfe, last 24h). Fixed by an RDE coding agent, orchestrated by Kolega._