### PR TITLE
fix(yml editor): stop disposing the Monaco editor &lt;Editor&gt; already owns

### DIFF
--- a/source/javascripts/pages/YmlPage/components/YmlEditor.tsx
+++ b/source/javascripts/pages/YmlPage/components/YmlEditor.tsx
@@ -1,6 +1,5 @@
 import Editor, { OnMount } from '@monaco-editor/react';
 import { useRef } from 'react';
-import { useUnmount } from 'usehooks-ts';
 
 import LoadingState from '@/components/LoadingState';
 import { getYmlString, updateBitriseYmlDocumentByString } from '@/core/stores/BitriseYmlStore';
@@ -13,12 +12,10 @@ const YmlEditor = () => {
   const enableBranchSwitching = useFeatureFlag('enable-branch-switching');
   const { data: ymlSettings, isLoading: isLoadingSetting } = useCiConfigSettings();
 
-  useUnmount(() => {
-    if (monacoEditorRef.current) {
-      monacoEditorRef.current.dispose();
-      monacoEditorRef.current = undefined;
-    }
-  });
+  // The editor is deliberately NOT disposed here: `<Editor>` created it and disposes it on unmount
+  // itself, after saving the view state that restores scroll and cursor position on the way back.
+  // A dispose from this parent would run first — React unmounts a parent's effects before its
+  // children's — leaving that teardown an already-disposed editor and nothing to save.
 
   if (isLoadingSetting) {
     return <LoadingState />;


### PR DESCRIPTION
## Summary

The YAML tab loses its scroll and cursor position every time you navigate away and come back, even within the same session. `YmlEditor` disposed the Monaco editor instance itself, but `@monaco-editor/react` created that instance and disposes it on unmount — after saving the view state used to restore the position. Ours ran first, so there was nothing left to save.

Deleting the redundant manual dispose is the whole fix.

## The bug

```tsx
const YmlEditor = () => {
  const monacoEditorRef = useRef<Parameters<OnMount>[0]>();

  useUnmount(() => {
    if (monacoEditorRef.current) {
      monacoEditorRef.current.dispose();   // the editor <Editor> created and owns
      monacoEditorRef.current = undefined;
    }
  });
```

`<Editor>`'s own unmount cleanup does this (`keepCurrentModel` is set, so it keeps the model — which is shared with the language service — and only tears down the editor):

```js
// @monaco-editor/react
keepCurrentModel ? saveViewState && viewStates.set(path, editor.saveViewState()) : editor.getModel()?.dispose();
editor.dispose();
```

React unmounts a parent's effects before its children's, so our `useUnmount` ran first and the library's cleanup then found an already-disposed editor. `CodeEditorWidget.saveViewState()` starts with `if (!this._modelData) return null`, and `dispose()` has already detached the model — so `viewStates.set(path, null)` is what got stored, and the `restoreViewState` on the way back had nothing to restore. The second `editor.dispose()` is a harmless no-op; the lost view state is the part users feel.

I verified the ordering rather than assuming it — a two-component probe (a parent `useUnmount`, a child `useEffect` cleanup, mirroring this component tree) confirms the parent's cleanup runs first.

## The fix

Delete the `useUnmount` block. Ownership belongs to the component that created the instance, and `<Editor>` disposes it correctly on its own.

`ModularYmlEditor` — the other half of this page, rendered for modular configs — has never disposed its editors manually, so this also makes the two paths consistent. A grep confirms `YmlEditor` was the only place in the app doing this, so nothing else follows the pattern.

`monacoEditorRef` stays: it is still assigned in `onMount` and read as a guard in the change handler. It is no longer cleared on unmount, which costs nothing — the ref is collected with the component.

## Testing

- `npm test` (1488 tests), `npx tsc --noEmit` and `npm run lint` all pass, with a lint warning set identical to `master`.
- Checked that nothing depended on the manual dispose: `YmlEditor` is rendered only by `YmlPage` (alternating with `ModularYmlEditor`), has no spec of its own, and no other `.tsx` in the app calls `dispose()` on an editor instance. The one spec that names this file (`ClarityUnmask.spec.tsx`) asserts it contains no unmask attributes, which is unaffected and still passes.
- No new automated test. Reproducing the behaviour needs a real Monaco editor with real layout — `monaco-editor` is a browser-only ESM bundle Jest cannot even resolve — so a test here would only assert that our code doesn't call a method on a mock. **Worth a manual check on review:** open the YAML tab, scroll down, switch to the visual editor and back — the scroll position should now be where you left it.

## Note on scope

This was originally part of a PR adding a workaround for a `monaco-editor` internal bug, which was closed on the (fair) grounds that the library bug doesn't crash the editor and isn't worth working around. This change is unrelated to that workaround: it's a defect in our own integration, it touches no library internals, and it fixes a small user-visible bug on its own. Split out so it can be judged on its own merits.

---
_Split out of the now-closed #1896, found via a routine Datadog FE error-log check. Fixed by an RDE coding agent, orchestrated by Kolega._