### PR TITLE
fix(diff-editor): reset the widget model before disposing the pair

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,14 @@ shows up as a wrecked pull request.
 - **`keepCurrent*Model` without a `path` leaks rather than reuses.** The `@monaco-editor/react`
   props only skip disposal; reuse needs `getModel(Uri.parse(path))` to hit. With a `path` /
   `originalModelPath` / `modifiedModelPath` on the same element they are load-bearing — the
-  YmlPage editors guard a model the language services share. Without one: a model per unmount.
+  YmlPage editors guard a model the language services share. Without one they hand you the
+  disposal instead, which is the deal `ManagedDiffEditor` takes.
+- **Mount a diff editor through `@/components/DiffEditor/ManagedDiffEditor`, never the library's
+  `<DiffEditor>`.** Left to itself the library ends both models before the widget still holding
+  them, and Monaco reports `TextModel got disposed before DiffEditorWidget model got reset` once
+  per unmount. `ManagedDiffEditor` owns the models (see above) and resets the widget first. The
+  single `<Editor>` needs none of this: `CodeEditorWidget` just calls `setModel(null)` and says
+  nothing.
 
 ## Writing docs here
 

--- a/source/javascripts/components/ConfigMergeDialog/ConfigMergeDialog.tsx
+++ b/source/javascripts/components/ConfigMergeDialog/ConfigMergeDialog.tsx
@@ -11,7 +11,7 @@ import {
   Text,
   Tooltip,
 } from '@bitrise/bitkit';
-import { DiffEditor, MonacoDiffEditor } from '@monaco-editor/react';
+import { MonacoDiffEditor } from '@monaco-editor/react';
 import { useQuery } from '@tanstack/react-query';
 import { ModalCloseButton, ModalHeader } from 'chakra-ui-2--react';
 import { toMerged } from 'es-toolkit';
@@ -31,6 +31,7 @@ import { useSaveCiConfig } from '@/hooks/useCiConfig';
 import useCurrentPage from '@/hooks/useCurrentPage';
 import useModelValidationStatus from '@/hooks/useModelValidationStatus';
 
+import ManagedDiffEditor from '../DiffEditor/ManagedDiffEditor';
 import YmlValidationBadge from '../YmlValidationBadge';
 import { diffEditorOptions, mergeYamls, readOnlyDiffEditorOptions } from './mergeYamls';
 
@@ -215,7 +216,7 @@ const ConfigMergeDialogContent = ({
           <Box display="flex" flexDirection="column" flex="1" gap="4">
             <Text textStyle="body/md/semibold">Your changes</Text>
             <Box flex="1" borderRadius="8" overflow="hidden" bg="rgb(30,30,30)" opacity="0.9">
-              <DiffEditor
+              <ManagedDiffEditor
                 theme="vs-dark"
                 language="yaml"
                 original={baseYml}
@@ -232,7 +233,7 @@ const ConfigMergeDialogContent = ({
           <Box display="flex" flexDirection="column" flex="1" gap="4">
             <Text textStyle="body/md/semibold">Results</Text>
             <Box flex="1" borderRadius="8" overflow="hidden" bg="rgb(30,30,30)">
-              <DiffEditor
+              <ManagedDiffEditor
                 theme="vs-dark"
                 language="yaml"
                 original={baseYml}
@@ -250,7 +251,7 @@ const ConfigMergeDialogContent = ({
           <Box display="flex" flexDirection="column" flex="1" gap="4">
             <Text textStyle="body/md/semibold">Remote changes</Text>
             <Box flex="1" borderRadius="8" overflow="hidden" bg="rgb(30,30,30)" opacity="0.9">
-              <DiffEditor
+              <ManagedDiffEditor
                 theme="vs-dark"
                 language="yaml"
                 original={baseYml}

--- a/source/javascripts/components/ConfigMergeDialog/ModularConfigMergeDialog.tsx
+++ b/source/javascripts/components/ConfigMergeDialog/ModularConfigMergeDialog.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, ButtonGroup, DialogBody, DialogFooter, Icon, Notification, Text, Tooltip } from '@bitrise/bitkit';
 import { BitkitTabs } from '@bitrise/bitkit-v2';
-import { DiffEditor, MonacoDiffEditor } from '@monaco-editor/react';
+import { MonacoDiffEditor } from '@monaco-editor/react';
 import { ModalCloseButton, ModalHeader } from 'chakra-ui-2--react';
 import type { editor, IDisposable } from 'monaco-editor';
 import { useMemo, useRef, useState } from 'react';
@@ -14,6 +14,7 @@ import YmlUtils from '@/core/utils/YmlUtils';
 import usePushBranch from '@/hooks/usePushBranch';
 
 import { DiffEditorDialogShell } from '../DiffEditor/DiffEditorDialog';
+import ManagedDiffEditor from '../DiffEditor/ManagedDiffEditor';
 import { diffEditorOptions, mergeYamls, readOnlyDiffEditorOptions } from './mergeYamls';
 
 type Props = {
@@ -171,7 +172,10 @@ const ModularConfigMergeDialogBody = ({
         );
       }
 
-      diff.onDidDispose(() => disposables.forEach((d) => d.dispose()));
+      // On the inner editor, not `diff`: `DelegatingEditor` declares `onDidDispose` and never fires
+      // it, so hanging this off the diff editor disposes nothing (monaco 0.53 fires `_onDidDispose`
+      // in `codeEditorWidget.js` alone).
+      modified.onDidDispose(() => disposables.forEach((d) => d.dispose()));
     };
   };
 
@@ -236,7 +240,7 @@ const ModularConfigMergeDialogBody = ({
             <Box display="flex" flexDirection="column" flex="1" gap="4">
               <Text textStyle="body/md/semibold">Your changes</Text>
               <Box flex="1" borderRadius="8" overflow="hidden" bg="rgb(30,30,30)" opacity="0.9">
-                <DiffEditor
+                <ManagedDiffEditor
                   key={`${activeMerge.nodeId}-yours`}
                   theme="vs-dark"
                   language="yaml"
@@ -254,7 +258,7 @@ const ModularConfigMergeDialogBody = ({
             <Box display="flex" flexDirection="column" flex="1" gap="4">
               <Text textStyle="body/md/semibold">Results</Text>
               <Box flex="1" borderRadius="8" overflow="hidden" bg="rgb(30,30,30)">
-                <DiffEditor
+                <ManagedDiffEditor
                   key={`${activeMerge.nodeId}-results`}
                   theme="vs-dark"
                   language="yaml"
@@ -273,7 +277,7 @@ const ModularConfigMergeDialogBody = ({
             <Box display="flex" flexDirection="column" flex="1" gap="4">
               <Text textStyle="body/md/semibold">Remote changes</Text>
               <Box flex="1" borderRadius="8" overflow="hidden" bg="rgb(30,30,30)" opacity="0.9">
-                <DiffEditor
+                <ManagedDiffEditor
                   key={`${activeMerge.nodeId}-remote`}
                   theme="vs-dark"
                   language="yaml"

--- a/source/javascripts/components/DiffEditor/DiffEditor.tsx
+++ b/source/javascripts/components/DiffEditor/DiffEditor.tsx
@@ -1,5 +1,7 @@
 import { ProgressBitbot } from '@bitrise/bitkit';
-import { DiffEditor, DiffEditorProps, MonacoDiffEditor } from '@monaco-editor/react';
+import { DiffEditorProps, MonacoDiffEditor } from '@monaco-editor/react';
+
+import ManagedDiffEditor from './ManagedDiffEditor';
 
 export type Props = {
   originalText: string;
@@ -42,7 +44,7 @@ const DiffEditorComponent = ({ originalText, modifiedText, language = 'yaml', on
         }
       `}
       </style>
-      <DiffEditor
+      <ManagedDiffEditor
         theme="vs-dark"
         language={language}
         original={originalText}

--- a/source/javascripts/components/DiffEditor/ManagedDiffEditor.spec.tsx
+++ b/source/javascripts/components/DiffEditor/ManagedDiffEditor.spec.tsx
@@ -1,0 +1,59 @@
+/**
+ * @jest-environment jsdom
+ */
+import { loader } from '@monaco-editor/react';
+import { render, waitFor } from '@testing-library/react';
+
+import ManagedDiffEditor from './ManagedDiffEditor';
+
+// The real `@monaco-editor/react` runs here — only Monaco itself is a stand-in. The whole point of
+// this component is the order two cleanups run in (its layout effect against the library's passive
+// one), so mocking the library would test the mock. A recorded call log is enough of a Monaco:
+// nothing below reaches Monaco behaviour, just its shape.
+const calls: string[] = [];
+
+const model = (name: string) => ({ dispose: () => calls.push(`${name}.dispose`) });
+let created = 0;
+
+const diffEditor = {
+  model: null as unknown,
+  getModel() {
+    return this.model;
+  },
+  setModel(next: unknown) {
+    calls.push(next ? 'setModel(models)' : 'setModel(null)');
+    this.model = next;
+  },
+  updateOptions: () => {},
+  dispose: () => calls.push('editor.dispose'),
+};
+
+const monaco = {
+  Uri: { parse: (path: string) => ({ path }) },
+  editor: {
+    getModel: () => null,
+    createModel: () => model(created++ === 0 ? 'original' : 'modified'),
+    createDiffEditor: () => diffEditor,
+    setTheme: () => {},
+    EditorOption: { readOnly: 0 },
+  },
+};
+
+loader.config({ monaco: monaco as never });
+
+describe('ManagedDiffEditor', () => {
+  it('resets the widget model before disposing the pair, so Monaco never sees a live widget lose a model', async () => {
+    const onMount = jest.fn();
+    const { unmount } = render(<ManagedDiffEditor original="a: 1" modified="a: 2" onMount={onMount} />);
+
+    await waitFor(() => expect(onMount).toHaveBeenCalled());
+    calls.length = 0;
+
+    unmount();
+
+    // `setModel(null)` first is what keeps `TextModel got disposed before DiffEditorWidget model got
+    // reset` out of the console; the two disposes are the leak the `keepCurrent*Model` props stop the
+    // library from handling.
+    expect(calls).toEqual(['setModel(null)', 'original.dispose', 'modified.dispose', 'editor.dispose']);
+  });
+});

--- a/source/javascripts/components/DiffEditor/ManagedDiffEditor.tsx
+++ b/source/javascripts/components/DiffEditor/ManagedDiffEditor.tsx
@@ -1,0 +1,46 @@
+import { DiffEditor, DiffEditorProps, MonacoDiffEditor } from '@monaco-editor/react';
+import { useLayoutEffect, useRef } from 'react';
+
+/**
+ * `<DiffEditor>` with the model pair disposed in an order Monaco accepts.
+ *
+ * The library's own cleanup ends the two models before the widget still holding them
+ * (`i.original.dispose(); i.modified.dispose(); u.current.dispose()`), which trips the
+ * `TextModel got disposed before DiffEditorWidget model got reset` guard in `diffEditorWidget.js`
+ * on every unmount. `keepCurrent*Model` takes the models off the library — the props only skip
+ * disposal, they never reuse anything without a `path` (see CLAUDE.md) — and this ends them here
+ * instead, `setModel(null)` first so the widget releases them before they die.
+ *
+ * A layout-effect cleanup is what makes that ordering hold: React runs those in the mutation
+ * phase, ahead of every passive cleanup in the deleted subtree, so the widget is still alive when
+ * this runs and the library's `useEffect` cleanup disposes it afterwards.
+ */
+const ManagedDiffEditor = ({ onMount, ...props }: DiffEditorProps) => {
+  const editorRef = useRef<MonacoDiffEditor | null>(null);
+
+  useLayoutEffect(
+    () => () => {
+      const editor = editorRef.current;
+      const models = editor?.getModel();
+
+      editor?.setModel(null);
+      models?.original.dispose();
+      models?.modified.dispose();
+    },
+    [],
+  );
+
+  return (
+    <DiffEditor
+      {...props}
+      keepCurrentOriginalModel
+      keepCurrentModifiedModel
+      onMount={(editor, monaco) => {
+        editorRef.current = editor;
+        onMount?.(editor, monaco);
+      }}
+    />
+  );
+};
+
+export default ManagedDiffEditor;


### PR DESCRIPTION
Follow-up to #1898. Taking `keepCurrent*Model` off the four `<DiffEditor>`s stopped the model leak
and handed disposal back to `@monaco-editor/react`, whose cleanup ends both models before the widget
still holding them (`i.original.dispose(); i.modified.dispose(); u.current.dispose()`). Monaco reports
that as `TextModel got disposed before DiffEditorWidget model got reset` — once per unmount since
2.5.16378 (absent from 2.5.16376), so six per merge-dialog close and one per diff-dialog tab switch.
Noise, not breakage: the guard resets the model itself and the widget was being torn down anyway.

`ManagedDiffEditor` keeps the props on and owns the disposal, in a layout-effect cleanup — React runs
those in the mutation phase, ahead of every passive cleanup in the deleted subtree, so the widget is
still alive for `setModel(null)` before the models go. All seven mount sites go through it.

Neither `onDidDispose` route works here: `DelegatingEditor` declares the event and never fires it
(monaco 0.53 fires `_onDidDispose` in `codeEditorWidget.js` alone), and the inner editors are disposed
ahead of the guards because `DisposableStore` clears in insertion order. That dead event is also why
`onResultEditorMount`'s `disposables` were never disposed — moved to the inner editor.

## Verification

Browser A/B against real monaco 0.53: an unpatched `<DiffEditor>` reproduces the production stack
frame-for-frame (`UniqueContainer.value` → `Emitter.fire` → `TextModel.dispose` → `I` →
`commitPassiveUnmountInsideDeletedTreeOnFiber`); `ManagedDiffEditor` with the real `onMount` shape
(content listener + marker subscription) runs three mount/unmount cycles with zero errors, no marker
callback after unmount, and `getModels()` back to 0. `ManagedDiffEditor.spec.tsx` pins the call order
against the real library and fails if the layout effect goes. `npm test` 1500 passed, `tsc`, lint and
`npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)