### PR TITLE
fix(diff-editor): stop leaking Monaco models on every DiffEditor unmount

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,11 +91,9 @@ shows up as a wrecked pull request.
   rule ids, so count boundaries rather than rules. See
   [docs/conventions.md](docs/conventions.md#lint).
 - **`keepCurrent*Model` without a `path` leaks rather than reuses.** The `@monaco-editor/react`
-  props only skip disposal; reuse goes through `getModel(Uri.parse(path))`, which can never find a
-  model created without one. Check the same element for `path` / `originalModelPath` /
-  `modifiedModelPath`: with one they are load-bearing, and the YmlPage editors need them to protect
-  the model the language services share. Without one they strand a model per unmount, and the prop
-  name is what makes it read as deliberate.
+  props only skip disposal; reuse needs `getModel(Uri.parse(path))` to hit. With a `path` /
+  `originalModelPath` / `modifiedModelPath` on the same element they are load-bearing — the
+  YmlPage editors guard a model the language services share. Without one: a model per unmount.
 
 ## Writing docs here
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,12 @@ shows up as a wrecked pull request.
   or `no-restricted-imports` means you crossed one, not that you wrote sloppy code. Some take two
   rule ids, so count boundaries rather than rules. See
   [docs/conventions.md](docs/conventions.md#lint).
+- **`keepCurrent*Model` without a `path` leaks rather than reuses.** The `@monaco-editor/react`
+  props only skip disposal; reuse goes through `getModel(Uri.parse(path))`, which can never find a
+  model created without one. Check the same element for `path` / `originalModelPath` /
+  `modifiedModelPath`: with one they are load-bearing, and the YmlPage editors need them to protect
+  the model the language services share. Without one they strand a model per unmount, and the prop
+  name is what makes it read as deliberate.
 
 ## Writing docs here
 

--- a/source/javascripts/components/ConfigMergeDialog/ConfigMergeDialog.tsx
+++ b/source/javascripts/components/ConfigMergeDialog/ConfigMergeDialog.tsx
@@ -296,8 +296,6 @@ const ConfigMergeDialogContent = ({
                 original={baseYml}
                 modified={yourYml}
                 options={readOnlyDiffEditorOptions}
-                keepCurrentModifiedModel
-                keepCurrentOriginalModel
               />
             </Box>
           </Box>
@@ -315,8 +313,6 @@ const ConfigMergeDialogContent = ({
                 original={baseYml}
                 modified={mergedYml}
                 options={diffEditorOptions}
-                keepCurrentModifiedModel
-                keepCurrentOriginalModel
                 onMount={onFinalYmlEditorMount}
               />
             </Box>
@@ -335,8 +331,6 @@ const ConfigMergeDialogContent = ({
                 original={baseYml}
                 modified={remoteYml}
                 options={readOnlyDiffEditorOptions}
-                keepCurrentModifiedModel
-                keepCurrentOriginalModel
               />
             </Box>
           </Box>

--- a/source/javascripts/components/ConfigMergeDialog/ModularConfigMergeDialog.tsx
+++ b/source/javascripts/components/ConfigMergeDialog/ModularConfigMergeDialog.tsx
@@ -247,8 +247,6 @@ const ModularConfigMergeDialogBody = ({
                   original={activeMerge.baseYml}
                   modified={activeMerge.yourYml}
                   options={readOnlyDiffEditorOptions}
-                  keepCurrentModifiedModel
-                  keepCurrentOriginalModel
                 />
               </Box>
             </Box>
@@ -267,8 +265,6 @@ const ModularConfigMergeDialogBody = ({
                   original={activeMerge.baseYml}
                   modified={resolved[activeMerge.nodeId] ?? activeMerge.mergedYml}
                   options={diffEditorOptions}
-                  keepCurrentModifiedModel
-                  keepCurrentOriginalModel
                   onMount={onResultEditorMount(activeMerge.nodeId, activeMerge.decorations)}
                 />
               </Box>
@@ -288,8 +284,6 @@ const ModularConfigMergeDialogBody = ({
                   original={activeMerge.baseYml}
                   modified={activeMerge.remoteYml}
                   options={readOnlyDiffEditorOptions}
-                  keepCurrentModifiedModel
-                  keepCurrentOriginalModel
                 />
               </Box>
             </Box>

--- a/source/javascripts/components/ConfigMergeDialog/ModularConfigMergeDialog.tsx
+++ b/source/javascripts/components/ConfigMergeDialog/ModularConfigMergeDialog.tsx
@@ -133,10 +133,6 @@ const ModularConfigMergeDialogBody = ({
   const onResultEditorMount = (mountedNodeId: string, decorations: editor.IModelDeltaDecoration[]) => {
     return (diff: MonacoDiffEditor) => {
       const modified = diff.getModifiedEditor();
-      // Tab switches remount this editor (its key includes the node_id), so every
-      // listener registered here must be disposed on unmount — otherwise the global
-      // marker listener (onModelMarkerStatusChange) leaks one per visit and keeps
-      // firing setValidity for stale models. Collected here, disposed on dispose.
       const disposables: IDisposable[] = [];
 
       disposables.push(

--- a/source/javascripts/components/DiffEditor/DiffEditor.tsx
+++ b/source/javascripts/components/DiffEditor/DiffEditor.tsx
@@ -50,8 +50,6 @@ const DiffEditorComponent = ({ originalText, modifiedText, language = 'yaml', on
         options={readOnly ? { ...diffEditorOptions, readOnly: true } : diffEditorOptions}
         loading={<ProgressBitbot />}
         onMount={handleEditorDidMount}
-        keepCurrentModifiedModel
-        keepCurrentOriginalModel
         wrapperProps={{ style: { flex: 1, display: 'flex' } }}
       />
     </>

--- a/source/javascripts/core/utils/MonacoUtils.ts
+++ b/source/javascripts/core/utils/MonacoUtils.ts
@@ -296,12 +296,26 @@ function onWorkspaceMarkerStatusChange(
   };
 }
 
-/** Single-model form of {@link onWorkspaceMarkerStatusChange}. */
+/**
+ * Single-model form of {@link onWorkspaceMarkerStatusChange}. This one captures `model` instead of
+ * looking it up, so it can outlive what it watches: `DiffEditorDialog` keeps the badge and the
+ * Apply gate mounted while a tab switch remounts the editor beneath them and disposes its model,
+ * and what a disposed model's markers report is its owner's business. So end the subscription with
+ * the model — `onWillDispose` fires before disposal, and `dispose()` cancels both debounce timers.
+ */
 function onModelMarkerStatusChange(
   model: monaco.editor.ITextModel,
   callback: (status: ValidationStatus) => void,
 ): monaco.IDisposable {
-  return onWorkspaceMarkerStatusChange(() => [model], callback);
+  const subscription = onWorkspaceMarkerStatusChange(() => [model], callback);
+  const willDispose = model.onWillDispose(() => subscription.dispose());
+
+  return {
+    dispose: () => {
+      willDispose.dispose();
+      subscription.dispose();
+    },
+  };
 }
 
 export default {

--- a/source/javascripts/core/utils/MonacoUtils.ts
+++ b/source/javascripts/core/utils/MonacoUtils.ts
@@ -296,29 +296,12 @@ function onWorkspaceMarkerStatusChange(
   };
 }
 
-/**
- * Single-model form of {@link onWorkspaceMarkerStatusChange}.
- *
- * Unlike the workspace form — whose callers look the models up fresh, so a disposed one simply
- * stops being returned — this captures `model`, which can be disposed while the subscription is
- * still alive (an editor unmounting under a dialog that stays open). What the marker service
- * reports for a dead URI is owner-dependent and not worth depending on either way, so end the
- * subscription with the model: `onWillDispose` fires before disposal and `dispose()` cancels
- * both debounce timers, so no status lands after the model it described is gone.
- */
+/** Single-model form of {@link onWorkspaceMarkerStatusChange}. */
 function onModelMarkerStatusChange(
   model: monaco.editor.ITextModel,
   callback: (status: ValidationStatus) => void,
 ): monaco.IDisposable {
-  const subscription = onWorkspaceMarkerStatusChange(() => [model], callback);
-  const willDispose = model.onWillDispose(() => subscription.dispose());
-
-  return {
-    dispose: () => {
-      willDispose.dispose();
-      subscription.dispose();
-    },
-  };
+  return onWorkspaceMarkerStatusChange(() => [model], callback);
 }
 
 export default {

--- a/source/javascripts/core/utils/MonacoUtils.ts
+++ b/source/javascripts/core/utils/MonacoUtils.ts
@@ -296,12 +296,29 @@ function onWorkspaceMarkerStatusChange(
   };
 }
 
-/** Single-model form of {@link onWorkspaceMarkerStatusChange}. */
+/**
+ * Single-model form of {@link onWorkspaceMarkerStatusChange}.
+ *
+ * Unlike the workspace form — whose callers look the models up fresh, so a disposed one simply
+ * stops being returned — this captures `model`, which can be disposed while the subscription is
+ * still alive (an editor unmounting under a dialog that stays open). What the marker service
+ * reports for a dead URI is owner-dependent and not worth depending on either way, so end the
+ * subscription with the model: `onWillDispose` fires before disposal and `dispose()` cancels
+ * both debounce timers, so no status lands after the model it described is gone.
+ */
 function onModelMarkerStatusChange(
   model: monaco.editor.ITextModel,
   callback: (status: ValidationStatus) => void,
 ): monaco.IDisposable {
-  return onWorkspaceMarkerStatusChange(() => [model], callback);
+  const subscription = onWorkspaceMarkerStatusChange(() => [model], callback);
+  const willDispose = model.onWillDispose(() => subscription.dispose());
+
+  return {
+    dispose: () => {
+      willDispose.dispose();
+      subscription.dispose();
+    },
+  };
 }
 
 export default {


### PR DESCRIPTION
`keepCurrentModifiedModel` and `keepCurrentOriginalModel` read like "reuse this model across
remounts". On these three `<DiffEditor>`s they only suppress disposal, so every unmount strands
a model pair. Deleting the four prop pairs is the fix.

## Why the props cannot work here

`@monaco-editor/react` resolves a model with `getModel(Uri.parse(path))`, else creates one. None
of the three passes `originalModelPath` or `modifiedModelPath`, so creation gets
an auto-generated `inmemory://model/N` URI while the lookup asks for `Uri.parse('')`, where
nothing is registered. Every mount builds a fresh pair, and the props only stop the old one
being disposed. One leaked pair per 409 retry in the legacy dialog and per tab switch in
the modular one, cleared by a page reload, which is why nobody reported it.

Nothing depended on the preservation: the edited text lives in React state, `DiffEditor` never
restored view state, and undo history dies with the new model. `keepCurrentModel` in the
two YML page editors is untouched: it has a real path and guards a model the language services hold.

## The MonacoUtils half

`onModelMarkerStatusChange` captures its model rather than looking it up, so it can outlive it
and report a dead URI's markers. `DiffEditorDialog` is where that shows: `<DiffEditor
key={nodeId}>` remounts on a tab switch while the badge and the Apply gate stay mounted, and the
hook disposes on its own unmount, not the editor's. `onWillDispose` ends it now.

`npm test` 1496 passed, `tsc` and lint clean. `MonacoUtils.ts` has no spec, so the guard is
untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
