### PR TITLE
Stop unreadable YAML shapes from crashing the workflow editor

### DIFF
--- a/source/javascripts/core/services/ContainerService.spec.tsx
+++ b/source/javascripts/core/services/ContainerService.spec.tsx
@@ -1807,6 +1807,57 @@ describe('ContainerService', () => {
         ).toBeUndefined();
       });
 
+      it('skips an aliased reference entry instead of naming a container after the anchor key', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          containers:
+            pg: &pg
+              image: postgres
+          workflows:
+            wf1:
+              steps:
+              - script:
+                  service_containers:
+                  - *pg
+                  - redis
+        `);
+
+        // Serializing the sequence as a whole would render the alias as `{ source: 'pg' }`, which
+        // would parse as a container called "source".
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Service,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toEqual([{ id: 'redis', recreate: false }]);
+      });
+
+      it('returns undefined when the only reference entry is an alias', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          containers:
+            pg: &pg
+              image: postgres
+          workflows:
+            wf1:
+              steps:
+              - script:
+                  service_containers:
+                  - *pg
+        `);
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Service,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toBeUndefined();
+      });
+
       it('returns undefined for a step bundle definition of an unexpected shape', () => {
         updateBitriseYmlDocumentByString(yaml`
           step_bundles:

--- a/source/javascripts/core/services/ContainerService.spec.tsx
+++ b/source/javascripts/core/services/ContainerService.spec.tsx
@@ -1325,7 +1325,7 @@ describe('ContainerService', () => {
         ).toBeUndefined();
       });
 
-      it('should throw error when step index does not exist', () => {
+      it('should return undefined when step index does not exist', () => {
         updateBitriseYmlDocumentByString(yaml`
         workflows:
           wf1:
@@ -1333,7 +1333,7 @@ describe('ContainerService', () => {
               - script: {}
       `);
 
-        expect(() =>
+        expect(
           ContainerService.getContainerReferenceFromInstance(
             'workflows',
             'wf1',
@@ -1341,7 +1341,7 @@ describe('ContainerService', () => {
             ContainerType.Execution,
             bitriseYmlStore.getState().ymlDocument,
           ),
-        ).toThrow('Step at index 5 not found in workflows.wf1');
+        ).toBeUndefined();
       });
     });
 
@@ -1599,7 +1599,7 @@ describe('ContainerService', () => {
         ).toBeUndefined();
       });
 
-      it('should throw error when step index does not exist', () => {
+      it('should return undefined when step index does not exist', () => {
         updateBitriseYmlDocumentByString(yaml`
         workflows:
           wf1:
@@ -1607,7 +1607,7 @@ describe('ContainerService', () => {
               - script: {}
       `);
 
-        expect(() =>
+        expect(
           ContainerService.getContainerReferenceFromInstance(
             'workflows',
             'wf1',
@@ -1615,7 +1615,7 @@ describe('ContainerService', () => {
             ContainerType.Service,
             bitriseYmlStore.getState().ymlDocument,
           ),
-        ).toThrow('Step at index 10 not found in workflows.wf1');
+        ).toBeUndefined();
       });
     });
 
@@ -1678,6 +1678,105 @@ describe('ContainerService', () => {
       expect(result2).toEqual([{ id: 'node', recreate: false }]);
       expect(result3).toEqual([{ id: 'postgres', recreate: false }]);
       expect(result4).toBeUndefined();
+    });
+
+    describe('steps the editor cannot read as a `{cvs: options}` map', () => {
+      // Every case below reaches this function through StepCard's render, so none of them may throw.
+      it.each([
+        ['written as a plain string', 'script@1'],
+        ['written without a value', ''],
+      ])('returns undefined for a step %s', (_, stepValue) => {
+        updateBitriseYmlDocumentByString(yaml`
+          workflows:
+            wf1:
+              steps:
+              - ${stepValue}
+        `);
+
+        const doc = bitriseYmlStore.getState().ymlDocument;
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance('workflows', 'wf1', 0, ContainerType.Execution, doc),
+        ).toBeUndefined();
+        expect(
+          ContainerService.getContainerReferenceFromInstance('workflows', 'wf1', 0, ContainerType.Service, doc),
+        ).toBeUndefined();
+      });
+
+      it('returns undefined when the workflow itself is not a map', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          workflows:
+            wf1: some-string
+        `);
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Execution,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toBeUndefined();
+      });
+
+      it('returns undefined when service_containers is not a sequence', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          workflows:
+            wf1:
+              steps:
+              - script:
+                  service_containers: postgres
+        `);
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Service,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toBeUndefined();
+      });
+
+      it('skips reference entries that name no container', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          workflows:
+            wf1:
+              steps:
+              - script:
+                  service_containers:
+                  - {}
+                  -
+                  - postgres
+        `);
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Service,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toEqual([{ id: 'postgres', recreate: false }]);
+      });
+
+      it('returns undefined for a step bundle definition of an unexpected shape', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          step_bundles:
+            b1: some-string
+        `);
+
+        expect(
+          ContainerService.getContainerReferencesFromStepBundleDefinition(
+            'b1',
+            ContainerType.Execution,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toBeUndefined();
+      });
     });
   });
 

--- a/source/javascripts/core/services/ContainerService.spec.tsx
+++ b/source/javascripts/core/services/ContainerService.spec.tsx
@@ -1763,6 +1763,50 @@ describe('ContainerService', () => {
         ).toEqual([{ id: 'postgres', recreate: false }]);
       });
 
+      it('skips a nested-array reference entry instead of naming a container after its index', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          workflows:
+            wf1:
+              steps:
+              - script:
+                  service_containers:
+                  - [postgres]
+                  - redis
+        `);
+
+        // `Object.entries(['postgres'])` would otherwise yield a container called "0".
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Service,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toEqual([{ id: 'redis', recreate: false }]);
+      });
+
+      it('returns undefined when every reference entry is unreadable', () => {
+        updateBitriseYmlDocumentByString(yaml`
+          workflows:
+            wf1:
+              steps:
+              - script:
+                  service_containers:
+                  - [postgres]
+        `);
+
+        expect(
+          ContainerService.getContainerReferenceFromInstance(
+            'workflows',
+            'wf1',
+            0,
+            ContainerType.Service,
+            bitriseYmlStore.getState().ymlDocument,
+          ),
+        ).toBeUndefined();
+      });
+
       it('returns undefined for a step bundle definition of an unexpected shape', () => {
         updateBitriseYmlDocumentByString(yaml`
           step_bundles:

--- a/source/javascripts/core/services/ContainerService.ts
+++ b/source/javascripts/core/services/ContainerService.ts
@@ -1,5 +1,5 @@
 import { uniq } from 'es-toolkit';
-import { Document, isMap, isScalar, YAMLMap } from 'yaml';
+import { Document, isMap, isScalar, isSeq, YAMLMap } from 'yaml';
 
 import { ContainerModel, Containers } from '@/core/models/BitriseYml';
 import { Container, ContainerReference, ContainerReferenceField, ContainerType } from '@/core/models/Container';
@@ -64,6 +64,29 @@ function getStepDataOrThrowError(
   }
 
   throw new Error(`Invalid step data at index ${stepIndex} in ${source} '${sourceId}'`);
+}
+
+/**
+ * The option map of a step (`- script@1: {...}` → the `{...}`), or `undefined` when the step is
+ * absent — a cross-file workflow, a step bundle defined in another module — or isn't a
+ * `{cvs: options}` map at all. Unlike `getStepDataOrThrowError` this neither throws nor materializes
+ * a missing option map, so it is safe to call while rendering.
+ */
+function findStepData(
+  doc: Document,
+  source: 'workflows' | 'step_bundles',
+  sourceId: string,
+  stepIndex: number,
+): YAMLMap | undefined {
+  const step = YmlUtils.getIn(doc, [source, sourceId, 'steps', stepIndex], true);
+
+  if (!isMap(step)) {
+    return undefined;
+  }
+
+  const stepData = step.items[0]?.value;
+
+  return isMap(stepData) ? stepData : undefined;
 }
 
 function addContainerReference(
@@ -230,17 +253,21 @@ function getAllContainers(containers: Containers, selector: (container: Containe
     .filter(selector);
 }
 
-type ContainerReferenceValue = string | Record<string, { recreate?: boolean }>;
-
-function parseContainerReference(value: ContainerReferenceValue): ContainerReference {
+// `undefined` for a reference that names no container (an empty map, an empty seq item, a number).
+// Both callers run during render, where throwing would take down the whole card.
+function parseContainerReference(value: unknown): ContainerReference | undefined {
   if (typeof value === 'string') {
-    return { id: value, recreate: false };
+    return value ? { id: value, recreate: false } : undefined;
   }
 
-  const [containerId, config] = Object.entries(value)[0] ?? [];
+  if (typeof value !== 'object' || value === null) {
+    return undefined;
+  }
+
+  const [containerId, config] = Object.entries(value as Record<string, { recreate?: boolean }>)[0] ?? [];
 
   if (!containerId) {
-    throw new Error(`Container not found. Ensure that the container exists in the 'containers' section.`);
+    return undefined;
   }
 
   return { id: containerId, recreate: config?.recreate === true };
@@ -255,15 +282,20 @@ function getContainerReferences(type: ContainerType, yamlMap: YAMLMap): Containe
     }
 
     const value = isMap(node) ? node.toJSON() : node;
-    return [parseContainerReference(value)];
+    const reference = parseContainerReference(value);
+    return reference ? [reference] : undefined;
   }
 
   if (type === ContainerType.Service) {
-    const serviceContainers = YmlUtils.getSeqIn(yamlMap, [ContainerReferenceField.Service])?.toJSON() as
-      ContainerReferenceValue[] | undefined;
+    // `service_containers:` is only usable as a sequence; any other shape is left to the YAML
+    // validator to report rather than thrown from here, mid-render.
+    const node = YmlUtils.getIn(yamlMap, [ContainerReferenceField.Service], true);
+    const references = (isSeq(node) ? (node.toJSON() as unknown[]) : [])
+      .map(parseContainerReference)
+      .filter((reference): reference is ContainerReference => Boolean(reference));
 
-    if (serviceContainers && serviceContainers.length > 0) {
-      return serviceContainers.map(parseContainerReference);
+    if (references.length > 0) {
+      return references;
     }
   }
 
@@ -271,9 +303,10 @@ function getContainerReferences(type: ContainerType, yamlMap: YAMLMap): Containe
 }
 
 function getContainerReferencesFromStepBundleDefinition(sourceId: string, type: ContainerType, doc: Document) {
-  // A cross-file bundle definition is absent here; return none rather than throwing (throwing crashes the card during render).
-  const yamlMap = YmlUtils.getMapIn(doc, ['step_bundles', sourceId]);
-  if (!yamlMap) {
+  // A cross-file bundle definition is absent here, and the definition may be of a shape this can't
+  // read; return none rather than throwing (throwing crashes the card during render).
+  const yamlMap = YmlUtils.getIn(doc, ['step_bundles', sourceId], true);
+  if (!isMap(yamlMap)) {
     return undefined;
   }
 
@@ -290,13 +323,14 @@ function getContainerReferenceFromInstance(
   if (source === 'step_bundles' && stepIndex === -1) {
     return getContainerReferencesFromStepBundleDefinition(sourceId, type, doc);
   }
-  // A cross-file source (a workflow/step bundle defined in another module) is absent from the active
-  // document; return none rather than throwing (throwing crashes the card during render) — mirrors
-  // getContainerReferencesFromStepBundleDefinition.
-  if (!YmlUtils.getMapIn(doc, [source, sourceId])) {
+  // This runs on every StepCard render, so it must not throw: a cross-file source (a workflow/step
+  // bundle defined in another module) is absent from the active document, and a step can be written
+  // in a shape this can't read. Either way the card renders without container references.
+  const yamlMap = findStepData(doc, source, sourceId, stepIndex);
+  if (!yamlMap) {
     return undefined;
   }
-  const yamlMap = getStepDataOrThrowError(doc, source, sourceId, stepIndex);
+
   return getContainerReferences(type, yamlMap);
 }
 

--- a/source/javascripts/core/services/ContainerService.ts
+++ b/source/javascripts/core/services/ContainerService.ts
@@ -1,5 +1,5 @@
 import { uniq } from 'es-toolkit';
-import { Document, isMap, isScalar, isSeq, YAMLMap } from 'yaml';
+import { Document, isAlias, isMap, isNode, isScalar, isSeq, YAMLMap } from 'yaml';
 
 import { ContainerModel, Containers } from '@/core/models/BitriseYml';
 import { Container, ContainerReference, ContainerReferenceField, ContainerType } from '@/core/models/Container';
@@ -291,9 +291,16 @@ function getContainerReferences(type: ContainerType, yamlMap: YAMLMap): Containe
   if (type === ContainerType.Service) {
     // `service_containers:` is only usable as a sequence; any other shape is left to the YAML
     // validator to report rather than thrown from here, mid-render.
+    //
+    // Entries are converted one at a time, skipping aliases. Calling `toJSON()` on the sequence as a
+    // whole has no document to resolve against, so an alias entry serializes to
+    // `{ source: '<anchor>' }` and would read as a container literally named "source" — a chip for
+    // something that doesn't exist, with working actions behind it. Reading an alias needs the
+    // document; until then, skip the entry rather than invent a reference for it.
     const node = YmlUtils.getIn(yamlMap, [ContainerReferenceField.Service], true);
-    const references = (isSeq(node) ? (node.toJSON() as unknown[]) : [])
-      .map(parseContainerReference)
+    const references = (isSeq(node) ? node.items : [])
+      .filter((item) => !isAlias(item))
+      .map((item) => parseContainerReference(isNode(item) ? item.toJSON() : item))
       .filter((reference): reference is ContainerReference => Boolean(reference));
 
     if (references.length > 0) {

--- a/source/javascripts/core/services/ContainerService.ts
+++ b/source/javascripts/core/services/ContainerService.ts
@@ -260,7 +260,9 @@ function parseContainerReference(value: unknown): ContainerReference | undefined
     return value ? { id: value, recreate: false } : undefined;
   }
 
-  if (typeof value !== 'object' || value === null) {
+  // Arrays reach the object branch too, and `Object.entries` would turn a nested `[[postgres]]`
+  // entry into a container literally named "0" — a bogus chip with working actions behind it.
+  if (Array.isArray(value) || typeof value !== 'object' || value === null) {
     return undefined;
   }
 

--- a/source/javascripts/core/services/PipelineService.spec.ts
+++ b/source/javascripts/core/services/PipelineService.spec.ts
@@ -1,5 +1,6 @@
 import { BitriseYml, PipelineModel, Stages } from '../models/BitriseYml';
 import { getYmlString, updateBitriseYmlDocumentByString } from '../stores/BitriseYmlStore';
+import YmlUtils from '../utils/YmlUtils';
 import PipelineService from './PipelineService';
 
 describe('PipelineService', () => {
@@ -658,6 +659,23 @@ describe('PipelineService', () => {
       );
     });
 
+    // A key written with no value still occupies the name. Treating it as free would overwrite the
+    // entry instead of reporting the clash.
+    it('should throw an error if the pipeline id is taken by a key written without a value', () => {
+      updateBitriseYmlDocumentByString(
+        yaml`
+          pipelines:
+            release:
+        `,
+      );
+
+      expect(() => PipelineService.createPipeline('release')).toThrow('Pipeline release already exists');
+      expect(getYmlString()).toEqual(yaml`
+        pipelines:
+          release:
+      `);
+    });
+
     it('should throw an error if the pipeline id already exists', () => {
       updateBitriseYmlDocumentByString(
         yaml`
@@ -674,6 +692,22 @@ describe('PipelineService', () => {
   });
 
   describe('renamePipeline', () => {
+    // Renaming onto a valueless key used to rewrite the key in place, leaving two identical keys
+    // behind — a bitrise.yml that no longer parses, with the renamed pipeline's body lost.
+    it('should refuse to rename onto a name taken by a key written without a value', () => {
+      const source = yaml`
+        pipelines:
+          b:
+          a:
+            workflows: {}
+      `;
+      updateBitriseYmlDocumentByString(source);
+
+      expect(() => PipelineService.renamePipeline('a', 'b')).toThrow('Pipeline b already exists');
+      expect(getYmlString()).toEqual(source);
+      expect(YmlUtils.toDoc(getYmlString()).errors).toHaveLength(0);
+    });
+
     it('should rename the pipeline and update references', () => {
       updateBitriseYmlDocumentByString(
         yaml`

--- a/source/javascripts/core/services/PipelineService.ts
+++ b/source/javascripts/core/services/PipelineService.ts
@@ -227,7 +227,9 @@ function getPipelineWorkflowOrThrowError(pipelineId: string, workflowId: string,
 
 function createPipeline(id: string, baseId?: string) {
   updateBitriseYmlDocument(({ doc }) => {
-    if (YmlUtils.getMapIn(doc, ['pipelines', id])) {
+    // `hasIn`, not `getMapIn`: a pipeline written as a bare `release:` still occupies the key, and
+    // reading it as "absent" would overwrite it instead of reporting the clash.
+    if (doc.hasIn(['pipelines', id])) {
       throw new Error(`Pipeline ${id} already exists`);
     }
 
@@ -256,7 +258,9 @@ function renamePipeline(id: string, newName: string) {
   updateBitriseYmlDocument(({ doc }) => {
     getPipelineOrThrowError(id, doc);
 
-    if (YmlUtils.getMapIn(doc, ['pipelines', newName])) {
+    // As in createPipeline: a valueless `b:` still takes the name, and renaming onto it would leave
+    // two `b:` keys behind — a document that no longer parses.
+    if (doc.hasIn(['pipelines', newName])) {
       throw new Error(`Pipeline ${newName} already exists`);
     }
 

--- a/source/javascripts/core/services/StackAndMachineService.spec.ts
+++ b/source/javascripts/core/services/StackAndMachineService.spec.ts
@@ -2575,6 +2575,59 @@ describe('StackAndMachineService', () => {
           );
         }).toThrow(`Workflow nonexistent not found. Ensure that the workflow exists in the 'workflows' section.`);
       });
+
+      it('fills in meta when it is written without a value', () => {
+        updateBitriseYmlDocumentByString(
+          yaml`
+            workflows:
+              primary:
+                meta:
+                steps: []`,
+        );
+
+        StackAndMachineService.updateStackAndMachine(
+          { stackId: 'osx-xcode-16', machineTypeId: 'mac-m1' },
+          StackAndMachineSource.Workflow,
+          'primary',
+        );
+
+        expect(getYmlString()).toEqual(yaml`
+          workflows:
+            primary:
+              meta:
+                bitrise.io:
+                  stack: osx-xcode-16
+                  machine_type_id: mac-m1
+              steps: []
+        `);
+      });
+
+      it('fills in meta.[bitrise.io] when it is written without a value', () => {
+        updateBitriseYmlDocumentByString(
+          yaml`
+            workflows:
+              primary:
+                meta:
+                  bitrise.io:
+                steps: []`,
+        );
+
+        StackAndMachineService.updateStackAndMachine(
+          { stackId: 'osx-xcode-16', machineTypeId: 'mac-m1' },
+          StackAndMachineSource.Workflow,
+          'primary',
+        );
+
+        expect(getYmlString()).toEqual(yaml`
+          workflows:
+            primary:
+              meta:
+                bitrise.io:
+                  stack: osx-xcode-16
+                  machine_type_id: mac-m1
+              steps: []
+        `);
+      });
     });
   });
 });

--- a/source/javascripts/core/services/StepBundleService.spec.ts
+++ b/source/javascripts/core/services/StepBundleService.spec.ts
@@ -2,6 +2,7 @@ import StepBundleService from '@/core/services/StepBundleService';
 
 import { StepBundles, Workflows } from '../models/BitriseYml';
 import { getYmlString, updateBitriseYmlDocumentByString } from '../stores/BitriseYmlStore';
+import YmlUtils from '../utils/YmlUtils';
 
 describe('StepBundleService', () => {
   describe('validateName', () => {
@@ -136,6 +137,19 @@ describe('StepBundleService', () => {
   });
 
   describe('createStepBundle', () => {
+    it('should throw an error if the id is taken by a key written without a value', () => {
+      updateBitriseYmlDocumentByString(yaml`
+        step_bundles:
+          b:
+      `);
+
+      expect(() => StepBundleService.createStepBundle('b')).toThrow("Step bundle 'b' already exists");
+      expect(getYmlString()).toEqual(yaml`
+        step_bundles:
+          b:
+      `);
+    });
+
     it('creates an empty step bundle', () => {
       updateBitriseYmlDocumentByString(
         yaml`
@@ -406,6 +420,22 @@ describe('StepBundleService', () => {
   });
 
   describe('changeStepBundleId', () => {
+    // Same duplicate-key corruption as renamePipeline: `updateKeyByPath` rewrites the key in place,
+    // so passing the guard leaves two identical keys and an unparseable document.
+    it('should refuse to rename onto an id taken by a key written without a value', () => {
+      const source = yaml`
+        step_bundles:
+          b:
+          a:
+            steps: []
+      `;
+      updateBitriseYmlDocumentByString(source);
+
+      expect(() => StepBundleService.changeStepBundleId('a', 'b')).toThrow("Step bundle 'b' already exists");
+      expect(getYmlString()).toEqual(source);
+      expect(YmlUtils.toDoc(getYmlString()).errors).toHaveLength(0);
+    });
+
     it('changes the id of a step bundle', () => {
       updateBitriseYmlDocumentByString(
         yaml`

--- a/source/javascripts/core/services/StepBundleService.ts
+++ b/source/javascripts/core/services/StepBundleService.ts
@@ -196,7 +196,10 @@ function getStepBundleOrThrowError(doc: Document, id: string) {
 }
 
 function throwIfStepBundleAlreadyExists(doc: Document, id: string) {
-  if (YmlUtils.getMapIn(doc, ['step_bundles', id])) {
+  // `hasIn`, not `getMapIn`: the question is whether the key is taken, and a bundle written as a
+  // bare `b:` still takes it. Reading it as "absent" would let a rename write a second `b:` key,
+  // producing a bitrise.yml that no longer parses. Matches WorkflowService/ContainerService.
+  if (doc.hasIn(['step_bundles', id])) {
     throw new Error(`Step bundle '${id}' already exists`);
   }
 }

--- a/source/javascripts/core/services/StepService.spec.ts
+++ b/source/javascripts/core/services/StepService.spec.ts
@@ -2,6 +2,7 @@ import { StepApiResult } from '@/core/api/StepApi';
 
 import { BITRISE_STEP_LIBRARY_SSH_URL, BITRISE_STEP_LIBRARY_URL, Step } from '../models/Step';
 import { getYmlString, updateBitriseYmlDocumentByString } from '../stores/BitriseYmlStore';
+import YmlUtils from '../utils/YmlUtils';
 import StepService from './StepService';
 
 jest.mock('@/../images/step/icon-default.svg', () => 'default-icon');
@@ -1887,6 +1888,35 @@ describe('StepService', () => {
       expectErrors(
         [() => StepService.changeStepVersion('workflows', 'primary', 2, '1.2.3')],
         ['Step at index 2 not found in workflows.primary'],
+      );
+    });
+  });
+
+  describe('getStepOrThrowError', () => {
+    it.each([
+      ['a plain string', 'script@1'],
+      ['no value at all', ''],
+    ])('should report a step written as %s as a missing step, not as a YAML shape error', (_, stepValue) => {
+      const doc = YmlUtils.toDoc(yaml`
+        workflows:
+          primary:
+            steps:
+            - ${stepValue}
+      `);
+
+      expect(() => StepService.getStepOrThrowError('workflows', 'primary', 0, doc)).toThrow(
+        'Step at index 0 not found in workflows.primary',
+      );
+    });
+
+    it('should report a workflow of an unexpected shape as missing, not as a YAML shape error', () => {
+      const doc = YmlUtils.toDoc(yaml`
+        workflows:
+          primary: some-string
+      `);
+
+      expect(() => StepService.getStepOrThrowError('workflows', 'primary', 0, doc)).toThrow(
+        'workflows.primary not found',
       );
     });
   });

--- a/source/javascripts/core/services/StepService.ts
+++ b/source/javascripts/core/services/StepService.ts
@@ -400,10 +400,14 @@ export const moveStepIndices = (
   }
 };
 
+// Read with `getIn` and check the shape here, rather than letting `getMapIn` throw. A node of an
+// unexpected shape at these paths is a config the editor can't read, not a programming error, and it
+// should surface as one of these domain errors instead of a low-level "Expected a YAMLMap at path
+// ..." — every caller below already handles "not found".
 function getSourceOrThrowError(source: Source, sourceId: string, doc: Document) {
-  const entity = YmlUtils.getMapIn(doc, [source, sourceId]);
+  const entity = YmlUtils.getIn(doc, [source, sourceId], true);
 
-  if (!entity) {
+  if (!isMap(entity)) {
     throw new Error(`${source}.${sourceId} not found`);
   }
 
@@ -412,9 +416,9 @@ function getSourceOrThrowError(source: Source, sourceId: string, doc: Document) 
 
 function getStepOrThrowError(source: Source, sourceId: string, stepIndex: number, doc: Document) {
   const entity = getSourceOrThrowError(source, sourceId, doc);
-  const step = YmlUtils.getMapIn(entity, ['steps', stepIndex]);
+  const step = YmlUtils.getIn(entity, ['steps', stepIndex], true);
 
-  if (!step || !isMap(step)) {
+  if (!isMap(step)) {
     throw new Error(`Step at index ${stepIndex} not found in ${source}.${sourceId}`);
   }
 

--- a/source/javascripts/core/utils/YmlUtils.spec.ts
+++ b/source/javascripts/core/utils/YmlUtils.spec.ts
@@ -874,6 +874,31 @@ describe('YmlUtils', () => {
       expect(YmlUtils.toYml(root)).toEqual(yaml`workflows: []`);
     });
 
+    it('should return undefined for a key written without a value', () => {
+      const root = YmlUtils.toDoc(yaml`
+        workflows:
+          wf1:
+            steps:
+      `);
+
+      expect(YmlUtils.getSeqIn(root, ['workflows', 'wf1', 'steps'])).toBeUndefined();
+    });
+
+    it('should create a YAMLSeq over a key written without a value when createIfNotExists is true', () => {
+      const root = YmlUtils.toDoc(yaml`
+        workflows:
+          wf1:
+            steps:
+      `);
+
+      expect(YmlUtils.getSeqIn(root, ['workflows', 'wf1', 'steps'], true)).toBeInstanceOf(YAMLSeq);
+      expect(YmlUtils.toYml(root)).toEqual(yaml`
+        workflows:
+          wf1:
+            steps: []
+      `);
+    });
+
     it('should throw an error if the path does not point to a YAMLSeq', () => {
       const root = YmlUtils.toDoc(yaml`
         workflows:
@@ -919,6 +944,37 @@ describe('YmlUtils', () => {
       const root = YmlUtils.toDoc(yaml``);
       expect(YmlUtils.getMapIn(root, ['workflows'], true)).toBeInstanceOf(YAMLMap);
       expect(YmlUtils.toYml(root)).toEqual(yaml`workflows: {}`);
+    });
+
+    it('should return undefined for a key written without a value', () => {
+      const root = YmlUtils.toDoc(yaml`
+        workflows:
+          wf1:
+            meta:
+              bitrise.io:
+      `);
+
+      expect(YmlUtils.getMapIn(root, ['workflows', 'wf1', 'meta', 'bitrise.io'])).toBeUndefined();
+    });
+
+    it('should create a YAMLMap over a key written without a value when createIfNotExists is true', () => {
+      const root = YmlUtils.toDoc(yaml`
+        workflows:
+          wf1:
+            meta:
+              bitrise.io:
+      `);
+
+      const meta = YmlUtils.getMapIn(root, ['workflows', 'wf1', 'meta', 'bitrise.io'], true);
+      YmlUtils.setIn(meta, ['stack'], 'linux-docker-android-22.04');
+
+      expect(YmlUtils.toYml(root)).toEqual(yaml`
+        workflows:
+          wf1:
+            meta:
+              bitrise.io:
+                stack: linux-docker-android-22.04
+      `);
     });
 
     it('should throw an error if the path does not point to a YAMLMap', () => {

--- a/source/javascripts/core/utils/YmlUtils.ts
+++ b/source/javascripts/core/utils/YmlUtils.ts
@@ -224,22 +224,6 @@ function getIn(root: Root, path: Path, keepScalar = false) {
   return root.getIn(path, keepScalar);
 }
 
-function hasIn(root: Root, path: Path) {
-  if (!isDocument(root) && !isCollection(root)) {
-    throw new Error('Root node must be a YAML Document or YAML Collection');
-  }
-
-  if (isWildcardPath(path)) {
-    throw new Error('Path cannot contain wildcards when checking for existence');
-  }
-
-  if (isEmpty(path)) {
-    return true;
-  }
-
-  return root.hasIn(path);
-}
-
 function setIn(root: Root, path: Path, value: unknown, stringToTypedValue = true) {
   if (!isDocument(root) && !isCollection(root)) {
     throw new Error('Root node must be a YAML Document or YAML Collection');
@@ -426,6 +410,15 @@ function isEqualValues(a: unknown, b: unknown) {
   return isEqual(isNode(a) ? toJSON(a) : a, isNode(b) ? toJSON(b) : b);
 }
 
+/**
+ * Whether a path holds nothing to read. A key written without a value (`meta:` on its own line, or a
+ * bare `-` seq item) parses to a null scalar rather than to a missing key, so the key looks present
+ * while there is no collection there. Both shapes mean "absent" to the collection getters.
+ */
+function isEmptyNode(node: unknown) {
+  return isNil(node) || (isScalar(node) && isNil(node.value));
+}
+
 function getSeqIn(root: Root, path: Path): YAMLSeq | undefined;
 function getSeqIn(root: Root, path: Path, createIfNotExists: true): YAMLSeq;
 function getSeqIn(root: Root, path: Path, createIfNotExists?: boolean): YAMLSeq | undefined;
@@ -438,15 +431,16 @@ function getSeqIn(root: Root, path: Path, createIfNotExists = false) {
     throw new Error('Path cannot contain wildcards when getting a YAMLSeq');
   }
 
-  if (!hasIn(root, path) && !createIfNotExists) {
-    return undefined;
-  }
+  let node = getIn(root, path, true);
 
-  if (!hasIn(root, path) && createIfNotExists) {
+  if (isEmptyNode(node)) {
+    if (!createIfNotExists) {
+      return undefined;
+    }
+
     setIn(root, path, new YAMLSeq());
+    node = getIn(root, path, true);
   }
-
-  const node = getIn(root, path, true);
 
   if (!isSeq(node)) {
     throw new Error(`Expected a YAMLSeq at path "${path.join('.')}", but found ${node?.constructor.name}`);
@@ -467,15 +461,16 @@ function getMapIn(root: Root, path: Path, createIfNotExists = false) {
     throw new Error('Path cannot contain wildcards when getting a YAMLMap');
   }
 
-  if (!root.hasIn(path) && !createIfNotExists) {
-    return undefined;
-  }
+  let node = getIn(root, path, true);
 
-  if (!root.hasIn(path) && createIfNotExists) {
+  if (isEmptyNode(node)) {
+    if (!createIfNotExists) {
+      return undefined;
+    }
+
     setIn(root, path, new YAMLMap());
+    node = getIn(root, path, true);
   }
-
-  const node = getIn(root, path, true);
 
   if (!isMap(node)) {
     throw new Error(`Expected a YAMLMap at path "${path.join('.')}", but found ${node?.constructor.name}`);
@@ -668,6 +663,7 @@ export default {
   isEqualValues,
   addIn,
   setIn,
+  getIn,
   getSeqIn,
   getMapIn,
   isInSeq,

--- a/source/javascripts/core/utils/resetBudget.spec.ts
+++ b/source/javascripts/core/utils/resetBudget.spec.ts
@@ -1,0 +1,51 @@
+import { createResetBudget } from './resetBudget';
+
+// Timestamps are passed explicitly so the window is exercised directly, with no timers involved.
+describe('createResetBudget', () => {
+  const budget = () => createResetBudget({ maxResets: 3, windowMs: 1000 });
+
+  it('allows resets up to the limit inside one window', () => {
+    const b = budget();
+
+    expect([0, 2, 4].map((t) => b.tryConsume(t))).toEqual([true, true, true]);
+  });
+
+  it('stops once the limit is exceeded inside one window', () => {
+    const b = budget();
+    [0, 2, 4].forEach((t) => b.tryConsume(t));
+
+    // A tight render loop: four resets within a few milliseconds.
+    expect(b.tryConsume(6)).toBe(false);
+  });
+
+  it('does not accumulate across separate failures spaced under the window apart', () => {
+    const b = budget();
+
+    // Transient failures 900ms apart never reach three inside any one-second window, so the editor
+    // must keep recovering rather than being blanked for good.
+    const attempts = [0, 900, 1800, 2700, 3600, 4500, 5400, 6300].map((t) => b.tryConsume(t));
+
+    expect(attempts).toEqual(attempts.map(() => true));
+  });
+
+  it('recovers after the window clears', () => {
+    const b = budget();
+    [0, 2, 4].forEach((t) => b.tryConsume(t));
+
+    expect(b.tryConsume(6)).toBe(false);
+    // Well past the window: the earlier burst no longer counts.
+    expect(b.tryConsume(5000)).toBe(true);
+  });
+
+  it('counts only the resets still inside the window', () => {
+    const b = budget();
+
+    expect(b.tryConsume(0)).toBe(true);
+    expect(b.tryConsume(400)).toBe(true);
+    expect(b.tryConsume(800)).toBe(true);
+    // 1200 drops the reset at 0, so this is the third in the window, not the fourth.
+    expect(b.tryConsume(1200)).toBe(true);
+    // 1300 keeps 400, 800 and 1200 — now four in the window.
+    expect(b.tryConsume(1300)).toBe(false);
+  });
+});

--- a/source/javascripts/core/utils/resetBudget.ts
+++ b/source/javascripts/core/utils/resetBudget.ts
@@ -1,0 +1,35 @@
+type ResetBudgetOptions = {
+  /** How many resets are allowed inside `windowMs`. */
+  maxResets: number;
+  /** Width of the rolling window, in milliseconds. */
+  windowMs: number;
+};
+
+/**
+ * Rate limiter for automatically resetting the root error boundary.
+ *
+ * A deterministic render error re-throws the moment the boundary is reset, so resetting
+ * unconditionally spins into an unbounded render loop that re-reports the same error every
+ * iteration. Giving up after a burst of resets stops that.
+ *
+ * The budget counts resets inside a rolling window rather than measuring the gap between
+ * consecutive ones. Measuring the gap conflates two different things: a genuine loop (resets
+ * microseconds apart) and an unlucky chain of separate transient failures that each land just inside
+ * the window. The latter would keep incrementing a gap-based counter forever and eventually blank
+ * the editor for good, at a rate the budget was never meant to reject.
+ */
+function createResetBudget({ maxResets, windowMs }: ResetBudgetOptions) {
+  let recentResets: number[] = [];
+
+  return {
+    /** Records a reset at `now` and reports whether it still fits in the budget. */
+    tryConsume(now: number = Date.now()) {
+      recentResets = recentResets.filter((at) => now - at < windowMs);
+      recentResets.push(now);
+
+      return recentResets.length <= maxResets;
+    },
+  };
+}
+
+export { createResetBudget };

--- a/source/javascripts/main.tsx
+++ b/source/javascripts/main.tsx
@@ -10,6 +10,7 @@ import { ComponentProps, StrictMode, useEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import Client from '@/core/api/client';
+import { createResetBudget } from '@/core/utils/resetBudget';
 import RuntimeUtils from '@/core/utils/RuntimeUtils';
 import InitialDataLoader from '@/layouts/InitialDataLoader';
 import MainLayout from '@/layouts/MainLayout';
@@ -68,27 +69,18 @@ const DefaultQueryClient = new QueryClient({
 // The fallback resets the boundary so a transient render error doesn't leave the whole editor
 // blanked out. A *deterministic* one re-throws on the very next render though, and resetting again
 // spins that into an unbounded render loop that re-reports the same error to RUM thousands of times
-// in a single session. Give up after a few immediate retries and stay in the fallback instead; the
-// errors still reach RUM, but once per occurrence rather than as a storm.
-const MAX_IMMEDIATE_RESETS = 3;
-const IMMEDIATE_RESET_WINDOW_MS = 1000;
-
+// in a single session. The budget stops that after a burst, while still letting spaced-out transient
+// failures recover; the errors still reach RUM, but once per occurrence rather than as a storm.
+//
 // Module scope on purpose: the fallback unmounts on every successful reset, so component state
 // cannot see how many times it has already retried.
-let immediateResets = 0;
-let lastResetAt = 0;
+const resetBudget = createResetBudget({ maxResets: 3, windowMs: 1000 });
 
 const PassThroughFallback: ComponentProps<typeof ErrorBoundary>['fallback'] = ({ resetError }) => {
   useEffect(() => {
-    const now = Date.now();
-    immediateResets = now - lastResetAt < IMMEDIATE_RESET_WINDOW_MS ? immediateResets + 1 : 1;
-    lastResetAt = now;
-
-    if (immediateResets > MAX_IMMEDIATE_RESETS) {
-      return;
+    if (resetBudget.tryConsume()) {
+      resetError();
     }
-
-    resetError();
   }, [resetError]);
 
   return null;

--- a/source/javascripts/main.tsx
+++ b/source/javascripts/main.tsx
@@ -65,8 +65,29 @@ const DefaultQueryClient = new QueryClient({
   },
 });
 
+// The fallback resets the boundary so a transient render error doesn't leave the whole editor
+// blanked out. A *deterministic* one re-throws on the very next render though, and resetting again
+// spins that into an unbounded render loop that re-reports the same error to RUM thousands of times
+// in a single session. Give up after a few immediate retries and stay in the fallback instead; the
+// errors still reach RUM, but once per occurrence rather than as a storm.
+const MAX_IMMEDIATE_RESETS = 3;
+const IMMEDIATE_RESET_WINDOW_MS = 1000;
+
+// Module scope on purpose: the fallback unmounts on every successful reset, so component state
+// cannot see how many times it has already retried.
+let immediateResets = 0;
+let lastResetAt = 0;
+
 const PassThroughFallback: ComponentProps<typeof ErrorBoundary>['fallback'] = ({ resetError }) => {
   useEffect(() => {
+    const now = Date.now();
+    immediateResets = now - lastResetAt < IMMEDIATE_RESET_WINDOW_MS ? immediateResets + 1 : 1;
+    lastResetAt = now;
+
+    if (immediateResets > MAX_IMMEDIATE_RESETS) {
+      return;
+    }
+
     resetError();
   }, [resetError]);
 


### PR DESCRIPTION
### Root cause

`getMapIn`/`getSeqIn` throw when a path holds something other than the collection the caller asked for. Two shapes of loadable `bitrise.yml` hit that, and one of them did so from inside a render, which took down the whole editor rather than degrading one card.

**A step the editor can't read.** `StepCard` renders from `toJSON()`, so it draws a card for any step in the list, then `useContainerReferences` reads the same step out of the document to look up its container references. When that node isn't a `{cvs: options}` map — a step written as a plain string, an empty `-` item, a YAML alias — the read threw during render.

**A key written with no value.** `meta:` or `bitrise.io:` alone on a line parses to a null scalar, not to a missing key, so the getters saw "present" with nothing to return and threw — including under `createIfNotExists`, while trying to create the very node they were asked for. That's what `updateStackAndMachine` hit on a workflow with an empty `meta.bitrise.io`.

**The reset loop.** The root `ErrorBoundary`'s fallback called `resetError()` unconditionally, so a deterministic render error re-threw, was caught, reset, and re-threw again — an unbounded loop re-reporting the same error every iteration. This is the reason a single affected session generated tens of thousands of duplicate error reports.

### Fix

- The container reads are now shape-tolerant, since they run on every `StepCard` render and must never throw: a new read-only `findStepData` returns `undefined` instead of throwing or materializing a missing option map; `parseContainerReference` returns `undefined` for a reference naming no container; a non-sequence `service_containers` is skipped; a step bundle definition of an unexpected shape returns no references. A card that can't be read renders without container badges. `StepService`'s lookups report their own "not found" instead of surfacing the low-level YAML shape error.
- Both getters now treat a null-valued key as absent: `undefined` on a read, and filled in on a create. `hasIn` was only used for that check and is dropped.
- `PassThroughFallback` gives up after three resets inside a one-second window. The terminal state is the same blank fallback the loop already produced, without the storm. This is defence-in-depth: it bounds any render-time throw, not just this one.

### Scope note

This deliberately does **not** resolve YAML aliases. An aliased step renders without its container badges rather than crashing, and `getMapIn`/`getSeqIn` still reject an alias exactly as before, which keeps the create path from ever overwriting one. Making the editor read and write through aliases is a larger change and is being handled separately (follow-up PR, #1891).

### Tests

Full suite green, `tsc --noEmit` clean, eslint clean, `knip` output unchanged vs master.