### PR TITLE
Revert "fix(diff-editor): stop leaking Monaco models on every DiffEditor unmount"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,10 +90,14 @@ shows up as a wrecked pull request.
   or `no-restricted-imports` means you crossed one, not that you wrote sloppy code. Some take two
   rule ids, so count boundaries rather than rules. See
   [docs/conventions.md](docs/conventions.md#lint).
-- **`keepCurrent*Model` without a `path` leaks rather than reuses.** The `@monaco-editor/react`
-  props only skip disposal; reuse needs `getModel(Uri.parse(path))` to hit. With a `path` /
-  `originalModelPath` / `modifiedModelPath` on the same element they are load-bearing — the
-  YmlPage editors guard a model the language services share. Without one: a model per unmount.
+- **`keepCurrent*Model` without a `path` leaks rather than reuses, and on the `<DiffEditor>`s that
+  leak is deliberate.** The `@monaco-editor/react` props only skip disposal; reuse needs
+  `getModel(Uri.parse(path))` to hit, so a pathless editor strands a model pair per unmount.
+  Do not "fix" that by deleting them. Disposal then goes back to the library, which ends both
+  models before the widget still holding them, and Monaco reports `TextModel got disposed before
+  DiffEditorWidget model got reset` on every unmount — that was #1898, reverted here after it
+  reached production on 2.5.16378. With a `path` the props are load-bearing instead: the YmlPage
+  editors guard a model the language services share.
 
 ## Writing docs here
 

--- a/source/javascripts/components/ConfigMergeDialog/ConfigMergeDialog.tsx
+++ b/source/javascripts/components/ConfigMergeDialog/ConfigMergeDialog.tsx
@@ -221,6 +221,8 @@ const ConfigMergeDialogContent = ({
                 original={baseYml}
                 modified={yourYml}
                 options={readOnlyDiffEditorOptions}
+                keepCurrentModifiedModel
+                keepCurrentOriginalModel
               />
             </Box>
           </Box>
@@ -238,6 +240,8 @@ const ConfigMergeDialogContent = ({
                 original={baseYml}
                 modified={mergedYml}
                 options={diffEditorOptions}
+                keepCurrentModifiedModel
+                keepCurrentOriginalModel
                 onMount={onFinalYmlEditorMount}
               />
             </Box>
@@ -256,6 +260,8 @@ const ConfigMergeDialogContent = ({
                 original={baseYml}
                 modified={remoteYml}
                 options={readOnlyDiffEditorOptions}
+                keepCurrentModifiedModel
+                keepCurrentOriginalModel
               />
             </Box>
           </Box>

--- a/source/javascripts/components/ConfigMergeDialog/ModularConfigMergeDialog.tsx
+++ b/source/javascripts/components/ConfigMergeDialog/ModularConfigMergeDialog.tsx
@@ -133,6 +133,10 @@ const ModularConfigMergeDialogBody = ({
   const onResultEditorMount = (mountedNodeId: string, decorations: editor.IModelDeltaDecoration[]) => {
     return (diff: MonacoDiffEditor) => {
       const modified = diff.getModifiedEditor();
+      // Tab switches remount this editor (its key includes the node_id), so every
+      // listener registered here must be disposed on unmount — otherwise the global
+      // marker listener (onModelMarkerStatusChange) leaks one per visit and keeps
+      // firing setValidity for stale models. Collected here, disposed on dispose.
       const disposables: IDisposable[] = [];
 
       disposables.push(
@@ -243,6 +247,8 @@ const ModularConfigMergeDialogBody = ({
                   original={activeMerge.baseYml}
                   modified={activeMerge.yourYml}
                   options={readOnlyDiffEditorOptions}
+                  keepCurrentModifiedModel
+                  keepCurrentOriginalModel
                 />
               </Box>
             </Box>
@@ -261,6 +267,8 @@ const ModularConfigMergeDialogBody = ({
                   original={activeMerge.baseYml}
                   modified={resolved[activeMerge.nodeId] ?? activeMerge.mergedYml}
                   options={diffEditorOptions}
+                  keepCurrentModifiedModel
+                  keepCurrentOriginalModel
                   onMount={onResultEditorMount(activeMerge.nodeId, activeMerge.decorations)}
                 />
               </Box>
@@ -280,6 +288,8 @@ const ModularConfigMergeDialogBody = ({
                   original={activeMerge.baseYml}
                   modified={activeMerge.remoteYml}
                   options={readOnlyDiffEditorOptions}
+                  keepCurrentModifiedModel
+                  keepCurrentOriginalModel
                 />
               </Box>
             </Box>

--- a/source/javascripts/components/DiffEditor/DiffEditor.tsx
+++ b/source/javascripts/components/DiffEditor/DiffEditor.tsx
@@ -50,6 +50,8 @@ const DiffEditorComponent = ({ originalText, modifiedText, language = 'yaml', on
         options={readOnly ? { ...diffEditorOptions, readOnly: true } : diffEditorOptions}
         loading={<ProgressBitbot />}
         onMount={handleEditorDidMount}
+        keepCurrentModifiedModel
+        keepCurrentOriginalModel
         wrapperProps={{ style: { flex: 1, display: 'flex' } }}
       />
     </>

--- a/source/javascripts/core/utils/MonacoUtils.ts
+++ b/source/javascripts/core/utils/MonacoUtils.ts
@@ -296,26 +296,12 @@ function onWorkspaceMarkerStatusChange(
   };
 }
 
-/**
- * Single-model form of {@link onWorkspaceMarkerStatusChange}. This one captures `model` instead of
- * looking it up, so it can outlive what it watches: `DiffEditorDialog` keeps the badge and the
- * Apply gate mounted while a tab switch remounts the editor beneath them and disposes its model,
- * and what a disposed model's markers report is its owner's business. So end the subscription with
- * the model — `onWillDispose` fires before disposal, and `dispose()` cancels both debounce timers.
- */
+/** Single-model form of {@link onWorkspaceMarkerStatusChange}. */
 function onModelMarkerStatusChange(
   model: monaco.editor.ITextModel,
   callback: (status: ValidationStatus) => void,
 ): monaco.IDisposable {
-  const subscription = onWorkspaceMarkerStatusChange(() => [model], callback);
-  const willDispose = model.onWillDispose(() => subscription.dispose());
-
-  return {
-    dispose: () => {
-      willDispose.dispose();
-      subscription.dispose();
-    },
-  };
+  return onWorkspaceMarkerStatusChange(() => [model], callback);
 }
 
 export default {


### PR DESCRIPTION
Reverts #1898.

Removing `keepCurrent*Model` stopped the leak by handing disposal back to `@monaco-editor/react`,
whose cleanup ends both models before the widget still holding them. Monaco reports that as
`TextModel got disposed before DiffEditorWidget model got reset`, once per unmount — six per
merge-dialog close, one per diff-dialog tab switch.

Confirmed in production on 2.5.16378 (`env:production`, diff-dialog close path). Harmless: the
throw is an async rethrow from `setTimeout`, outside React's stack, and the guard calls
`setModel(null)` itself on a widget that was being torn down anyway. The dialog closes normally.
But two RUM events per close is a worse trade than the leak it replaced.

Back to a stranded model pair per unmount, cleared by a page reload.

Fixing the leak properly means owning disposal (`keepCurrent*Model` on, plus `setModel(null)` and
two `dispose()` calls in a layout-effect cleanup) rather than handing it back. That was #1905;
closed, and out of scope here. `4.8.0-rc.3` has the identical disposal order, so an upgrade
doesn't help either.

The CLAUDE.md note is kept and rewritten rather than reverted — with the props restored they read
as a bug, and deleting them again lands straight back here.

`npm test` 1499 passed, `tsc`, lint and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)