### PR TITLE
[CI-6372] fix: only revalidate Intercom page targeting on real page changes

### DIFF
--- a/source/javascripts/lib/intercomPageSync.spec.ts
+++ b/source/javascripts/lib/intercomPageSync.spec.ts
@@ -1,0 +1,86 @@
+import syncIntercomWithEditorNavigation, { IntercomWindow } from './intercomPageSync';
+
+const EDITOR_ORIGIN = 'https://app.bitrise.io/wfe/index.html';
+
+const createWindows = (initialHash: string) => {
+  const hashChangeListeners = new Set<() => void>();
+
+  const parentWindow = {
+    location: { hash: initialHash },
+    Intercom: jest.fn(),
+    addEventListener: (type: string, listener: () => void) => {
+      if (type === 'hashchange') {
+        hashChangeListeners.add(listener);
+      }
+    },
+  };
+
+  const editorWindow = {
+    location: { href: `${EDITOR_ORIGIN}${initialHash}` },
+    history: {
+      state: null,
+      replaceState: jest.fn((state: unknown, _title: string, url: URL) => {
+        editorWindow.history.state = state as null;
+        editorWindow.location.href = url.toString();
+      }),
+    },
+    Intercom: jest.fn(),
+    parent: parentWindow,
+  };
+
+  const navigateParentTo = (hash: string) => {
+    parentWindow.location.hash = hash;
+    hashChangeListeners.forEach((listener) => listener());
+  };
+
+  return {
+    parentWindow,
+    editorWindow,
+    navigateParentTo,
+    editorWindowAsWindow: editorWindow as unknown as IntercomWindow,
+  };
+};
+
+describe('syncIntercomWithEditorNavigation', () => {
+  it('revalidates the page targeting of both Intercom instances when another editor page opens', () => {
+    const { editorWindow, parentWindow, editorWindowAsWindow, navigateParentTo } = createWindows('#!/workflows');
+    syncIntercomWithEditorNavigation(editorWindowAsWindow);
+
+    navigateParentTo('#!/triggers');
+
+    expect(editorWindow.Intercom).toHaveBeenCalledWith('update');
+    expect(parentWindow.Intercom).toHaveBeenCalledWith('update');
+  });
+
+  it('keeps both instances quiet while only the search params of the same page change', () => {
+    const { editorWindow, parentWindow, editorWindowAsWindow, navigateParentTo } = createWindows(
+      '#!/workflows?workflow=primary&tab=configuration',
+    );
+    syncIntercomWithEditorNavigation(editorWindowAsWindow);
+
+    navigateParentTo('#!/workflows?workflow=primary&tab=triggers');
+
+    expect(editorWindow.Intercom).not.toHaveBeenCalled();
+    expect(parentWindow.Intercom).not.toHaveBeenCalled();
+  });
+
+  it('mirrors the parent hash onto its own URL even when no revalidation happens', () => {
+    const { editorWindow, editorWindowAsWindow, navigateParentTo } = createWindows('#!/workflows?tab=configuration');
+    syncIntercomWithEditorNavigation(editorWindowAsWindow);
+
+    navigateParentTo('#!/workflows?tab=triggers');
+
+    expect(editorWindow.location.href).toBe(`${EDITOR_ORIGIN}#!/workflows?tab=triggers`);
+  });
+
+  it('revalidates again when the user leaves a page and comes back to it', () => {
+    const { editorWindow, parentWindow, editorWindowAsWindow, navigateParentTo } = createWindows('#!/triggers');
+    syncIntercomWithEditorNavigation(editorWindowAsWindow);
+
+    navigateParentTo('#!/workflows');
+    navigateParentTo('#!/triggers');
+
+    expect(editorWindow.Intercom).toHaveBeenCalledTimes(2);
+    expect(parentWindow.Intercom).toHaveBeenCalledTimes(2);
+  });
+});

--- a/source/javascripts/lib/intercomPageSync.ts
+++ b/source/javascripts/lib/intercomPageSync.ts
@@ -1,0 +1,34 @@
+type IntercomWindow = Window & {
+  Intercom?: (command: string, ...args: unknown[]) => void;
+};
+
+const pageOfHash = (hash: string) => hash.split('?')[0];
+
+const syncIntercomWithEditorNavigation = (win: IntercomWindow) => {
+  const parentWin = win.parent as IntercomWindow;
+  let lastVisitedPage = pageOfHash(parentWin.location.hash);
+
+  const handleParentHashChange = () => {
+    const parentHash = parentWin.location.hash;
+
+    const ownUrl = new URL(win.location.href);
+    if (ownUrl.hash !== parentHash) {
+      ownUrl.hash = parentHash;
+      win.history.replaceState(win.history.state, '', ownUrl);
+    }
+
+    const visitedPage = pageOfHash(parentHash);
+    if (visitedPage === lastVisitedPage) {
+      return;
+    }
+
+    lastVisitedPage = visitedPage;
+    win.Intercom?.('update');
+    parentWin.Intercom?.('update');
+  };
+
+  parentWin.addEventListener('hashchange', handleParentHashChange);
+};
+
+export type { IntercomWindow };
+export default syncIntercomWithEditorNavigation;

--- a/source/javascripts/lib/intrcm.js
+++ b/source/javascripts/lib/intrcm.js
@@ -1,20 +1,6 @@
+import syncIntercomWithEditorNavigation from './intercomPageSync';
+
 const APP_ID = import.meta.env.INTERCOM_APP_ID;
-
-const syncOwnUrlWithParentHash = () => {
-  const url = new URL(window.location.href);
-
-  if (url.hash === window.parent.location.hash) {
-    return;
-  }
-
-  url.hash = window.parent.location.hash;
-  window.history.replaceState(window.history.state, '', url);
-};
-
-const revalidatePageTargetingOfBothInstances = () => {
-  window.Intercom?.('update');
-  window.parent.Intercom?.('update');
-};
 
 if (APP_ID) {
   window.intercomSettings = {
@@ -28,10 +14,7 @@ if (APP_ID) {
   const isEmbeddedInParentWindow = window.parent !== window;
 
   if (isEmbeddedInParentWindow) {
-    window.parent.addEventListener('hashchange', () => {
-      syncOwnUrlWithParentHash();
-      revalidatePageTargetingOfBothInstances();
-    });
+    syncIntercomWithEditorNavigation(window);
   }
 }
 


### PR DESCRIPTION
The triggers product tour popped up inside the workflow config dialog's add-trigger modal.

## Why it happened

The tour itself lives in Intercom; what fires it lives here.

1. The workflow config dialog keeps its active tab in the parent hash's query string (`useSearchParams`), so opening the Triggers tab is a navigation from `#!/workflows?workflow=x&tab=configuration` to `…&tab=triggers`.
2. #1886 pings both Intercom instances with `update` on every parent `hashchange`, so Intercom re-evaluated its page targeting there.
3. A tour aimed at the editor's Triggers page matches a URL rule that any hash containing `triggers` satisfies — so it armed itself and rendered as soon as the add-trigger dialog supplied its first anchor element.

## The fix

A tab, or a selected workflow, is not a page view. The sync now remembers the hash up to the `?` and pings Intercom only when that part changes — which is exactly when the left nav takes the user somewhere else. Mirroring the parent hash onto this window still happens on every change, so the iframe URL stays accurate for whatever Intercom reads next.

The listener moved out of `intrcm.js`'s import-time side effect (which `import.meta.env` keeps out of jest's reach) into `intercomPageSync.ts`, behind a window parameter, so the page-vs-search-param distinction is covered by unit tests.

## How to test

Use an account that has never seen the triggers product tour.

- **The bug:** open a project's WFE → a workflow → Triggers tab → click any `Add trigger` button. No tour should appear.
- **Still works:** navigate to the Triggers item in the WFE left nav. The tour should appear.